### PR TITLE
STR-502: require secure RNG for seed encryption

### DIFF
--- a/bin/strata-cli/src/seed.rs
+++ b/bin/strata-cli/src/seed.rs
@@ -12,7 +12,7 @@ use bip39::{Language, Mnemonic};
 use console::Term;
 use dialoguer::{Confirm, Input};
 use password::{IncorrectPassword, Password};
-use rand::{thread_rng, Rng, RngCore};
+use rand::{thread_rng, CryptoRng, RngCore};
 use sha2::{Digest, Sha256};
 use terrors::OneOf;
 
@@ -30,8 +30,10 @@ impl BaseWallet {
 pub struct Seed([u8; SEED_LEN]);
 
 impl Seed {
-    fn gen(rng: &mut impl Rng) -> Self {
-        Self(rng.gen())
+    fn gen<R: CryptoRng + RngCore>(rng: &mut R) -> Self {
+        let mut bytes = [0u8; SEED_LEN];
+        rng.fill_bytes(&mut bytes);
+        Self(bytes)
     }
 
     pub fn print_mnemonic(&self, language: Language) {
@@ -47,10 +49,10 @@ impl Seed {
         hasher.finalize().into()
     }
 
-    pub fn encrypt(
+    pub fn encrypt<R: CryptoRng + RngCore>(
         &self,
         password: &mut Password,
-        rng: &mut impl RngCore,
+        rng: &mut R,
     ) -> Result<EncryptedSeed, OneOf<(argon2::Error, aes_gcm_siv::Error)>> {
         let mut buf = [0u8; EncryptedSeed::LEN];
         rng.fill_bytes(&mut buf[..PW_SALT_LEN + AES_NONCE_LEN]);


### PR DESCRIPTION
## Description

Seed encryption requires the caller provide an RNG, which currently requires only the `RngCore` trait. This allows the caller to provide an insecure generator.

This PR requires the caller to provide a cryptographically-secure generator via the `CryptoRng` trait.

### Type of Change

-   [x] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature/Enhancement (non-breaking change which adds functionality or enhances an existing one)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] Documentation update
-   [ ] Refactor

## Checklist

-   [x] I have performed a self-review of my code.
-   [x] I have commented my code where necessary.
-   [x] I have updated the documentation if needed.
-   [x] My changes do not introduce new warnings.
-   [ ] I have added tests that prove my changes are effective or that my feature works.
-   [x] New and existing tests pass with my changes.

## Related Issues

Unit testing of seed encryption functionality is blocked by STR-506.