### PR TITLE
feat(cli): manual signet fee rates, full scan cmd, disable L2 faucet, refresh -> recover, config file + more

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12686,6 +12686,7 @@ dependencies = [
  "strata-bridge-tx-builder",
  "terrors",
  "tokio",
+ "zeroize",
  "zxcvbn",
 ]
 

--- a/bin/strata-cli/Cargo.toml
+++ b/bin/strata-cli/Cargo.toml
@@ -3,6 +3,9 @@ edition = "2021"
 name = "strata-cli"
 version = "0.1.0"
 
+[features]
+strata_faucet = []
+
 [[bin]]
 name = "strata"
 path = "src/main.rs"

--- a/bin/strata-cli/Cargo.toml
+++ b/bin/strata-cli/Cargo.toml
@@ -45,6 +45,7 @@ sled = "0.34.7"
 strata-bridge-tx-builder.workspace = true
 terrors.workspace = true
 tokio.workspace = true
+zeroize = { version = "1.8.1", features = ["derive"] }
 zxcvbn = "3.1.0"
 
 # sha2 fails to compile on windows with the "asm" feature

--- a/bin/strata-cli/src/cmd/balance.rs
+++ b/bin/strata-cli/src/cmd/balance.rs
@@ -41,7 +41,7 @@ pub async fn balance(args: BalanceArgs, seed: Seed, settings: Settings, esplora:
     }
 
     if let NetworkType::Strata = network_type {
-        let l2w = StrataWallet::new(&seed, &settings.l2_http_endpoint).unwrap();
+        let l2w = StrataWallet::new(&seed, &settings.strata_endpoint).unwrap();
         let _ = term.write_line("Getting balance...");
         let balance = l2w.get_balance(l2w.default_signer_address()).await.unwrap();
         // 1 BTC = 1 ETH

--- a/bin/strata-cli/src/cmd/balance.rs
+++ b/bin/strata-cli/src/cmd/balance.rs
@@ -3,9 +3,11 @@ use alloy::{
     providers::{Provider, WalletProvider},
 };
 use argh::FromArgs;
+use bdk_wallet::bitcoin::Amount;
 use console::Term;
 
 use crate::{
+    constants::SATS_TO_WEI,
     net_type::{net_type_or_exit, NetworkType},
     seed::Seed,
     settings::Settings,
@@ -44,8 +46,11 @@ pub async fn balance(args: BalanceArgs, seed: Seed, settings: Settings, esplora:
         let l2w = StrataWallet::new(&seed, &settings.strata_endpoint).unwrap();
         let _ = term.write_line("Getting balance...");
         let balance = l2w.get_balance(l2w.default_signer_address()).await.unwrap();
-        // 1 BTC = 1 ETH
-        let balance_in_btc = balance / U256::from(10u64.pow(18));
-        let _ = term.write_line(&format!("\nTotal: {} BTC", balance_in_btc));
+        let balance = Amount::from_sat(
+            (balance / U256::from(SATS_TO_WEI))
+                .try_into()
+                .expect("valid amount"),
+        );
+        let _ = term.write_line(&format!("\nTotal: {}", balance));
     }
 }

--- a/bin/strata-cli/src/cmd/balance.rs
+++ b/bin/strata-cli/src/cmd/balance.rs
@@ -6,7 +6,6 @@ use argh::FromArgs;
 use console::Term;
 
 use crate::{
-    constants::NETWORK,
     net_type::{net_type_or_exit, NetworkType},
     seed::Seed,
     settings::Settings,
@@ -28,7 +27,7 @@ pub async fn balance(args: BalanceArgs, seed: Seed, settings: Settings, esplora:
     let network_type = net_type_or_exit(&args.network_type, &term);
 
     if let NetworkType::Signet = network_type {
-        let mut l1w = SignetWallet::new(&seed, NETWORK).unwrap();
+        let mut l1w = SignetWallet::new(&seed, settings.network).unwrap();
         l1w.sync(&esplora).await.unwrap();
         let balance = l1w.balance();
         let _ = term.write_line(&format!("Total: {}", balance.total()));

--- a/bin/strata-cli/src/cmd/bridge_in.rs
+++ b/bin/strata-cli/src/cmd/bridge_in.rs
@@ -50,7 +50,7 @@ pub async fn bridge_in(
     let requested_strata_address =
         strata_address.map(|a| StrataAddress::from_str(&a).expect("bad strata address"));
     let mut l1w = SignetWallet::new(&seed, settings.network).unwrap();
-    let l2w = StrataWallet::new(&seed, &settings.l2_http_endpoint).unwrap();
+    let l2w = StrataWallet::new(&seed, &settings.strata_endpoint).unwrap();
 
     l1w.sync(&esplora).await.unwrap();
     let recovery_address = l1w.reveal_next_address(KeychainKind::External).address;

--- a/bin/strata-cli/src/cmd/bridge_in.rs
+++ b/bin/strata-cli/src/cmd/bridge_in.rs
@@ -36,7 +36,7 @@ pub struct BridgeInArgs {
 
     /// override signet fee rate in sat/vbyte. must be >1
     #[argh(option)]
-    fee_rate: Option<String>,
+    fee_rate: Option<u64>,
 }
 
 pub async fn bridge_in(

--- a/bin/strata-cli/src/cmd/bridge_in.rs
+++ b/bin/strata-cli/src/cmd/bridge_in.rs
@@ -15,9 +15,7 @@ use indicatif::ProgressBar;
 use strata_bridge_tx_builder::constants::MAGIC_BYTES;
 
 use crate::{
-    constants::{
-        BRIDGE_IN_AMOUNT, L2_BLOCK_TIME, NETWORK, RECOVER_AT_DELAY, RECOVER_DELAY, UNSPENDABLE,
-    },
+    constants::{BRIDGE_IN_AMOUNT, L2_BLOCK_TIME, RECOVER_AT_DELAY, RECOVER_DELAY, UNSPENDABLE},
     recovery::DescriptorRecovery,
     seed::Seed,
     settings::Settings,
@@ -51,7 +49,7 @@ pub async fn bridge_in(
     let term = Term::stdout();
     let requested_strata_address =
         strata_address.map(|a| StrataAddress::from_str(&a).expect("bad strata address"));
-    let mut l1w = SignetWallet::new(&seed, NETWORK).unwrap();
+    let mut l1w = SignetWallet::new(&seed, settings.network).unwrap();
     let l2w = StrataWallet::new(&seed, &settings.l2_http_endpoint).unwrap();
 
     l1w.sync(&esplora).await.unwrap();
@@ -76,11 +74,11 @@ pub async fn bridge_in(
 
     let desc = bridge_in_desc
         .clone()
-        .into_wallet_descriptor(l1w.secp_ctx(), NETWORK)
+        .into_wallet_descriptor(l1w.secp_ctx(), settings.network)
         .expect("valid descriptor");
 
     let mut temp_wallet = Wallet::create_single(desc.clone())
-        .network(NETWORK)
+        .network(settings.network)
         .create_wallet_no_persist()
         .expect("valid wallet");
 

--- a/bin/strata-cli/src/cmd/bridge_in.rs
+++ b/bin/strata-cli/src/cmd/bridge_in.rs
@@ -21,7 +21,7 @@ use crate::{
     recovery::DescriptorRecovery,
     seed::Seed,
     settings::Settings,
-    signet::{get_fee_rate, log_fee_rate, EsploraClient, SignetWallet},
+    signet::{fee_rate_or_crash, log_fee_rate, print_explorer_url, EsploraClient, SignetWallet},
     strata::StrataWallet,
     taproot::{ExtractP2trPubkey, NotTaprootAddress},
 };
@@ -33,13 +33,24 @@ use crate::{
 pub struct BridgeInArgs {
     #[argh(positional)]
     strata_address: Option<String>,
+
+    /// override signet fee rate in sat/vbyte. must be >1
+    #[argh(option)]
+    fee_rate: Option<String>,
 }
 
-pub async fn bridge_in(args: BridgeInArgs, seed: Seed, settings: Settings, esplora: EsploraClient) {
+pub async fn bridge_in(
+    BridgeInArgs {
+        strata_address,
+        fee_rate,
+    }: BridgeInArgs,
+    seed: Seed,
+    settings: Settings,
+    esplora: EsploraClient,
+) {
     let term = Term::stdout();
-    let requested_strata_address = args
-        .strata_address
-        .map(|a| StrataAddress::from_str(&a).expect("bad strata address"));
+    let requested_strata_address =
+        strata_address.map(|a| StrataAddress::from_str(&a).expect("bad strata address"));
     let mut l1w = SignetWallet::new(&seed, NETWORK).unwrap();
     let l2w = StrataWallet::new(&seed, &settings.l2_http_endpoint).unwrap();
 
@@ -90,11 +101,7 @@ pub async fn bridge_in(args: BridgeInArgs, seed: Seed, settings: Settings, esplo
         style(bridge_in_address.to_string()).yellow()
     ));
 
-    let fee_rate = get_fee_rate(1, &esplora)
-        .await
-        .expect("should get fee rate")
-        .expect("should have valid fee rate");
-
+    let fee_rate = fee_rate_or_crash(fee_rate, &esplora).await;
     log_fee_rate(&term, &fee_rate);
 
     const MBL: usize = MAGIC_BYTES.len();
@@ -135,7 +142,9 @@ pub async fn bridge_in(args: BridgeInArgs, seed: Seed, settings: Settings, esplo
     let pb = ProgressBar::new_spinner().with_message("Broadcasting transaction");
     pb.enable_steady_tick(Duration::from_millis(100));
     esplora.broadcast(&tx).await.expect("successful broadcast");
-    pb.finish_with_message(format!("Transaction {} broadcasted", tx.compute_txid()));
+    let txid = tx.compute_txid();
+    pb.finish_with_message(format!("Transaction {} broadcasted", txid));
+    let _ = print_explorer_url(&txid, &term);
     let _ = term.write_line(&format!(
         "Expect transaction confirmation in ~{:?}. Funds will take longer than this to be available on Strata.",
         L2_BLOCK_TIME

--- a/bin/strata-cli/src/cmd/bridge_out.rs
+++ b/bin/strata-cli/src/cmd/bridge_out.rs
@@ -32,7 +32,7 @@ pub async fn bridge_out(args: BridgeOutArgs, seed: Seed, settings: Settings) {
     });
 
     let mut l1w = SignetWallet::new(&seed, settings.network).unwrap();
-    let l2w = StrataWallet::new(&seed, &settings.l2_http_endpoint).unwrap();
+    let l2w = StrataWallet::new(&seed, &settings.strata_endpoint).unwrap();
 
     let address = match address {
         Some(a) => a,

--- a/bin/strata-cli/src/cmd/bridge_out.rs
+++ b/bin/strata-cli/src/cmd/bridge_out.rs
@@ -10,12 +10,8 @@ use console::Term;
 use indicatif::ProgressBar;
 
 use crate::{
-    constants::{BRIDGE_OUT_AMOUNT, NETWORK},
-    seed::Seed,
-    settings::Settings,
-    signet::SignetWallet,
-    strata::StrataWallet,
-    taproot::ExtractP2trPubkey,
+    constants::BRIDGE_OUT_AMOUNT, seed::Seed, settings::Settings, signet::SignetWallet,
+    strata::StrataWallet, taproot::ExtractP2trPubkey,
 };
 
 /// Bridge 10 BTC from Strata to signet
@@ -31,11 +27,11 @@ pub async fn bridge_out(args: BridgeOutArgs, seed: Seed, settings: Settings) {
     let address = args.p2tr_address.map(|a| {
         Address::from_str(&a)
             .expect("valid address")
-            .require_network(NETWORK)
+            .require_network(settings.network)
             .expect("correct network")
     });
 
-    let mut l1w = SignetWallet::new(&seed, NETWORK).unwrap();
+    let mut l1w = SignetWallet::new(&seed, settings.network).unwrap();
     let l2w = StrataWallet::new(&seed, &settings.l2_http_endpoint).unwrap();
 
     let address = match address {

--- a/bin/strata-cli/src/cmd/config.rs
+++ b/bin/strata-cli/src/cmd/config.rs
@@ -1,0 +1,12 @@
+use argh::FromArgs;
+
+use crate::settings::Settings;
+
+/// Prints the location of the CLI's TOML config file
+#[derive(FromArgs, PartialEq, Debug)]
+#[argh(subcommand, name = "config")]
+pub struct ConfigArgs {}
+
+pub async fn config(_args: ConfigArgs, settings: Settings) {
+    println!("{}", settings.config_file.to_string_lossy())
+}

--- a/bin/strata-cli/src/cmd/config.rs
+++ b/bin/strata-cli/src/cmd/config.rs
@@ -1,12 +1,12 @@
 use argh::FromArgs;
 
-use crate::settings::Settings;
+use crate::settings::CONFIG_FILE;
 
 /// Prints the location of the CLI's TOML config file
 #[derive(FromArgs, PartialEq, Debug)]
 #[argh(subcommand, name = "config")]
 pub struct ConfigArgs {}
 
-pub async fn config(_args: ConfigArgs, settings: Settings) {
-    println!("{}", settings.config_file.to_string_lossy())
+pub async fn config(_args: ConfigArgs) {
+    println!("{}", CONFIG_FILE.to_string_lossy())
 }

--- a/bin/strata-cli/src/cmd/deposit.rs
+++ b/bin/strata-cli/src/cmd/deposit.rs
@@ -15,7 +15,9 @@ use indicatif::ProgressBar;
 use strata_bridge_tx_builder::constants::MAGIC_BYTES;
 
 use crate::{
-    constants::{BRIDGE_IN_AMOUNT, L2_BLOCK_TIME, RECOVER_AT_DELAY, RECOVER_DELAY, UNSPENDABLE},
+    constants::{
+        BRIDGE_IN_AMOUNT, RECOVER_AT_DELAY, RECOVER_DELAY, SIGNET_BLOCK_TIME, UNSPENDABLE,
+    },
     recovery::DescriptorRecovery,
     seed::Seed,
     settings::Settings,
@@ -142,10 +144,10 @@ pub async fn deposit(
     esplora.broadcast(&tx).await.expect("successful broadcast");
     let txid = tx.compute_txid();
     pb.finish_with_message(format!("Transaction {} broadcasted", txid));
-    let _ = print_explorer_url(&txid, &term);
+    let _ = print_explorer_url(&txid, &term, &settings);
     let _ = term.write_line(&format!(
         "Expect transaction confirmation in ~{:?}. Funds will take longer than this to be available on Strata.",
-        L2_BLOCK_TIME
+        SIGNET_BLOCK_TIME
     ));
 }
 

--- a/bin/strata-cli/src/cmd/deposit.rs
+++ b/bin/strata-cli/src/cmd/deposit.rs
@@ -32,7 +32,7 @@ pub struct DepositArgs {
     #[argh(positional)]
     strata_address: Option<String>,
 
-    /// override signet fee rate in sat/vbyte. must be >1
+    /// override signet fee rate in sat/vbyte. must be >=1
     #[argh(option)]
     fee_rate: Option<u64>,
 }

--- a/bin/strata-cli/src/cmd/deposit.rs
+++ b/bin/strata-cli/src/cmd/deposit.rs
@@ -24,11 +24,11 @@ use crate::{
     taproot::{ExtractP2trPubkey, NotTaprootAddress},
 };
 
-/// Bridge 10 BTC from signet to Strata. If an address is not provided, the wallet's internal
+/// Deposit 10 BTC from signet to Strata. If an address is not provided, the wallet's internal
 /// Strata address will be used.
 #[derive(FromArgs, PartialEq, Debug)]
-#[argh(subcommand, name = "bridge-in")]
-pub struct BridgeInArgs {
+#[argh(subcommand, name = "deposit")]
+pub struct DepositArgs {
     #[argh(positional)]
     strata_address: Option<String>,
 
@@ -37,11 +37,11 @@ pub struct BridgeInArgs {
     fee_rate: Option<u64>,
 }
 
-pub async fn bridge_in(
-    BridgeInArgs {
+pub async fn deposit(
+    DepositArgs {
         strata_address,
         fee_rate,
-    }: BridgeInArgs,
+    }: DepositArgs,
     seed: Seed,
     settings: Settings,
     esplora: EsploraClient,

--- a/bin/strata-cli/src/cmd/deposit.rs
+++ b/bin/strata-cli/src/cmd/deposit.rs
@@ -21,7 +21,7 @@ use crate::{
     recovery::DescriptorRecovery,
     seed::Seed,
     settings::Settings,
-    signet::{fee_rate_or_crash, log_fee_rate, print_explorer_url, EsploraClient, SignetWallet},
+    signet::{get_fee_rate, log_fee_rate, print_explorer_url, EsploraClient, SignetWallet},
     strata::StrataWallet,
     taproot::{ExtractP2trPubkey, NotTaprootAddress},
 };
@@ -101,7 +101,9 @@ pub async fn deposit(
         style(bridge_in_address.to_string()).yellow()
     ));
 
-    let fee_rate = fee_rate_or_crash(fee_rate, &esplora).await;
+    let fee_rate = get_fee_rate(fee_rate, &esplora, 1)
+        .await
+        .expect("valid fee rate");
     log_fee_rate(&term, &fee_rate);
 
     const MBL: usize = MAGIC_BYTES.len();

--- a/bin/strata-cli/src/cmd/drain.rs
+++ b/bin/strata-cli/src/cmd/drain.rs
@@ -11,7 +11,7 @@ use console::{style, Term};
 use crate::{
     seed::Seed,
     settings::Settings,
-    signet::{fee_rate_or_crash, log_fee_rate, print_explorer_url, EsploraClient, SignetWallet},
+    signet::{get_fee_rate, log_fee_rate, print_explorer_url, EsploraClient, SignetWallet},
     strata::StrataWallet,
 };
 
@@ -68,7 +68,9 @@ pub async fn drain(
                     .to_string(),
             );
         }
-        let fr = fee_rate_or_crash(fee_rate, &esplora).await;
+        let fr = get_fee_rate(fee_rate, &esplora, 1)
+            .await
+            .expect("valid fee rate");
         log_fee_rate(&term, &fr);
 
         let mut psbt = l1w

--- a/bin/strata-cli/src/cmd/drain.rs
+++ b/bin/strata-cli/src/cmd/drain.rs
@@ -31,7 +31,7 @@ pub struct DrainArgs {
 
     /// override signet fee rate in sat/vbyte. must be >1
     #[argh(option)]
-    fee_rate: Option<String>,
+    fee_rate: Option<u64>,
 }
 
 pub async fn drain(

--- a/bin/strata-cli/src/cmd/drain.rs
+++ b/bin/strata-cli/src/cmd/drain.rs
@@ -9,7 +9,6 @@ use bdk_wallet::bitcoin::{Address, Amount};
 use console::{style, Term};
 
 use crate::{
-    constants::NETWORK,
     seed::Seed,
     settings::Settings,
     signet::{fee_rate_or_crash, log_fee_rate, print_explorer_url, EsploraClient, SignetWallet},
@@ -52,14 +51,14 @@ pub async fn drain(
     let signet_address = signet_address.map(|a| {
         Address::from_str(&a)
             .expect("valid signet address")
-            .require_network(NETWORK)
+            .require_network(settings.network)
             .expect("correct network")
     });
     let strata_address =
         strata_address.map(|a| StrataAddress::from_str(&a).expect("valid Strata address"));
 
     if let Some(address) = signet_address {
-        let mut l1w = SignetWallet::new(&seed, NETWORK).unwrap();
+        let mut l1w = SignetWallet::new(&seed, settings.network).unwrap();
         l1w.sync(&esplora).await.unwrap();
         let balance = l1w.balance();
         if balance.untrusted_pending > Amount::ZERO {

--- a/bin/strata-cli/src/cmd/drain.rs
+++ b/bin/strata-cli/src/cmd/drain.rs
@@ -28,7 +28,7 @@ pub struct DrainArgs {
     #[argh(option, short = 'r')]
     strata_address: Option<String>,
 
-    /// override signet fee rate in sat/vbyte. must be >1
+    /// override signet fee rate in sat/vbyte. must be >=1
     #[argh(option)]
     fee_rate: Option<u64>,
 }

--- a/bin/strata-cli/src/cmd/drain.rs
+++ b/bin/strata-cli/src/cmd/drain.rs
@@ -82,7 +82,7 @@ pub async fn drain(
         l1w.sign(&mut psbt, Default::default()).unwrap();
         let tx = psbt.extract_tx().expect("fully signed tx");
         esplora.broadcast(&tx).await.unwrap();
-        let _ = print_explorer_url(&tx.compute_txid(), &term);
+        let _ = print_explorer_url(&tx.compute_txid(), &term, &settings);
     }
 
     if let Some(address) = strata_address {

--- a/bin/strata-cli/src/cmd/drain.rs
+++ b/bin/strata-cli/src/cmd/drain.rs
@@ -73,6 +73,7 @@ pub async fn drain(
 
         let mut psbt = l1w
             .build_tx()
+            .drain_wallet()
             .drain_to(address.script_pubkey())
             .fee_rate(fr)
             .clone()
@@ -98,7 +99,7 @@ pub async fn drain(
         let estimate_tx = l2w
             .transaction_request()
             .to(address)
-            .value(balance) // Use full balance for estimation
+            .value(U256::from(1))
             .max_fee_per_gas(max_fee_per_gas)
             .max_priority_fee_per_gas(max_priority_fee_per_gas);
 

--- a/bin/strata-cli/src/cmd/drain.rs
+++ b/bin/strata-cli/src/cmd/drain.rs
@@ -85,7 +85,7 @@ pub async fn drain(
     }
 
     if let Some(address) = strata_address {
-        let l2w = StrataWallet::new(&seed, &settings.l2_http_endpoint).unwrap();
+        let l2w = StrataWallet::new(&seed, &settings.strata_endpoint).unwrap();
         let balance = l2w.get_balance(l2w.default_signer_address()).await.unwrap();
         if balance == U256::ZERO {
             let _ = term.write_line("No Strata bitcoin to send");

--- a/bin/strata-cli/src/cmd/faucet.rs
+++ b/bin/strata-cli/src/cmd/faucet.rs
@@ -15,7 +15,6 @@ use sha2::{Digest, Sha256};
 use shrex::{encode, Hex};
 
 use crate::{
-    constants::NETWORK,
     // net_type::{net_type_or_exit, NetworkType},
     seed::Seed,
     settings::Settings,
@@ -106,7 +105,7 @@ pub async fn faucet(args: FaucetArgs, seed: Seed, settings: Settings) {
     // };
 
     let url = {
-        let mut l1w = SignetWallet::new(&seed, NETWORK).unwrap();
+        let mut l1w = SignetWallet::new(&seed, settings.network).unwrap();
         let address = match args.address {
             None => {
                 let address_info = l1w.reveal_next_address(KeychainKind::External);
@@ -116,7 +115,7 @@ pub async fn faucet(args: FaucetArgs, seed: Seed, settings: Settings) {
             Some(address) => {
                 let address = Address::from_str(&address).expect("bad address");
                 address
-                    .require_network(NETWORK)
+                    .require_network(settings.network)
                     .expect("wrong bitcoin network")
             }
         };

--- a/bin/strata-cli/src/cmd/faucet.rs
+++ b/bin/strata-cli/src/cmd/faucet.rs
@@ -119,7 +119,7 @@ pub async fn faucet(args: FaucetArgs, seed: Seed, settings: Settings) {
             )
         }
         NetworkType::Strata => {
-            let l2w = StrataWallet::new(&seed, &settings.l2_http_endpoint).unwrap();
+            let l2w = StrataWallet::new(&seed, &settings.strata_endpoint).unwrap();
             // they said EVMs were advanced 👁️👁️
             let address = match args.address {
                 Some(address) => StrataAddress::from_str(&address).expect("bad address"),

--- a/bin/strata-cli/src/cmd/faucet.rs
+++ b/bin/strata-cli/src/cmd/faucet.rs
@@ -2,7 +2,10 @@ use std::str::FromStr;
 
 use alloy::{primitives::Address as StrataAddress, providers::WalletProvider};
 use argh::FromArgs;
-use bdk_wallet::{bitcoin::Address, KeychainKind};
+use bdk_wallet::{
+    bitcoin::{Address, Txid},
+    KeychainKind,
+};
 use console::Term;
 use indicatif::ProgressBar;
 use rand::{distributions::uniform::SampleRange, thread_rng};
@@ -16,7 +19,7 @@ use crate::{
     net_type::{net_type_or_exit, NetworkType},
     seed::Seed,
     settings::Settings,
-    signet::SignetWallet,
+    signet::{print_explorer_url, SignetWallet},
     strata::StrataWallet,
 };
 
@@ -131,6 +134,9 @@ pub async fn faucet(args: FaucetArgs, seed: Seed, settings: Settings) {
     let status = res.status();
     let body = res.text().await.expect("invalid response");
     if status == StatusCode::OK {
+        if network_type == NetworkType::Signet {
+            let _ = print_explorer_url(&Txid::from_str(&body).expect("valid txid"), &term);
+        }
         let _ = term.write_line(&format!("Successful. Claimed in transaction {body}"));
     } else {
         let _ = term.write_line(&format!("Failed: faucet responded with {status}: {body}"));

--- a/bin/strata-cli/src/cmd/faucet.rs
+++ b/bin/strata-cli/src/cmd/faucet.rs
@@ -167,7 +167,11 @@ pub async fn faucet(args: FaucetArgs, seed: Seed, settings: Settings) {
     if status == StatusCode::OK {
         #[cfg(feature = "strata_faucet")]
         if network_type == NetworkType::Signet {
-            let _ = print_explorer_url(&Txid::from_str(&body).expect("valid txid"), &term);
+            let _ = print_explorer_url(
+                &Txid::from_str(&body).expect("valid txid"),
+                &term,
+                &settings,
+            );
         }
         #[cfg(not(feature = "strata_faucet"))]
         let _ = print_explorer_url(

--- a/bin/strata-cli/src/cmd/faucet.rs
+++ b/bin/strata-cli/src/cmd/faucet.rs
@@ -170,7 +170,11 @@ pub async fn faucet(args: FaucetArgs, seed: Seed, settings: Settings) {
             let _ = print_explorer_url(&Txid::from_str(&body).expect("valid txid"), &term);
         }
         #[cfg(not(feature = "strata_faucet"))]
-        let _ = print_explorer_url(&Txid::from_str(&body).expect("valid txid"), &term);
+        let _ = print_explorer_url(
+            &Txid::from_str(&body).expect("valid txid"),
+            &term,
+            &settings,
+        );
         let _ = term.write_line(&format!("Successful. Claimed in transaction {body}"));
     } else {
         let _ = term.write_line(&format!("Failed: faucet responded with {status}: {body}"));

--- a/bin/strata-cli/src/cmd/faucet.rs
+++ b/bin/strata-cli/src/cmd/faucet.rs
@@ -1,6 +1,6 @@
 use std::str::FromStr;
 
-use alloy::{primitives::Address as StrataAddress, providers::WalletProvider};
+// use alloy::{primitives::Address as StrataAddress, providers::WalletProvider};
 use argh::FromArgs;
 use bdk_wallet::{
     bitcoin::{Address, Txid},
@@ -16,21 +16,20 @@ use shrex::{encode, Hex};
 
 use crate::{
     constants::NETWORK,
-    net_type::{net_type_or_exit, NetworkType},
+    // net_type::{net_type_or_exit, NetworkType},
     seed::Seed,
     settings::Settings,
     signet::{print_explorer_url, SignetWallet},
-    strata::StrataWallet,
+    // strata::StrataWallet,
 };
 
 /// Request some bitcoin from the faucet
 #[derive(FromArgs, PartialEq, Debug)]
 #[argh(subcommand, name = "faucet")]
 pub struct FaucetArgs {
-    /// either "signet" or "strata"
-    #[argh(positional)]
-    network_type: String,
-
+    // /// either "signet" or "strata"
+    // #[argh(positional)]
+    // network_type: String,
     /// address that funds will be sent to. defaults to internal wallet
     #[argh(positional)]
     address: Option<String>,
@@ -47,7 +46,7 @@ pub struct PowChallenge {
 
 pub async fn faucet(args: FaucetArgs, seed: Seed, settings: Settings) {
     let term = Term::stdout();
-    let network_type = net_type_or_exit(&args.network_type, &term);
+    // let network_type = net_type_or_exit(&args.network_type, &term);
 
     let _ = term.write_line("Fetching challenge from faucet");
 
@@ -88,45 +87,47 @@ pub async fn faucet(args: FaucetArgs, seed: Seed, settings: Settings) {
         "✔ Solved challenge after {solution} attempts. Claiming now."
     ));
 
-    let url = match network_type {
-        NetworkType::Signet => {
-            let mut l1w = SignetWallet::new(&seed, NETWORK).unwrap();
-            let address = match args.address {
-                None => {
-                    let address_info = l1w.reveal_next_address(KeychainKind::External);
-                    l1w.persist().unwrap();
-                    address_info.address
-                }
-                Some(address) => {
-                    let address = Address::from_str(&address).expect("bad address");
-                    address
-                        .require_network(NETWORK)
-                        .expect("wrong bitcoin network")
-                }
-            };
+    // let url = match network_type {
+    //     NetworkType::Signet =>
+    //     NetworkType::Strata => {
+    //         let l2w = StrataWallet::new(&seed, &settings.l2_http_endpoint).unwrap();
+    //         // they said EVMs were advanced 👁️👁️
+    //         let address = match args.address {
+    //             Some(address) => StrataAddress::from_str(&address).expect("bad address"),
+    //             None => l2w.default_signer_address(),
+    //         };
+    //         let _ = term.write_line(&format!("Claiming to Strata address {}", address));
+    //         format!(
+    //             "{base}claim_l2/{}/{}",
+    //             encode(&solution.to_le_bytes()),
+    //             address
+    //         )
+    //     }
+    // };
 
-            let _ = term.write_line(&format!("Claiming to signet address {}", address));
+    let url = {
+        let mut l1w = SignetWallet::new(&seed, NETWORK).unwrap();
+        let address = match args.address {
+            None => {
+                let address_info = l1w.reveal_next_address(KeychainKind::External);
+                l1w.persist().unwrap();
+                address_info.address
+            }
+            Some(address) => {
+                let address = Address::from_str(&address).expect("bad address");
+                address
+                    .require_network(NETWORK)
+                    .expect("wrong bitcoin network")
+            }
+        };
 
-            format!(
-                "{base}claim_l1/{}/{}",
-                encode(&solution.to_le_bytes()),
-                address
-            )
-        }
-        NetworkType::Strata => {
-            let l2w = StrataWallet::new(&seed, &settings.l2_http_endpoint).unwrap();
-            // they said EVMs were advanced 👁️👁️
-            let address = match args.address {
-                Some(address) => StrataAddress::from_str(&address).expect("bad address"),
-                None => l2w.default_signer_address(),
-            };
-            let _ = term.write_line(&format!("Claiming to Strata address {}", address));
-            format!(
-                "{base}claim_l2/{}/{}",
-                encode(&solution.to_le_bytes()),
-                address
-            )
-        }
+        let _ = term.write_line(&format!("Claiming to signet address {}", address));
+
+        format!(
+            "{base}claim_l1/{}/{}",
+            encode(&solution.to_le_bytes()),
+            address
+        )
     };
 
     let res = client.get(url).send().await.unwrap();
@@ -134,9 +135,9 @@ pub async fn faucet(args: FaucetArgs, seed: Seed, settings: Settings) {
     let status = res.status();
     let body = res.text().await.expect("invalid response");
     if status == StatusCode::OK {
-        if network_type == NetworkType::Signet {
-            let _ = print_explorer_url(&Txid::from_str(&body).expect("valid txid"), &term);
-        }
+        // if network_type == NetworkType::Signet {
+        let _ = print_explorer_url(&Txid::from_str(&body).expect("valid txid"), &term);
+        // }
         let _ = term.write_line(&format!("Successful. Claimed in transaction {body}"));
     } else {
         let _ = term.write_line(&format!("Failed: faucet responded with {status}: {body}"));

--- a/bin/strata-cli/src/cmd/mod.rs
+++ b/bin/strata-cli/src/cmd/mod.rs
@@ -1,10 +1,9 @@
 use argh::FromArgs;
 use backup::BackupArgs;
 use balance::BalanceArgs;
-use bridge_in::BridgeInArgs;
-use bridge_out::BridgeOutArgs;
 use change_pwd::ChangePwdArgs;
 use config::ConfigArgs;
+use deposit::DepositArgs;
 use drain::DrainArgs;
 use faucet::FaucetArgs;
 use receive::ReceiveArgs;
@@ -12,13 +11,13 @@ use recover::RecoverArgs;
 use reset::ResetArgs;
 use scan::ScanArgs;
 use send::SendArgs;
+use withdraw::WithdrawArgs;
 
 pub mod backup;
 pub mod balance;
-pub mod bridge_in;
-pub mod bridge_out;
 pub mod change_pwd;
 pub mod config;
+pub mod deposit;
 pub mod drain;
 pub mod faucet;
 pub mod receive;
@@ -26,6 +25,7 @@ pub mod recover;
 pub mod reset;
 pub mod scan;
 pub mod send;
+pub mod withdraw;
 
 /// A CLI for interacting with Strata and Alpen Labs' bitcoin signet
 #[derive(FromArgs, PartialEq, Debug)]
@@ -41,8 +41,8 @@ pub enum Commands {
     Drain(DrainArgs),
     Balance(BalanceArgs),
     Backup(BackupArgs),
-    BridgeIn(BridgeInArgs),
-    BridgeOut(BridgeOutArgs),
+    Deposit(DepositArgs),
+    Withdraw(WithdrawArgs),
     Faucet(FaucetArgs),
     Send(SendArgs),
     Receive(ReceiveArgs),

--- a/bin/strata-cli/src/cmd/mod.rs
+++ b/bin/strata-cli/src/cmd/mod.rs
@@ -7,7 +7,7 @@ use change_pwd::ChangePwdArgs;
 use drain::DrainArgs;
 use faucet::FaucetArgs;
 use receive::ReceiveArgs;
-use refresh::RefreshArgs;
+use recover::RecoverArgs;
 use reset::ResetArgs;
 use scan::ScanArgs;
 use send::SendArgs;
@@ -20,7 +20,7 @@ pub mod change_pwd;
 pub mod drain;
 pub mod faucet;
 pub mod receive;
-pub mod refresh;
+pub mod recover;
 pub mod reset;
 pub mod scan;
 pub mod send;
@@ -35,7 +35,7 @@ pub struct TopLevel {
 #[derive(FromArgs, PartialEq, Debug)]
 #[argh(subcommand)]
 pub enum Commands {
-    Refresh(RefreshArgs),
+    Recover(RecoverArgs),
     Drain(DrainArgs),
     Balance(BalanceArgs),
     Backup(BackupArgs),

--- a/bin/strata-cli/src/cmd/mod.rs
+++ b/bin/strata-cli/src/cmd/mod.rs
@@ -4,6 +4,7 @@ use balance::BalanceArgs;
 use bridge_in::BridgeInArgs;
 use bridge_out::BridgeOutArgs;
 use change_pwd::ChangePwdArgs;
+use config::ConfigArgs;
 use drain::DrainArgs;
 use faucet::FaucetArgs;
 use receive::ReceiveArgs;
@@ -17,6 +18,7 @@ pub mod balance;
 pub mod bridge_in;
 pub mod bridge_out;
 pub mod change_pwd;
+pub mod config;
 pub mod drain;
 pub mod faucet;
 pub mod receive;
@@ -47,4 +49,5 @@ pub enum Commands {
     ChangePwd(ChangePwdArgs),
     Reset(ResetArgs),
     Scan(ScanArgs),
+    Config(ConfigArgs),
 }

--- a/bin/strata-cli/src/cmd/mod.rs
+++ b/bin/strata-cli/src/cmd/mod.rs
@@ -9,6 +9,7 @@ use faucet::FaucetArgs;
 use receive::ReceiveArgs;
 use refresh::RefreshArgs;
 use reset::ResetArgs;
+use scan::ScanArgs;
 use send::SendArgs;
 
 pub mod backup;
@@ -21,6 +22,7 @@ pub mod faucet;
 pub mod receive;
 pub mod refresh;
 pub mod reset;
+pub mod scan;
 pub mod send;
 
 /// A CLI for interacting with Strata and Alpen Labs' bitcoin signet
@@ -44,4 +46,5 @@ pub enum Commands {
     Receive(ReceiveArgs),
     ChangePwd(ChangePwdArgs),
     Reset(ResetArgs),
+    Scan(ScanArgs),
 }

--- a/bin/strata-cli/src/cmd/receive.rs
+++ b/bin/strata-cli/src/cmd/receive.rs
@@ -4,7 +4,6 @@ use bdk_wallet::KeychainKind;
 use console::Term;
 
 use crate::{
-    constants::NETWORK,
     net_type::{net_type_or_exit, NetworkType},
     seed::Seed,
     settings::Settings,
@@ -27,7 +26,7 @@ pub async fn receive(args: ReceiveArgs, seed: Seed, settings: Settings, esplora:
 
     let address = match network_type {
         NetworkType::Signet => {
-            let mut l1w = SignetWallet::new(&seed, NETWORK).unwrap();
+            let mut l1w = SignetWallet::new(&seed, settings.network).unwrap();
             let _ = term.write_line("Syncing signet wallet");
             l1w.sync(&esplora).await.unwrap();
             let _ = term.write_line("Wallet synced");

--- a/bin/strata-cli/src/cmd/receive.rs
+++ b/bin/strata-cli/src/cmd/receive.rs
@@ -35,7 +35,7 @@ pub async fn receive(args: ReceiveArgs, seed: Seed, settings: Settings, esplora:
             address_info.address.to_string()
         }
         NetworkType::Strata => {
-            let l2w = StrataWallet::new(&seed, &settings.l2_http_endpoint).unwrap();
+            let l2w = StrataWallet::new(&seed, &settings.strata_endpoint).unwrap();
             l2w.default_signer_address().to_string()
         }
     };

--- a/bin/strata-cli/src/cmd/recover.rs
+++ b/bin/strata-cli/src/cmd/recover.rs
@@ -6,7 +6,6 @@ use bdk_wallet::{
 use console::{style, Term};
 
 use crate::{
-    constants::NETWORK,
     recovery::DescriptorRecovery,
     seed::Seed,
     settings::Settings,
@@ -20,7 +19,7 @@ pub struct RecoverArgs {}
 
 pub async fn recover(seed: Seed, settings: Settings, esplora: EsploraClient) {
     let term = Term::stdout();
-    let mut l1w = SignetWallet::new(&seed, NETWORK).unwrap();
+    let mut l1w = SignetWallet::new(&seed, settings.network).unwrap();
     l1w.sync(&esplora).await.unwrap();
 
     let _ = term.write_line("Opening descriptor recovery");
@@ -47,11 +46,11 @@ pub async fn recover(seed: Seed, settings: Settings, esplora: EsploraClient) {
     for desc in descs {
         let desc = desc
             .clone()
-            .into_wallet_descriptor(l1w.secp_ctx(), NETWORK)
+            .into_wallet_descriptor(l1w.secp_ctx(), settings.network)
             .expect("valid descriptor");
 
         let mut recovery_wallet = Wallet::create_single(desc)
-            .network(NETWORK)
+            .network(settings.network)
             .create_wallet_no_persist()
             .expect("valid wallet");
 

--- a/bin/strata-cli/src/cmd/recover.rs
+++ b/bin/strata-cli/src/cmd/recover.rs
@@ -10,7 +10,7 @@ use crate::{
     recovery::DescriptorRecovery,
     seed::Seed,
     settings::Settings,
-    signet::{fee_rate_or_crash, log_fee_rate, EsploraClient, SignetWallet},
+    signet::{get_fee_rate, log_fee_rate, EsploraClient, SignetWallet},
 };
 
 /// Attempt recovery of old deposit transactions
@@ -43,7 +43,9 @@ pub async fn recover(args: RecoverArgs, seed: Seed, settings: Settings, esplora:
         return;
     }
 
-    let fee_rate = fee_rate_or_crash(args.fee_rate, &esplora).await;
+    let fee_rate = get_fee_rate(args.fee_rate, &esplora, 1)
+        .await
+        .expect("valid fee rate");
     log_fee_rate(&term, &fee_rate);
 
     for (key, desc) in descs {

--- a/bin/strata-cli/src/cmd/recover.rs
+++ b/bin/strata-cli/src/cmd/recover.rs
@@ -13,13 +13,12 @@ use crate::{
     signet::{get_fee_rate, EsploraClient, SignetWallet},
 };
 
-/// Runs any background tasks manually. Currently performs recovery of old
-/// bridge in transactions
+/// Attempt recovery of old bridge-in transactions
 #[derive(FromArgs, PartialEq, Debug)]
-#[argh(subcommand, name = "refresh")]
-pub struct RefreshArgs {}
+#[argh(subcommand, name = "recover")]
+pub struct RecoverArgs {}
 
-pub async fn refresh(seed: Seed, settings: Settings, esplora: EsploraClient) {
+pub async fn recover(seed: Seed, settings: Settings, esplora: EsploraClient) {
     let term = Term::stdout();
     let mut l1w = SignetWallet::new(&seed, NETWORK).unwrap();
     l1w.sync(&esplora).await.unwrap();

--- a/bin/strata-cli/src/cmd/recover.rs
+++ b/bin/strata-cli/src/cmd/recover.rs
@@ -12,7 +12,7 @@ use crate::{
     signet::{get_fee_rate, EsploraClient, SignetWallet},
 };
 
-/// Attempt recovery of old bridge-in transactions
+/// Attempt recovery of old deposit transactions
 #[derive(FromArgs, PartialEq, Debug)]
 #[argh(subcommand, name = "recover")]
 pub struct RecoverArgs {}
@@ -71,7 +71,7 @@ pub async fn recover(seed: Seed, settings: Settings, esplora: EsploraClient) {
 
         let recover_to = l1w.reveal_next_address(KeychainKind::External).address;
         let _ = term.write_line(&format!(
-            "Recovering a bridge-in transaction from address {} to {}",
+            "Recovering a deposit transaction from address {} to {}",
             style(address).yellow(),
             style(&recover_to).yellow()
         ));

--- a/bin/strata-cli/src/cmd/reset.rs
+++ b/bin/strata-cli/src/cmd/reset.rs
@@ -4,7 +4,8 @@ use dialoguer::Confirm;
 
 use crate::{seed::EncryptedSeedPersister, settings::Settings};
 
-/// Prints a BIP39 mnemonic encoding the internal wallet's seed bytes
+/// DANGER: resets the CLI completely, destroying all keys and databases.
+/// Keeps config.
 #[derive(FromArgs, PartialEq, Debug)]
 #[argh(subcommand, name = "reset")]
 pub struct ResetArgs {

--- a/bin/strata-cli/src/cmd/scan.rs
+++ b/bin/strata-cli/src/cmd/scan.rs
@@ -1,0 +1,17 @@
+use argh::FromArgs;
+
+use crate::{
+    constants::NETWORK,
+    seed::Seed,
+    signet::{EsploraClient, SignetWallet},
+};
+
+/// Performs a full scan of the signet wallet
+#[derive(FromArgs, PartialEq, Debug)]
+#[argh(subcommand, name = "scan")]
+pub struct ScanArgs {}
+
+pub async fn scan(_args: ScanArgs, seed: Seed, esplora: EsploraClient) {
+    let mut l1w = SignetWallet::new(&seed, NETWORK).unwrap();
+    l1w.scan(&esplora).await.unwrap();
+}

--- a/bin/strata-cli/src/cmd/scan.rs
+++ b/bin/strata-cli/src/cmd/scan.rs
@@ -1,8 +1,8 @@
 use argh::FromArgs;
 
 use crate::{
-    constants::NETWORK,
     seed::Seed,
+    settings::Settings,
     signet::{EsploraClient, SignetWallet},
 };
 
@@ -11,7 +11,7 @@ use crate::{
 #[argh(subcommand, name = "scan")]
 pub struct ScanArgs {}
 
-pub async fn scan(_args: ScanArgs, seed: Seed, esplora: EsploraClient) {
-    let mut l1w = SignetWallet::new(&seed, NETWORK).unwrap();
+pub async fn scan(_args: ScanArgs, seed: Seed, settings: Settings, esplora: EsploraClient) {
+    let mut l1w = SignetWallet::new(&seed, settings.network).unwrap();
     l1w.scan(&esplora).await.unwrap();
 }

--- a/bin/strata-cli/src/cmd/send.rs
+++ b/bin/strata-cli/src/cmd/send.rs
@@ -37,7 +37,7 @@ pub struct SendArgs {
 
     /// override signet fee rate in sat/vbyte. must be >1
     #[argh(option)]
-    fee_rate: Option<String>,
+    fee_rate: Option<u64>,
 }
 
 pub async fn send(args: SendArgs, seed: Seed, settings: Settings, esplora: EsploraClient) {

--- a/bin/strata-cli/src/cmd/send.rs
+++ b/bin/strata-cli/src/cmd/send.rs
@@ -7,16 +7,15 @@ use alloy::{
     rpc::types::TransactionRequest,
 };
 use argh::FromArgs;
-use bdk_wallet::bitcoin::{hashes::Hash, Address, Amount};
+use bdk_wallet::bitcoin::{Address, Amount};
 use console::Term;
-use shrex::encode;
 
 use crate::{
     constants::NETWORK,
     net_type::{net_type_or_exit, NetworkType},
     seed::Seed,
     settings::Settings,
-    signet::{get_fee_rate, EsploraClient, SignetWallet},
+    signet::{fee_rate_or_crash, log_fee_rate, print_explorer_url, EsploraClient, SignetWallet},
     strata::StrataWallet,
 };
 
@@ -35,13 +34,17 @@ pub struct SendArgs {
     /// address to send to
     #[argh(positional)]
     address: String,
+
+    /// override signet fee rate in sat/vbyte. must be >1
+    #[argh(option)]
+    fee_rate: Option<String>,
 }
 
 pub async fn send(args: SendArgs, seed: Seed, settings: Settings, esplora: EsploraClient) {
     let term = Term::stdout();
     let network_type = net_type_or_exit(&args.network_type, &term);
 
-    let txid = match network_type {
+    match network_type {
         NetworkType::Signet => {
             let amount = Amount::from_sat(args.amount);
             let address = Address::from_str(&args.address)
@@ -50,10 +53,8 @@ pub async fn send(args: SendArgs, seed: Seed, settings: Settings, esplora: Esplo
                 .expect("correct network");
             let mut l1w = SignetWallet::new(&seed, NETWORK).expect("valid wallet");
             l1w.sync(&esplora).await.unwrap();
-            let fee_rate = get_fee_rate(1, &esplora)
-                .await
-                .expect("valid response")
-                .expect("valid target");
+            let fee_rate = fee_rate_or_crash(args.fee_rate, &esplora).await;
+            log_fee_rate(&term, &fee_rate);
             let mut psbt = l1w
                 .build_tx()
                 .add_recipient(address.script_pubkey(), amount)
@@ -65,7 +66,7 @@ pub async fn send(args: SendArgs, seed: Seed, settings: Settings, esplora: Esplo
                 .expect("signable psbt");
             let tx = psbt.extract_tx().expect("signed tx");
             esplora.broadcast(&tx).await.expect("successful broadcast");
-            tx.compute_txid().as_raw_hash().to_byte_array()
+            let _ = print_explorer_url(&tx.compute_txid(), &term);
         }
         NetworkType::Strata => {
             let l2w = StrataWallet::new(&seed, &settings.l2_http_endpoint).expect("valid wallet");
@@ -74,18 +75,13 @@ pub async fn send(args: SendArgs, seed: Seed, settings: Settings, esplora: Esplo
                 .with_to(address)
                 // 1 btc == 1 "eth" => 1 sat = 1e10 "wei"
                 .with_value(U256::from(args.amount * 10u64.pow(10)));
-            l2w.send_transaction(tx)
+            let res = l2w
+                .send_transaction(tx)
                 .await
-                .expect("successful broadcast")
-                .tx_hash()
-                .0
+                .expect("successful broadcast");
+            let _ = term.write_line(&format!("Transaction {} sent", res.tx_hash()));
         }
     };
 
-    let _ = term.write_line(&format!(
-        "Sent {} to {} in tx {}",
-        args.amount,
-        args.address,
-        encode(&txid)
-    ));
+    let _ = term.write_line(&format!("Sent {} to {}", args.amount, args.address,));
 }

--- a/bin/strata-cli/src/cmd/send.rs
+++ b/bin/strata-cli/src/cmd/send.rs
@@ -11,7 +11,6 @@ use bdk_wallet::bitcoin::{Address, Amount};
 use console::Term;
 
 use crate::{
-    constants::NETWORK,
     net_type::{net_type_or_exit, NetworkType},
     seed::Seed,
     settings::Settings,
@@ -49,9 +48,9 @@ pub async fn send(args: SendArgs, seed: Seed, settings: Settings, esplora: Esplo
             let amount = Amount::from_sat(args.amount);
             let address = Address::from_str(&args.address)
                 .expect("valid address")
-                .require_network(NETWORK)
+                .require_network(settings.network)
                 .expect("correct network");
-            let mut l1w = SignetWallet::new(&seed, NETWORK).expect("valid wallet");
+            let mut l1w = SignetWallet::new(&seed, settings.network).expect("valid wallet");
             l1w.sync(&esplora).await.unwrap();
             let fee_rate = fee_rate_or_crash(args.fee_rate, &esplora).await;
             log_fee_rate(&term, &fee_rate);

--- a/bin/strata-cli/src/cmd/send.rs
+++ b/bin/strata-cli/src/cmd/send.rs
@@ -11,6 +11,7 @@ use bdk_wallet::bitcoin::{Address, Amount};
 use console::Term;
 
 use crate::{
+    constants::SATS_TO_WEI,
     net_type::{net_type_or_exit, NetworkType},
     seed::Seed,
     settings::Settings,
@@ -72,8 +73,7 @@ pub async fn send(args: SendArgs, seed: Seed, settings: Settings, esplora: Esplo
             let address = StrataAddress::from_str(&args.address).expect("valid address");
             let tx = TransactionRequest::default()
                 .with_to(address)
-                // 1 btc == 1 "eth" => 1 sat = 1e10 "wei"
-                .with_value(U256::from(args.amount * 10u64.pow(10)));
+                .with_value(U256::from(args.amount as u128 * SATS_TO_WEI));
             let res = l2w
                 .send_transaction(tx)
                 .await
@@ -82,5 +82,9 @@ pub async fn send(args: SendArgs, seed: Seed, settings: Settings, esplora: Esplo
         }
     };
 
-    let _ = term.write_line(&format!("Sent {} to {}", args.amount, args.address,));
+    let _ = term.write_line(&format!(
+        "Sent {} to {}",
+        Amount::from_sat(args.amount),
+        args.address,
+    ));
 }

--- a/bin/strata-cli/src/cmd/send.rs
+++ b/bin/strata-cli/src/cmd/send.rs
@@ -15,7 +15,7 @@ use crate::{
     net_type::{net_type_or_exit, NetworkType},
     seed::Seed,
     settings::Settings,
-    signet::{fee_rate_or_crash, log_fee_rate, print_explorer_url, EsploraClient, SignetWallet},
+    signet::{get_fee_rate, log_fee_rate, print_explorer_url, EsploraClient, SignetWallet},
     strata::StrataWallet,
 };
 
@@ -53,7 +53,9 @@ pub async fn send(args: SendArgs, seed: Seed, settings: Settings, esplora: Esplo
                 .expect("correct network");
             let mut l1w = SignetWallet::new(&seed, settings.network).expect("valid wallet");
             l1w.sync(&esplora).await.unwrap();
-            let fee_rate = fee_rate_or_crash(args.fee_rate, &esplora).await;
+            let fee_rate = get_fee_rate(args.fee_rate, &esplora, 1)
+                .await
+                .expect("valid fee rate");
             log_fee_rate(&term, &fee_rate);
             let mut psbt = l1w
                 .build_tx()

--- a/bin/strata-cli/src/cmd/send.rs
+++ b/bin/strata-cli/src/cmd/send.rs
@@ -34,7 +34,7 @@ pub struct SendArgs {
     #[argh(positional)]
     address: String,
 
-    /// override signet fee rate in sat/vbyte. must be >1
+    /// override signet fee rate in sat/vbyte. must be >=1
     #[argh(option)]
     fee_rate: Option<u64>,
 }

--- a/bin/strata-cli/src/cmd/send.rs
+++ b/bin/strata-cli/src/cmd/send.rs
@@ -65,7 +65,7 @@ pub async fn send(args: SendArgs, seed: Seed, settings: Settings, esplora: Esplo
                 .expect("signable psbt");
             let tx = psbt.extract_tx().expect("signed tx");
             esplora.broadcast(&tx).await.expect("successful broadcast");
-            let _ = print_explorer_url(&tx.compute_txid(), &term);
+            let _ = print_explorer_url(&tx.compute_txid(), &term, &settings);
         }
         NetworkType::Strata => {
             let l2w = StrataWallet::new(&seed, &settings.strata_endpoint).expect("valid wallet");

--- a/bin/strata-cli/src/cmd/send.rs
+++ b/bin/strata-cli/src/cmd/send.rs
@@ -68,7 +68,7 @@ pub async fn send(args: SendArgs, seed: Seed, settings: Settings, esplora: Esplo
             let _ = print_explorer_url(&tx.compute_txid(), &term);
         }
         NetworkType::Strata => {
-            let l2w = StrataWallet::new(&seed, &settings.l2_http_endpoint).expect("valid wallet");
+            let l2w = StrataWallet::new(&seed, &settings.strata_endpoint).expect("valid wallet");
             let address = StrataAddress::from_str(&args.address).expect("valid address");
             let tx = TransactionRequest::default()
                 .with_to(address)

--- a/bin/strata-cli/src/cmd/withdraw.rs
+++ b/bin/strata-cli/src/cmd/withdraw.rs
@@ -16,7 +16,7 @@ use crate::{
 
 /// Withdraw 10 BTC from Strata to signet
 #[derive(FromArgs, PartialEq, Debug)]
-#[argh(subcommand, name = "bridge-out")]
+#[argh(subcommand, name = "withdraw")]
 pub struct WithdrawArgs {
     /// the signet address to send funds to. defaults to a new internal wallet address
     #[argh(positional)]

--- a/bin/strata-cli/src/cmd/withdraw.rs
+++ b/bin/strata-cli/src/cmd/withdraw.rs
@@ -14,16 +14,16 @@ use crate::{
     strata::StrataWallet, taproot::ExtractP2trPubkey,
 };
 
-/// Bridge 10 BTC from Strata to signet
+/// Withdraw 10 BTC from Strata to signet
 #[derive(FromArgs, PartialEq, Debug)]
 #[argh(subcommand, name = "bridge-out")]
-pub struct BridgeOutArgs {
+pub struct WithdrawArgs {
     /// the signet address to send funds to. defaults to a new internal wallet address
     #[argh(positional)]
     p2tr_address: Option<String>,
 }
 
-pub async fn bridge_out(args: BridgeOutArgs, seed: Seed, settings: Settings) {
+pub async fn withdraw(args: WithdrawArgs, seed: Seed, settings: Settings) {
     let address = args.p2tr_address.map(|a| {
         Address::from_str(&a)
             .expect("valid address")

--- a/bin/strata-cli/src/cmd/withdraw.rs
+++ b/bin/strata-cli/src/cmd/withdraw.rs
@@ -10,8 +10,12 @@ use console::Term;
 use indicatif::ProgressBar;
 
 use crate::{
-    constants::BRIDGE_OUT_AMOUNT, seed::Seed, settings::Settings, signet::SignetWallet,
-    strata::StrataWallet, taproot::ExtractP2trPubkey,
+    constants::{BRIDGE_OUT_AMOUNT, SATS_TO_WEI},
+    seed::Seed,
+    settings::Settings,
+    signet::SignetWallet,
+    strata::StrataWallet,
+    taproot::ExtractP2trPubkey,
 };
 
 /// Withdraw 10 BTC from Strata to signet
@@ -52,7 +56,7 @@ pub async fn withdraw(args: WithdrawArgs, seed: Seed, settings: Settings) {
     let tx = l2w
         .transaction_request()
         .with_to(settings.bridge_strata_address)
-        .with_value(U256::from(BRIDGE_OUT_AMOUNT.to_sat() * 1u64.pow(10)))
+        .with_value(U256::from(BRIDGE_OUT_AMOUNT.to_sat() as u128 * SATS_TO_WEI))
         .input(TransactionInput::new(
             address
                 .extract_p2tr_pubkey()

--- a/bin/strata-cli/src/constants.rs
+++ b/bin/strata-cli/src/constants.rs
@@ -38,9 +38,8 @@ pub const DEFAULT_ESPLORA: &str = "https://esploraapi.devnet-annapurna.stratabtc
 pub const DEFAULT_L2_HTTP_ENDPOINT: &str = "https://stratareth.devnet-annapurna.stratabtc.org";
 pub const DEFAULT_FAUCET_ENDPOINT: &str = "https://faucet.devnet-annapurna.stratabtc.org";
 pub const DEFAULT_MEMPOOL_ENDPOINT: &str = "https://mempool.devnet-annapurna.stratabtc.org";
-// FIXME: CHANGE BELOW!!!
 pub const BRIDGE_MUSIG2_PUBKEY: &str =
-    "fbd79b6b8b7fe11bad25ae89a7415221c030978de448775729c3f0a903819dd0";
+    "51acd1574ef6b1fb98ed000db6e31a7cb8d3dba302fa22e2c99a03f4cbfc2438";
 
 /// A provably unspendable, static public key from predetermined inputs created using method specified in [BIP-341](https://github.com/bitcoin/bips/blob/master/bip-0341.mediawiki#cite_note-23)
 pub static UNSPENDABLE: LazyLock<XOnlyPublicKey> = LazyLock::new(|| {

--- a/bin/strata-cli/src/constants.rs
+++ b/bin/strata-cli/src/constants.rs
@@ -30,7 +30,7 @@ pub const SEED_LEN: usize = 32;
 /// AES-256-GCM-SIV tag len
 pub const AES_TAG_LEN: usize = 16;
 
-pub const NETWORK: Network = Network::Signet;
+pub const DEFAULT_NETWORK: Network = Network::Signet;
 pub const BRIDGE_STRATA_ADDRESS: &str = "0x000000000000000000000000000000000B121d9E";
 pub const L2_BLOCK_TIME: Duration = Duration::from_secs(30);
 

--- a/bin/strata-cli/src/constants.rs
+++ b/bin/strata-cli/src/constants.rs
@@ -32,12 +32,8 @@ pub const AES_TAG_LEN: usize = 16;
 
 pub const DEFAULT_NETWORK: Network = Network::Signet;
 pub const BRIDGE_STRATA_ADDRESS: &str = "0x5400000000000000000000000000000000000001";
-pub const L2_BLOCK_TIME: Duration = Duration::from_secs(30);
+pub const SIGNET_BLOCK_TIME: Duration = Duration::from_secs(30);
 
-pub const DEFAULT_ESPLORA: &str = "https://esploraapi.devnet-annapurna.stratabtc.org";
-pub const DEFAULT_STRATA_ENDPOINT: &str = "https://stratareth.devnet-annapurna.stratabtc.org";
-pub const DEFAULT_FAUCET_ENDPOINT: &str = "https://faucet.devnet-annapurna.stratabtc.org";
-pub const DEFAULT_MEMPOOL_ENDPOINT: &str = "https://mempool.devnet-annapurna.stratabtc.org";
 pub const BRIDGE_MUSIG2_PUBKEY: &str =
     "14ced579c6a92533fa68ccc16da93b41073993cfc6cc982320645d8e9a63ee65";
 

--- a/bin/strata-cli/src/constants.rs
+++ b/bin/strata-cli/src/constants.rs
@@ -39,7 +39,7 @@ pub const DEFAULT_STRATA_ENDPOINT: &str = "https://stratareth.devnet-annapurna.s
 pub const DEFAULT_FAUCET_ENDPOINT: &str = "https://faucet.devnet-annapurna.stratabtc.org";
 pub const DEFAULT_MEMPOOL_ENDPOINT: &str = "https://mempool.devnet-annapurna.stratabtc.org";
 pub const BRIDGE_MUSIG2_PUBKEY: &str =
-    "51acd1574ef6b1fb98ed000db6e31a7cb8d3dba302fa22e2c99a03f4cbfc2438";
+    "14ced579c6a92533fa68ccc16da93b41073993cfc6cc982320645d8e9a63ee65";
 
 /// A provably unspendable, static public key from predetermined inputs created using method specified in [BIP-341](https://github.com/bitcoin/bips/blob/master/bip-0341.mediawiki#cite_note-23)
 pub static UNSPENDABLE: LazyLock<XOnlyPublicKey> = LazyLock::new(|| {

--- a/bin/strata-cli/src/constants.rs
+++ b/bin/strata-cli/src/constants.rs
@@ -31,7 +31,7 @@ pub const SEED_LEN: usize = 16;
 pub const AES_TAG_LEN: usize = 16;
 
 pub const DEFAULT_NETWORK: Network = Network::Signet;
-pub const BRIDGE_STRATA_ADDRESS: &str = "0x000000000000000000000000000000000B121d9E";
+pub const BRIDGE_STRATA_ADDRESS: &str = "0x5400000000000000000000000000000000000001";
 pub const L2_BLOCK_TIME: Duration = Duration::from_secs(30);
 
 pub const DEFAULT_ESPLORA: &str = "https://esploraapi.devnet-annapurna.stratabtc.org";

--- a/bin/strata-cli/src/constants.rs
+++ b/bin/strata-cli/src/constants.rs
@@ -26,7 +26,7 @@ pub const PW_SALT_LEN: usize = 16;
 /// Length of nonce in bytes
 pub const AES_NONCE_LEN: usize = 12;
 /// Length of seed in bytes
-pub const SEED_LEN: usize = 32;
+pub const SEED_LEN: usize = 16;
 /// AES-256-GCM-SIV tag len
 pub const AES_TAG_LEN: usize = 16;
 
@@ -35,7 +35,7 @@ pub const BRIDGE_STRATA_ADDRESS: &str = "0x000000000000000000000000000000000B121
 pub const L2_BLOCK_TIME: Duration = Duration::from_secs(30);
 
 pub const DEFAULT_ESPLORA: &str = "https://esploraapi.devnet-annapurna.stratabtc.org";
-pub const DEFAULT_L2_HTTP_ENDPOINT: &str = "https://stratareth.devnet-annapurna.stratabtc.org";
+pub const DEFAULT_STRATA_ENDPOINT: &str = "https://stratareth.devnet-annapurna.stratabtc.org";
 pub const DEFAULT_FAUCET_ENDPOINT: &str = "https://faucet.devnet-annapurna.stratabtc.org";
 pub const DEFAULT_MEMPOOL_ENDPOINT: &str = "https://mempool.devnet-annapurna.stratabtc.org";
 pub const BRIDGE_MUSIG2_PUBKEY: &str =

--- a/bin/strata-cli/src/constants.rs
+++ b/bin/strata-cli/src/constants.rs
@@ -1,5 +1,6 @@
 use std::{sync::LazyLock, time::Duration};
 
+use alloy::consensus::constants::ETH_TO_WEI;
 use bdk_wallet::bitcoin::{
     key::Parity,
     secp256k1::{PublicKey, SecretKey, SECP256K1},
@@ -14,12 +15,17 @@ pub const RECOVER_DELAY: u32 = 1008;
 /// reorgs that may happen at the recovery height.
 pub const RECOVER_AT_DELAY: u32 = RECOVER_DELAY + 10;
 
+pub const RECOVERY_DESC_CLEANUP_DELAY: u32 = 100;
+
 /// 10 BTC + 0.01 to cover fees in the following transaction where the operator spends it into the
 /// federation.
 pub const BRIDGE_IN_AMOUNT: Amount = Amount::from_sat(1_001_000_000);
 
 /// Bridge outs are enforced to be exactly 10 BTC
 pub const BRIDGE_OUT_AMOUNT: Amount = Amount::from_int_btc(10);
+
+pub const BTC_TO_WEI: u128 = ETH_TO_WEI;
+pub const SATS_TO_WEI: u128 = BTC_TO_WEI / 100_000_000;
 
 /// Length of salt used for password hashing
 pub const PW_SALT_LEN: usize = 16;

--- a/bin/strata-cli/src/constants.rs
+++ b/bin/strata-cli/src/constants.rs
@@ -37,6 +37,7 @@ pub const L2_BLOCK_TIME: Duration = Duration::from_secs(30);
 pub const DEFAULT_ESPLORA: &str = "https://esploraapi.devnet-annapurna.stratabtc.org";
 pub const DEFAULT_L2_HTTP_ENDPOINT: &str = "https://stratareth.devnet-annapurna.stratabtc.org";
 pub const DEFAULT_FAUCET_ENDPOINT: &str = "https://faucet.devnet-annapurna.stratabtc.org";
+pub const DEFAULT_MEMPOOL_ENDPOINT: &str = "https://mempool.devnet-annapurna.stratabtc.org";
 // FIXME: CHANGE BELOW!!!
 pub const BRIDGE_MUSIG2_PUBKEY: &str =
     "fbd79b6b8b7fe11bad25ae89a7415221c030978de448775729c3f0a903819dd0";

--- a/bin/strata-cli/src/main.rs
+++ b/bin/strata-cli/src/main.rs
@@ -11,7 +11,7 @@ pub mod taproot;
 use cmd::{
     backup::backup, balance::balance, bridge_in::bridge_in, bridge_out::bridge_out,
     change_pwd::change_pwd, drain::drain, faucet::faucet, receive::receive, refresh::refresh,
-    reset::reset, send::send, Commands, TopLevel,
+    reset::reset, scan::scan, send::send, Commands, TopLevel,
 };
 #[cfg(target_os = "linux")]
 use seed::FilePersister;
@@ -47,5 +47,6 @@ async fn main() {
         Commands::Receive(args) => receive(args, seed, settings, esplora).await,
         Commands::Reset(args) => reset(args, persister, settings).await,
         Commands::ChangePwd(args) => change_pwd(args, seed, persister).await,
+        Commands::Scan(args) => scan(args, seed, esplora).await,
     }
 }

--- a/bin/strata-cli/src/main.rs
+++ b/bin/strata-cli/src/main.rs
@@ -47,6 +47,6 @@ async fn main() {
         Commands::Receive(args) => receive(args, seed, settings, esplora).await,
         Commands::Reset(args) => reset(args, persister, settings).await,
         Commands::ChangePwd(args) => change_pwd(args, seed, persister).await,
-        Commands::Scan(args) => scan(args, seed, esplora).await,
+        Commands::Scan(args) => scan(args, seed, settings, esplora).await,
     }
 }

--- a/bin/strata-cli/src/main.rs
+++ b/bin/strata-cli/src/main.rs
@@ -9,9 +9,9 @@ pub mod strata;
 pub mod taproot;
 
 use cmd::{
-    backup::backup, balance::balance, bridge_in::bridge_in, bridge_out::bridge_out,
-    change_pwd::change_pwd, config::config, drain::drain, faucet::faucet, receive::receive,
-    recover::recover, reset::reset, scan::scan, send::send, Commands, TopLevel,
+    backup::backup, balance::balance, change_pwd::change_pwd, config::config, deposit::deposit,
+    drain::drain, faucet::faucet, receive::receive, recover::recover, reset::reset, scan::scan,
+    send::send, withdraw::withdraw, Commands, TopLevel,
 };
 #[cfg(target_os = "linux")]
 use seed::FilePersister;
@@ -50,8 +50,8 @@ async fn main() {
         Commands::Drain(args) => drain(args, seed, settings, esplora).await,
         Commands::Balance(args) => balance(args, seed, settings, esplora).await,
         Commands::Backup(args) => backup(args, seed).await,
-        Commands::BridgeIn(args) => bridge_in(args, seed, settings, esplora).await,
-        Commands::BridgeOut(args) => bridge_out(args, seed, settings).await,
+        Commands::Deposit(args) => deposit(args, seed, settings, esplora).await,
+        Commands::Withdraw(args) => withdraw(args, seed, settings).await,
         Commands::Faucet(args) => faucet(args, seed, settings).await,
         Commands::Send(args) => send(args, seed, settings, esplora).await,
         Commands::Receive(args) => receive(args, seed, settings, esplora).await,

--- a/bin/strata-cli/src/main.rs
+++ b/bin/strata-cli/src/main.rs
@@ -23,17 +23,18 @@ use signet::{set_data_dir, EsploraClient};
 #[tokio::main(flavor = "current_thread")]
 async fn main() {
     let TopLevel { cmd } = argh::from_env();
+
+    if let Commands::Config(args) = cmd {
+        config(args).await;
+        return;
+    }
+
     let settings = Settings::load().unwrap();
 
     #[cfg(not(target_os = "linux"))]
     let persister = KeychainPersister;
     #[cfg(target_os = "linux")]
     let persister = FilePersister::new(settings.linux_seed_file.clone());
-
-    if let Commands::Config(args) = cmd {
-        config(args, settings).await;
-        return;
-    }
 
     if let Commands::Reset(args) = cmd {
         reset(args, persister, settings).await;

--- a/bin/strata-cli/src/main.rs
+++ b/bin/strata-cli/src/main.rs
@@ -47,7 +47,7 @@ async fn main() {
     let esplora = EsploraClient::new(&settings.esplora).expect("valid esplora url");
 
     match cmd {
-        Commands::Recover(_) => recover(seed, settings, esplora).await,
+        Commands::Recover(args) => recover(args, seed, settings, esplora).await,
         Commands::Drain(args) => drain(args, seed, settings, esplora).await,
         Commands::Balance(args) => balance(args, seed, settings, esplora).await,
         Commands::Backup(args) => backup(args, seed).await,

--- a/bin/strata-cli/src/main.rs
+++ b/bin/strata-cli/src/main.rs
@@ -10,7 +10,7 @@ pub mod taproot;
 
 use cmd::{
     backup::backup, balance::balance, bridge_in::bridge_in, bridge_out::bridge_out,
-    change_pwd::change_pwd, drain::drain, faucet::faucet, receive::receive, refresh::refresh,
+    change_pwd::change_pwd, drain::drain, faucet::faucet, receive::receive, recover::recover,
     reset::reset, scan::scan, send::send, Commands, TopLevel,
 };
 #[cfg(target_os = "linux")]
@@ -36,7 +36,7 @@ async fn main() {
     let esplora = EsploraClient::new(&settings.esplora).expect("valid esplora url");
 
     match cmd {
-        Commands::Refresh(_) => refresh(seed, settings, esplora).await,
+        Commands::Recover(_) => recover(seed, settings, esplora).await,
         Commands::Drain(args) => drain(args, seed, settings, esplora).await,
         Commands::Balance(args) => balance(args, seed, settings, esplora).await,
         Commands::Backup(args) => backup(args, seed).await,

--- a/bin/strata-cli/src/net_type.rs
+++ b/bin/strata-cli/src/net_type.rs
@@ -3,6 +3,7 @@ use std::str::FromStr;
 use console::Term;
 
 /// Represents a type of network, either Alpen's signet or Strata
+#[derive(PartialEq)]
 pub enum NetworkType {
     Signet,
     Strata,

--- a/bin/strata-cli/src/net_type.rs
+++ b/bin/strata-cli/src/net_type.rs
@@ -3,7 +3,7 @@ use std::str::FromStr;
 use console::Term;
 
 /// Represents a type of network, either Alpen's signet or Strata
-#[derive(PartialEq)]
+#[derive(PartialEq, Eq)]
 pub enum NetworkType {
     Signet,
     Strata,

--- a/bin/strata-cli/src/recovery.rs
+++ b/bin/strata-cli/src/recovery.rs
@@ -15,6 +15,7 @@ use bdk_wallet::{
 };
 use rand::{thread_rng, Rng};
 use sha2::{Digest, Sha256};
+use sled::IVec;
 use terrors::OneOf;
 use tokio::io::AsyncReadExt;
 
@@ -127,11 +128,11 @@ impl DescriptorRecovery {
     pub async fn read_descs_after_block(
         &mut self,
         height: u32,
-    ) -> Result<Vec<DescriptorTemplateOut>, OneOf<ReadDescsAfterError>> {
+    ) -> Result<Vec<(IVec, DescriptorTemplateOut)>, OneOf<ReadDescsAfterError>> {
         let after_height = self.db.range(height.to_be_bytes()..);
         let mut descs = vec![];
         for desc_entry in after_height {
-            let mut raw = desc_entry.map_err(OneOf::new)?.1;
+            let (key, mut raw) = desc_entry.map_err(OneOf::new)?;
             if raw.len() <= 12 + 16 {
                 return Err(OneOf::new(EntryTooShort { length: raw.len() }));
             }
@@ -198,9 +199,13 @@ impl DescriptorRecovery {
                 networks.insert(network);
             }
 
-            descs.push((desc, keymap, networks));
+            descs.push((key, (desc, keymap, networks)));
         }
         Ok(descs)
+    }
+
+    pub fn remove<K: AsRef<[u8]>>(&self, key: K) -> sled::Result<Option<sled::IVec>> {
+        self.db.remove(key)
     }
 }
 

--- a/bin/strata-cli/src/seed.rs
+++ b/bin/strata-cli/src/seed.rs
@@ -70,7 +70,7 @@ impl Seed {
         seed.copy_from_slice(&self.0);
 
         let mut cipher =
-            Aes256GcmSiv::new_from_slice(seed_encryption_key).expect("should be correct key size");
+            Aes256GcmSiv::new_from_slice(&seed_encryption_key).expect("should be correct key size");
         let nonce = Nonce::from_slice(&salt_and_nonce[PW_SALT_LEN..]);
         let tag = cipher
             .encrypt_in_place_detached(nonce, &[], seed)
@@ -124,7 +124,7 @@ impl EncryptedSeed {
             .map_err(OneOf::new)?;
 
         let mut cipher =
-            Aes256GcmSiv::new_from_slice(seed_encryption_key).expect("should be correct key size");
+            Aes256GcmSiv::new_from_slice(&seed_encryption_key).expect("should be correct key size");
         let (salt_and_nonce, rest) = self.0.split_at_mut(PW_SALT_LEN + AES_NONCE_LEN);
         let (seed, tag) = rest.split_at_mut(SEED_LEN);
         let tag = Tag::from_slice(tag);

--- a/bin/strata-cli/src/seed/password.rs
+++ b/bin/strata-cli/src/seed/password.rs
@@ -29,15 +29,14 @@ impl HashVersion {
 
 impl Password {
     pub fn read(new: bool) -> Result<Self, dialoguer::Error> {
-        let mut input = InputPassword::new();
+        let mut input = InputPassword::new().allow_empty_password(true);
         if new {
             input = input
                 .with_prompt("Create a new password (leave empty for no password, dangerous!)")
                 .with_confirmation(
                     "Confirm password (leave empty for no password, dangerous!)",
                     "Passwords didn't match",
-                )
-                .allow_empty_password(true);
+                );
         } else {
             input = input.with_prompt("Enter your password");
         }

--- a/bin/strata-cli/src/seed/password.rs
+++ b/bin/strata-cli/src/seed/password.rs
@@ -1,9 +1,11 @@
 use argon2::{Algorithm, Argon2, Params, Version};
 use dialoguer::Password as InputPassword;
+use zeroize::ZeroizeOnDrop;
 use zxcvbn::{zxcvbn, Entropy};
 
 use super::PW_SALT_LEN;
 
+#[derive(ZeroizeOnDrop)]
 pub struct Password {
     inner: String,
 }
@@ -57,13 +59,11 @@ impl Password {
     ) -> Result<[u8; 32], argon2::Error> {
         let mut sek = [0u8; 32];
         let (algo, ver, params) = version.params();
-        if !self.inner.is_empty() {
-            Argon2::new(algo, ver, params.expect("valid params")).hash_password_into(
-                self.inner.as_bytes(),
-                salt,
-                &mut sek,
-            )?;
-        }
+        Argon2::new(algo, ver, params.expect("valid params")).hash_password_into(
+            self.inner.as_bytes(),
+            salt,
+            &mut sek,
+        )?;
         Ok(sek)
     }
 }

--- a/bin/strata-cli/src/settings.rs
+++ b/bin/strata-cli/src/settings.rs
@@ -13,16 +13,14 @@ use serde::{Deserialize, Serialize};
 use shrex::{decode, Hex};
 use terrors::OneOf;
 
-use crate::constants::{
-    BRIDGE_MUSIG2_PUBKEY, BRIDGE_STRATA_ADDRESS, DEFAULT_ESPLORA, DEFAULT_FAUCET_ENDPOINT,
-    DEFAULT_NETWORK, DEFAULT_STRATA_ENDPOINT,
-};
+use crate::constants::{BRIDGE_MUSIG2_PUBKEY, BRIDGE_STRATA_ADDRESS, DEFAULT_NETWORK};
 
 #[derive(Serialize, Deserialize)]
 pub struct SettingsFromFile {
-    pub esplora: Option<String>,
-    pub strata_endpoint: Option<String>,
-    pub faucet_endpoint: Option<String>,
+    pub esplora: String,
+    pub strata_endpoint: String,
+    pub faucet_endpoint: String,
+    pub mempool_endpoint: String,
     pub bridge_pubkey: Option<Hex<[u8; 32]>>,
     pub network: Option<Network>,
 }
@@ -37,6 +35,7 @@ pub struct Settings {
     pub faucet_endpoint: String,
     pub bridge_musig2_pubkey: XOnlyPublicKey,
     pub descriptor_db: PathBuf,
+    pub mempool_endpoint: String,
     pub bridge_strata_address: StrataAddress,
     pub linux_seed_file: PathBuf,
     pub network: Network,
@@ -59,7 +58,7 @@ impl Settings {
 
         // create config file if not exists
         let _ = File::create_new(&config_file);
-        let from_file = Config::builder()
+        let from_file: SettingsFromFile = Config::builder()
             .add_source(config::File::from(config_file.clone()))
             .build()
             .map_err(OneOf::new)?
@@ -67,14 +66,11 @@ impl Settings {
             .map_err(OneOf::new)?;
 
         Ok(Settings {
-            esplora: from_file.esplora.unwrap_or(DEFAULT_ESPLORA.to_owned()),
-            strata_endpoint: from_file
-                .strata_endpoint
-                .unwrap_or(DEFAULT_STRATA_ENDPOINT.to_owned()),
+            esplora: from_file.esplora,
+            strata_endpoint: from_file.strata_endpoint,
             data_dir: proj_dirs.data_dir().to_owned(),
-            faucet_endpoint: from_file
-                .faucet_endpoint
-                .unwrap_or(DEFAULT_FAUCET_ENDPOINT.to_owned()),
+            faucet_endpoint: from_file.faucet_endpoint,
+            mempool_endpoint: from_file.mempool_endpoint,
             bridge_musig2_pubkey: XOnlyPublicKey::from_slice(&match from_file.bridge_pubkey {
                 Some(key) => key.0,
                 None => {

--- a/bin/strata-cli/src/settings.rs
+++ b/bin/strata-cli/src/settings.rs
@@ -6,16 +6,16 @@ use std::{
 };
 
 use alloy::primitives::Address as StrataAddress;
-use bdk_wallet::bitcoin::XOnlyPublicKey;
+use bdk_wallet::bitcoin::{Network, XOnlyPublicKey};
 use config::Config;
 use directories::ProjectDirs;
 use serde::{Deserialize, Serialize};
-use shrex::decode;
+use shrex::{decode, Hex};
 use terrors::OneOf;
 
 use crate::constants::{
     BRIDGE_MUSIG2_PUBKEY, BRIDGE_STRATA_ADDRESS, DEFAULT_ESPLORA, DEFAULT_FAUCET_ENDPOINT,
-    DEFAULT_L2_HTTP_ENDPOINT,
+    DEFAULT_L2_HTTP_ENDPOINT, DEFAULT_NETWORK,
 };
 
 #[derive(Serialize, Deserialize)]
@@ -23,6 +23,8 @@ pub struct SettingsFromFile {
     pub esplora: Option<String>,
     pub l2_http_endpoint: Option<String>,
     pub faucet_endpoint: Option<String>,
+    pub bridge_pubkey: Option<Hex<[u8; 32]>>,
+    pub network: Option<Network>,
 }
 
 /// Settings struct filled with either config values or
@@ -37,17 +39,24 @@ pub struct Settings {
     pub descriptor_db: PathBuf,
     pub bridge_strata_address: StrataAddress,
     pub linux_seed_file: PathBuf,
+    pub network: Network,
 }
 
 impl Settings {
     pub fn load() -> Result<Self, OneOf<(io::Error, config::ConfigError)>> {
         let proj_dirs = ProjectDirs::from("io", "alpenlabs", "strata")
             .expect("project dir should be available");
-        let config_file = proj_dirs.config_dir().to_owned().join("config.toml");
+        let config_file = match std::env::var("CLI_CONFIG").ok() {
+            Some(path) => PathBuf::from_str(&path).expect("valid config path"),
+            None => proj_dirs.config_dir().to_owned().join("config.toml"),
+        };
         let descriptor_file = proj_dirs.data_dir().to_owned().join("descriptors");
         let linux_seed_file = proj_dirs.data_dir().to_owned().join("seed");
+
         create_dir_all(proj_dirs.config_dir()).map_err(OneOf::new)?;
         create_dir_all(proj_dirs.data_dir()).map_err(OneOf::new)?;
+
+        // create config file if not exists
         let _ = File::create_new(&config_file);
         let from_file = Config::builder()
             .add_source(config::File::from(config_file))
@@ -55,6 +64,7 @@ impl Settings {
             .map_err(OneOf::new)?
             .try_deserialize::<SettingsFromFile>()
             .map_err(OneOf::new)?;
+
         Ok(Settings {
             esplora: from_file.esplora.unwrap_or(DEFAULT_ESPLORA.to_owned()),
             l2_http_endpoint: from_file
@@ -64,12 +74,16 @@ impl Settings {
             faucet_endpoint: from_file
                 .faucet_endpoint
                 .unwrap_or(DEFAULT_FAUCET_ENDPOINT.to_owned()),
-            bridge_musig2_pubkey: XOnlyPublicKey::from_slice(&{
-                let mut buf = [0u8; 32];
-                decode(BRIDGE_MUSIG2_PUBKEY, &mut buf).expect("valid hex");
-                buf
+            bridge_musig2_pubkey: XOnlyPublicKey::from_slice(&match from_file.bridge_pubkey {
+                Some(key) => key.0,
+                None => {
+                    let mut buf = [0u8; 32];
+                    decode(BRIDGE_MUSIG2_PUBKEY, &mut buf).expect("valid hex");
+                    buf
+                }
             })
             .expect("valid length"),
+            network: from_file.network.unwrap_or(DEFAULT_NETWORK),
             descriptor_db: descriptor_file,
             bridge_strata_address: StrataAddress::from_str(BRIDGE_STRATA_ADDRESS)
                 .expect("valid strata address"),

--- a/bin/strata-cli/src/settings.rs
+++ b/bin/strata-cli/src/settings.rs
@@ -15,13 +15,13 @@ use terrors::OneOf;
 
 use crate::constants::{
     BRIDGE_MUSIG2_PUBKEY, BRIDGE_STRATA_ADDRESS, DEFAULT_ESPLORA, DEFAULT_FAUCET_ENDPOINT,
-    DEFAULT_L2_HTTP_ENDPOINT, DEFAULT_NETWORK,
+    DEFAULT_NETWORK, DEFAULT_STRATA_ENDPOINT,
 };
 
 #[derive(Serialize, Deserialize)]
 pub struct SettingsFromFile {
     pub esplora: Option<String>,
-    pub l2_http_endpoint: Option<String>,
+    pub strata_endpoint: Option<String>,
     pub faucet_endpoint: Option<String>,
     pub bridge_pubkey: Option<Hex<[u8; 32]>>,
     pub network: Option<Network>,
@@ -32,7 +32,7 @@ pub struct SettingsFromFile {
 #[derive(Serialize, Deserialize, Debug)]
 pub struct Settings {
     pub esplora: String,
-    pub l2_http_endpoint: String,
+    pub strata_endpoint: String,
     pub data_dir: PathBuf,
     pub faucet_endpoint: String,
     pub bridge_musig2_pubkey: XOnlyPublicKey,
@@ -68,9 +68,9 @@ impl Settings {
 
         Ok(Settings {
             esplora: from_file.esplora.unwrap_or(DEFAULT_ESPLORA.to_owned()),
-            l2_http_endpoint: from_file
-                .l2_http_endpoint
-                .unwrap_or(DEFAULT_L2_HTTP_ENDPOINT.to_owned()),
+            strata_endpoint: from_file
+                .strata_endpoint
+                .unwrap_or(DEFAULT_STRATA_ENDPOINT.to_owned()),
             data_dir: proj_dirs.data_dir().to_owned(),
             faucet_endpoint: from_file
                 .faucet_endpoint

--- a/bin/strata-cli/src/settings.rs
+++ b/bin/strata-cli/src/settings.rs
@@ -40,6 +40,7 @@ pub struct Settings {
     pub bridge_strata_address: StrataAddress,
     pub linux_seed_file: PathBuf,
     pub network: Network,
+    pub config_file: PathBuf,
 }
 
 impl Settings {
@@ -59,7 +60,7 @@ impl Settings {
         // create config file if not exists
         let _ = File::create_new(&config_file);
         let from_file = Config::builder()
-            .add_source(config::File::from(config_file))
+            .add_source(config::File::from(config_file.clone()))
             .build()
             .map_err(OneOf::new)?
             .try_deserialize::<SettingsFromFile>()
@@ -83,6 +84,7 @@ impl Settings {
                 }
             })
             .expect("valid length"),
+            config_file,
             network: from_file.network.unwrap_or(DEFAULT_NETWORK),
             descriptor_db: descriptor_file,
             bridge_strata_address: StrataAddress::from_str(BRIDGE_STRATA_ADDRESS)

--- a/bin/strata-cli/src/settings.rs
+++ b/bin/strata-cli/src/settings.rs
@@ -64,7 +64,7 @@ impl Settings {
         create_dir_all(proj_dirs.data_dir()).map_err(OneOf::new)?;
 
         // create config file if not exists
-        let _ = File::create_new(&config_file);
+        let _ = File::create_new(config_file);
         let from_file: SettingsFromFile = Config::builder()
             .add_source(config::File::from(config_file))
             .build()

--- a/bin/strata-cli/src/signet.rs
+++ b/bin/strata-cli/src/signet.rs
@@ -20,7 +20,7 @@ use bdk_wallet::{
 use console::{style, Term};
 use indicatif::{MultiProgress, ProgressBar, ProgressStyle};
 
-use crate::{constants::DEFAULT_MEMPOOL_ENDPOINT, seed::Seed};
+use crate::{seed::Seed, settings::Settings};
 
 /// Retrieves an estimated fee rate to settle a transaction in `target` blocks
 pub async fn get_fee_rate(
@@ -41,10 +41,10 @@ pub fn log_fee_rate(term: &Term, fr: &FeeRate) {
     ));
 }
 
-pub fn print_explorer_url(txid: &Txid, term: &Term) -> Result<(), io::Error> {
+pub fn print_explorer_url(txid: &Txid, term: &Term, settings: &Settings) -> Result<(), io::Error> {
     term.write_line(&format!(
         "View transaction at {}",
-        style(format!("{DEFAULT_MEMPOOL_ENDPOINT}/tx/{txid}")).blue()
+        style(format!("{}/tx/{txid}", settings.mempool_endpoint)).blue()
     ))
 }
 

--- a/bin/strata-cli/src/signet.rs
+++ b/bin/strata-cli/src/signet.rs
@@ -5,7 +5,6 @@ use std::{
     ops::{Deref, DerefMut},
     path::{Path, PathBuf},
     rc::Rc,
-    str::FromStr,
     sync::OnceLock,
 };
 
@@ -49,8 +48,8 @@ pub fn print_explorer_url(txid: &Txid, term: &Term) -> Result<(), io::Error> {
     ))
 }
 
-pub async fn fee_rate_or_crash(user_provided: Option<String>, esplora: &EsploraClient) -> FeeRate {
-    match user_provided.and_then(|fr| FeeRate::from_sat_per_vb(u64::from_str(&fr).ok()?)) {
+pub async fn fee_rate_or_crash(user_provided: Option<u64>, esplora: &EsploraClient) -> FeeRate {
+    match user_provided.and_then(|fr| FeeRate::from_sat_per_vb(fr)) {
         Some(fr) => fr,
         None => get_fee_rate(1, esplora)
             .await

--- a/bin/strata-cli/src/signet.rs
+++ b/bin/strata-cli/src/signet.rs
@@ -49,7 +49,7 @@ pub fn print_explorer_url(txid: &Txid, term: &Term) -> Result<(), io::Error> {
 }
 
 pub async fn fee_rate_or_crash(user_provided: Option<u64>, esplora: &EsploraClient) -> FeeRate {
-    match user_provided.and_then(|fr| FeeRate::from_sat_per_vb(fr)) {
+    match user_provided.and_then(FeeRate::from_sat_per_vb) {
         Some(fr) => fr,
         None => get_fee_rate(1, esplora)
             .await

--- a/bin/strata-client/src/extractor.rs
+++ b/bin/strata-client/src/extractor.rs
@@ -21,7 +21,7 @@ use strata_rpc_types::RpcServerError;
 use strata_state::{bridge_state::DepositState, chain_state::ChainState, tx::ProtocolOperation};
 use tracing::{debug, error};
 
-/// The `vout` corresponding to the bridge-in related Taproot address on the Deposit Request
+/// The `vout` corresponding to the deposit related Taproot address on the Deposit Request
 /// Transaction.
 ///
 /// This is always going to be the first [`OutPoint`].


### PR DESCRIPTION
## Description

<!--
Provide a brief summary of the changes and the motivation behind them.
-->

- Allows you to manually specify a signet fee rate with the --fee-rate option
- new “scan” command that should be used after importing a mnemonic
- featuregate L2 faucet in the CLI for the moment
- rename refresh cmd to recover
- allow configuration of bridge pubkey and network via config file
- config file location overrideable from env
- change seed length to 16 bytes from 32 (**warning** you need to reset your CLI after this PR is merged)
- update musig2 bridge pubkey


### Type of Change

<!--
Select the type of change your PR introduces (put an `x` in all that apply):-
-->

-   [x] Bug fix (non-breaking change which fixes an issue)
-   [x] New feature/Enhancement (non-breaking change which adds functionality or enhances an existing one)
-   [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] Documentation update
-   [x] Refactor

## Checklist

<!--
Ensure all the following are checked:
-->

-   [x] I have performed a self-review of my code.
-   [x] I have commented my code where necessary.
-   [x] I have updated the documentation if needed.
-   [x] My changes do not introduce new warnings.
-   [ ] I have added tests that prove my changes are effective or that my feature works.
-   [x] New and existing tests pass with my changes.

## Related Issues

<!--
Link any related issues (e.g., `closes #123`, `fixes #456`).
-->
Closes STR-491
Closes STR-495