### PR TITLE
feat(strata-cli)!: add hash version and optional password

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3477,6 +3477,37 @@ dependencies = [
 ]
 
 [[package]]
+name = "derive_builder"
+version = "0.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "507dfb09ea8b7fa618fcf76e953f4f5e192547945816d5358edffe39f6f94947"
+dependencies = [
+ "derive_builder_macro",
+]
+
+[[package]]
+name = "derive_builder_core"
+version = "0.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d5bcf7b024d6835cfb3d473887cd966994907effbe9227e8c8219824d06c4e8"
+dependencies = [
+ "darling",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.71",
+]
+
+[[package]]
+name = "derive_builder_macro"
+version = "0.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab63b0e2bf4d5928aff72e83a7dace85d7bba5fe12dcc3c5a572d78caffd3f3c"
+dependencies = [
+ "derive_builder_core",
+ "syn 2.0.71",
+]
+
+[[package]]
 name = "derive_more"
 version = "0.99.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4228,6 +4259,17 @@ name = "fallible-streaming-iterator"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7360491ce676a36bf9bb3c56c1aa791658183a54d2744120f27285738d90465a"
+
+[[package]]
+name = "fancy-regex"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "531e46835a22af56d1e3b66f04844bed63158bc094a628bec1d321d9b4c44bf2"
+dependencies = [
+ "bit-set",
+ "regex-automata 0.4.7",
+ "regex-syntax 0.8.4",
+]
 
 [[package]]
 name = "fast-float"
@@ -6915,7 +6957,7 @@ version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "681030a937600a36906c185595136d26abfebb4aa9c65701cefcaf8578bb982b"
 dependencies = [
- "proc-macro-crate 1.3.1",
+ "proc-macro-crate 3.1.0",
  "proc-macro2",
  "quote",
  "syn 2.0.71",
@@ -12644,6 +12686,7 @@ dependencies = [
  "strata-bridge-tx-builder",
  "terrors",
  "tokio",
+ "zxcvbn",
 ]
 
 [[package]]
@@ -15361,4 +15404,21 @@ checksum = "0a4e40c320c3cb459d9a9ff6de98cff88f4751ee9275d140e2be94a2b74e4c13"
 dependencies = [
  "cc",
  "pkg-config",
+]
+
+[[package]]
+name = "zxcvbn"
+version = "3.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ad76e35b00ad53688d6b90c431cabe3cbf51f7a4a154739e04b63004ab1c736c"
+dependencies = [
+ "chrono",
+ "derive_builder",
+ "fancy-regex",
+ "itertools 0.13.0",
+ "lazy_static",
+ "regex",
+ "time",
+ "wasm-bindgen",
+ "web-sys",
 ]

--- a/bin/strata-cli/Cargo.toml
+++ b/bin/strata-cli/Cargo.toml
@@ -42,6 +42,7 @@ sled = "0.34.7"
 strata-bridge-tx-builder.workspace = true
 terrors.workspace = true
 tokio.workspace = true
+zxcvbn = "3.1.0"
 
 # sha2 fails to compile on windows with the "asm" feature
 [target.'cfg(not(target_os = "windows"))'.dependencies]

--- a/bin/strata-cli/src/cmd/change_pwd.rs
+++ b/bin/strata-cli/src/cmd/change_pwd.rs
@@ -1,6 +1,7 @@
 use argh::FromArgs;
 use console::Term;
 use rand::thread_rng;
+use zxcvbn::Score;
 
 use crate::seed::{password::Password, EncryptedSeedPersister, Seed};
 
@@ -12,6 +13,17 @@ pub struct ChangePwdArgs {}
 pub async fn change_pwd(_args: ChangePwdArgs, seed: Seed, persister: impl EncryptedSeedPersister) {
     let term = Term::stdout();
     let mut new_pw = Password::read(true).unwrap();
+    let entropy = new_pw.entropy();
+    let _ = term.write_line(format!("Password strength (Overall strength score from 0-4, where anything below 3 is too weak): {}", entropy.score()).as_str());
+    if entropy.score() <= Score::Two {
+        let _ = term.write_line(
+            entropy
+                .feedback()
+                .expect("No feedback")
+                .to_string()
+                .as_str(),
+        );
+    }
     let encrypted_seed = seed.encrypt(&mut new_pw, &mut thread_rng()).unwrap();
     persister.save(&encrypted_seed).unwrap();
     let _ = term.write_line("Password changed successfully");

--- a/bin/strata-cli/src/seed.rs
+++ b/bin/strata-cli/src/seed.rs
@@ -15,6 +15,7 @@ use password::{HashVersion, IncorrectPassword, Password};
 use rand::{thread_rng, Rng, RngCore};
 use sha2::{Digest, Sha256};
 use terrors::OneOf;
+use zxcvbn::Score;
 
 use crate::constants::{AES_NONCE_LEN, AES_TAG_LEN, PW_SALT_LEN, SEED_LEN};
 
@@ -194,6 +195,17 @@ pub fn load_or_create(
         };
 
         let mut password = Password::read(true).map_err(OneOf::new)?;
+        let entropy = password.entropy();
+        let _ = term.write_line(format!("Password strength (Overall strength score from 0-4, where anything below 3 is too weak): {}", entropy.score()).as_str());
+        if entropy.score() <= Score::Two {
+            let _ = term.write_line(
+                entropy
+                    .feedback()
+                    .expect("No feedback")
+                    .to_string()
+                    .as_str(),
+            );
+        }
         let encrypted_seed = match seed.encrypt(&mut password, &mut thread_rng()) {
             Ok(es) => es,
             Err(e) => {

--- a/bin/strata-cli/src/seed.rs
+++ b/bin/strata-cli/src/seed.rs
@@ -11,7 +11,7 @@ use bdk_wallet::{
 use bip39::{Language, Mnemonic};
 use console::Term;
 use dialoguer::{Confirm, Input};
-use password::{IncorrectPassword, Password};
+use password::{HashVersion, IncorrectPassword, Password};
 use rand::{thread_rng, Rng, RngCore};
 use sha2::{Digest, Sha256};
 use terrors::OneOf;
@@ -56,7 +56,10 @@ impl Seed {
         rng.fill_bytes(&mut buf[..PW_SALT_LEN + AES_NONCE_LEN]);
 
         let seed_encryption_key = password
-            .seed_encryption_key(&buf[..PW_SALT_LEN].try_into().expect("cannot fail"))
+            .seed_encryption_key(
+                &buf[..PW_SALT_LEN].try_into().expect("cannot fail"),
+                HashVersion::V0,
+            )
             .map_err(OneOf::new)?;
 
         let (salt_and_nonce, rest) = buf.split_at_mut(PW_SALT_LEN + AES_NONCE_LEN);
@@ -111,7 +114,10 @@ impl EncryptedSeed {
         password: &mut Password,
     ) -> Result<Seed, OneOf<(argon2::Error, aes_gcm_siv::Error)>> {
         let seed_encryption_key = password
-            .seed_encryption_key(&self.0[..PW_SALT_LEN].try_into().expect("cannot fail"))
+            .seed_encryption_key(
+                &self.0[..PW_SALT_LEN].try_into().expect("cannot fail"),
+                HashVersion::V0,
+            )
             .map_err(OneOf::new)?;
 
         let mut cipher =

--- a/bin/strata-cli/src/seed/password.rs
+++ b/bin/strata-cli/src/seed/password.rs
@@ -1,5 +1,6 @@
 use argon2::{Algorithm, Argon2, Params, Version};
 use dialoguer::Password as InputPassword;
+use zxcvbn::{zxcvbn, Entropy};
 
 use super::PW_SALT_LEN;
 
@@ -47,6 +48,11 @@ impl Password {
             inner: password,
             seed_encryption_key: None,
         })
+    }
+
+    /// Returns the password entropy.
+    pub fn entropy(&self) -> Entropy {
+        zxcvbn(self.inner.as_str(), &[])
     }
 
     pub fn seed_encryption_key(

--- a/bin/strata-cli/src/seed/password.rs
+++ b/bin/strata-cli/src/seed/password.rs
@@ -1,4 +1,4 @@
-use argon2::Argon2;
+use argon2::{Algorithm, Argon2, Params, Version};
 use dialoguer::Password as InputPassword;
 
 use super::PW_SALT_LEN;
@@ -8,13 +8,35 @@ pub struct Password {
     seed_encryption_key: Option<[u8; 32]>,
 }
 
+pub enum HashVersion {
+    V0,
+}
+
+impl HashVersion {
+    const fn params(&self) -> (Algorithm, Version, Result<Params, argon2::Error>) {
+        match self {
+            HashVersion::V0 => (
+                Algorithm::Argon2id,
+                Version::V0x13,
+                // NOTE: This is the OWASP recommended params for Argon2id
+                //       see https://cheatsheetseries.owasp.org/cheatsheets/Password_Storage_Cheat_Sheet.html#argon2id
+                Params::new(19_456, 2, 1, Some(32)),
+            ),
+        }
+    }
+}
+
 impl Password {
     pub fn read(new: bool) -> Result<Self, dialoguer::Error> {
         let mut input = InputPassword::new();
         if new {
             input = input
-                .with_prompt("Create a new password")
-                .with_confirmation("Confirm password", "Passwords didn't match");
+                .with_prompt("Create a new password (leave empty for no password, dangerous!)")
+                .with_confirmation(
+                    "Confirm password (leave empty for no password, dangerous!)",
+                    "Passwords didn't match",
+                )
+                .allow_empty_password(true);
         } else {
             input = input.with_prompt("Enter your password");
         }
@@ -30,14 +52,22 @@ impl Password {
     pub fn seed_encryption_key(
         &mut self,
         salt: &[u8; PW_SALT_LEN],
+        version: HashVersion,
     ) -> Result<&[u8; 32], argon2::Error> {
         match self.seed_encryption_key {
             Some(ref key) => Ok(key),
             None => {
                 let mut sek = [0u8; 32];
-                Argon2::default().hash_password_into(self.inner.as_bytes(), salt, &mut sek)?;
+                let (algo, ver, params) = version.params();
+                if !self.inner.is_empty() {
+                    Argon2::new(algo, ver, params.expect("valid params")).hash_password_into(
+                        self.inner.as_bytes(),
+                        salt,
+                        &mut sek,
+                    )?;
+                }
                 self.seed_encryption_key = Some(sek);
-                self.seed_encryption_key(salt)
+                self.seed_encryption_key(salt, version)
             }
         }
     }


### PR DESCRIPTION
## Description

- Adds the `HashVersion` enum to the wallet encryption.
- Adds password strenght assessment with `zxcvbn`.

### Type of Change


-   [ ] Bug fix (non-breaking change which fixes an issue)
-   [x] New feature/Enhancement (non-breaking change which adds functionality or enhances an existing one)
-   [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] Documentation update
-   [ ] Refactor

## Checklist

-   [x] I have performed a self-review of my code.
-   [x] I have commented my code where necessary.
-   [x] I have updated the documentation if needed.
-   [x] My changes do not introduce new warnings.
-   [x] I have added tests that prove my changes are effective or that my feature works.
-   [x] New and existing tests pass with my changes.

## Related Issues

STR-493 and STR-500.

## Screenshots

> [!NOTE]
> I've changed this and removed the `in seconds`

Good password:
![image](https://github.com/user-attachments/assets/358898fa-7d14-4827-87fa-aadceb6e7642)

Empty or very low entropy password:
![image](https://github.com/user-attachments/assets/966689ba-561a-4440-9d8a-9877ca147f7e)


