### PR TITLE
fix: update L1Status with Network from params

### DIFF
--- a/bin/strata-client/src/helpers.rs
+++ b/bin/strata-client/src/helpers.rs
@@ -196,7 +196,10 @@ pub fn load_seqkey(path: &PathBuf) -> anyhow::Result<IdentityData> {
 }
 
 // initializes the status bundle that we can pass around cheaply for status/metrics
-pub fn init_status_channel<D>(database: &D) -> anyhow::Result<(Arc<StatusTx>, Arc<StatusRx>)>
+pub fn init_status_channel<D>(
+    database: &D,
+    network: Network,
+) -> anyhow::Result<(Arc<StatusTx>, Arc<StatusRx>)>
 where
     D: Database + Send + Sync + 'static,
 {
@@ -209,11 +212,12 @@ where
     status.set_last_sync_ev_idx(cur_state_idx);
     status.update_from_client_state(&cur_state);
 
-    Ok(create_status_channel(
-        status,
-        cur_state,
-        L1Status::default(),
-    ))
+    let l1_status = L1Status {
+        network,
+        ..Default::default()
+    };
+
+    Ok(create_status_channel(status, cur_state, l1_status))
 }
 
 pub fn init_engine_controller(

--- a/bin/strata-client/src/main.rs
+++ b/bin/strata-client/src/main.rs
@@ -297,7 +297,7 @@ fn start_core_tasks(
     bitcoin_client: Arc<BitcoinClient>,
 ) -> anyhow::Result<CoreContext> {
     // init status tasks
-    let (status_tx, status_rx) = init_status_channel(database.as_ref())?;
+    let (status_tx, status_rx) = init_status_channel(database.as_ref(), params.network())?;
 
     let engine = init_engine_controller(
         config,


### PR DESCRIPTION
## Description

<!--
Provide a brief summary of the changes and the motivation behind them.
-->

This PR updates the L1Status channel to receive the network information from the rollup params. Without this update, the bridge deposit duty that is constructed will have the default network of `Regtest`.

### Type of Change

<!--
Select the type of change your PR introduces (put an `x` in all that apply):-
-->

-   [x] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature/Enhancement (non-breaking change which adds functionality or enhances an existing one)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] Documentation update
-   [ ] Refactor

## Checklist

<!--
Ensure all the following are checked:
-->

-   [x] I have performed a self-review of my code.
-   [x] I have commented my code where necessary.
-   [x] I have updated the documentation if needed.
-   [x] My changes do not introduce new warnings.
-   [x] I have added tests that prove my changes are effective or that my feature works.
-   [x] New and existing tests pass with my changes.