### PR TITLE
 fix: make `SECP256K1` great again with ALLCAPS!

### DIFF
--- a/bin/datatool/src/main.rs
+++ b/bin/datatool/src/main.rs
@@ -7,6 +7,7 @@ use argh::FromArgs;
 use bitcoin::{
     base58,
     bip32::{ChildNumber, DerivationPath, Xpriv, Xpub},
+    secp256k1::SECP256K1,
     Network,
 };
 use rand::{rngs::OsRng, CryptoRng, RngCore};
@@ -275,7 +276,7 @@ fn exec_genseqpubkey(cmd: SubcGenSeqPubkey, _ctx: &mut CmdContext) -> anyhow::Re
     };
 
     let seq_xpriv = derive_seq_xpriv(&xpriv)?;
-    let seq_xpub = Xpub::from_priv(bitcoin::secp256k1::SECP256K1, &seq_xpriv);
+    let seq_xpub = Xpub::from_priv(SECP256K1, &seq_xpriv);
     let raw_buf = seq_xpub.to_x_only_pub().serialize();
     let s = base58::encode_check(&raw_buf);
 
@@ -304,7 +305,7 @@ fn exec_genopxpub(cmd: SubcGenOpXpub, _ctx: &mut CmdContext) -> anyhow::Result<(
     };
 
     let op_xpriv = derive_op_root_xpub(&xpriv)?;
-    let op_xpub = Xpub::from_priv(bitcoin::secp256k1::SECP256K1, &op_xpriv);
+    let op_xpub = Xpub::from_priv(SECP256K1, &op_xpriv);
     let raw_buf = op_xpub.encode();
     let s = base58::encode_check(&raw_buf);
 
@@ -432,7 +433,7 @@ fn derive_strata_scheme_xpriv(master: &Xpriv, last: u32) -> anyhow::Result<Xpriv
         ChildNumber::from_hardened_idx(DERIV_BASE_IDX).unwrap(),
         ChildNumber::from_hardened_idx(last).unwrap(),
     ]);
-    Ok(master.derive_priv(bitcoin::secp256k1::SECP256K1, &derivation_path)?)
+    Ok(master.derive_priv(SECP256K1, &derivation_path)?)
 }
 
 /// Derives the sequencer xpriv.
@@ -454,12 +455,8 @@ fn derive_op_purpose_xpubs(op_xpub: &Xpub) -> (Xpub, Xpub) {
     let wallet_path = DerivationPath::master()
         .extend([ChildNumber::from_normal_idx(DERIV_OP_WALLET_IDX).unwrap()]);
 
-    let signing_xpub = op_xpub
-        .derive_pub(bitcoin::secp256k1::SECP256K1, &signing_path)
-        .unwrap();
-    let wallet_xpub = op_xpub
-        .derive_pub(bitcoin::secp256k1::SECP256K1, &wallet_path)
-        .unwrap();
+    let signing_xpub = op_xpub.derive_pub(SECP256K1, &signing_path).unwrap();
+    let wallet_xpub = op_xpub.derive_pub(SECP256K1, &wallet_path).unwrap();
 
     (signing_xpub, wallet_xpub)
 }

--- a/bin/prover-client/src/proving_ops/btc_ops.rs
+++ b/bin/prover-client/src/proving_ops/btc_ops.rs
@@ -1,8 +1,8 @@
 use std::sync::Arc;
 
 use async_trait::async_trait;
-use bitcoin::{key::Secp256k1, Block};
-use musig2::secp256k1::SecretKey;
+use bitcoin::Block;
+use musig2::secp256k1::{SecretKey, SECP256K1};
 use rand::{rngs::StdRng, SeedableRng};
 use strata_btcio::rpc::{traits::Reader, BitcoinClient};
 use strata_primitives::{
@@ -112,9 +112,8 @@ fn gen_params_with_seed(seed: u64) -> Params {
 }
 
 pub fn make_dummy_operator_pubkeys_with_seed(seed: u64) -> OperatorPubkeys {
-    let secp = Secp256k1::new();
     let mut rng = StdRng::seed_from_u64(seed);
     let sk = SecretKey::new(&mut rng);
-    let (pk, _) = sk.x_only_public_key(&secp);
+    let (pk, _) = sk.x_only_public_key(SECP256K1);
     OperatorPubkeys::new(pk.into(), pk.into())
 }

--- a/bin/prover-client/src/proving_ops/btc_ops.rs
+++ b/bin/prover-client/src/proving_ops/btc_ops.rs
@@ -1,8 +1,10 @@
 use std::sync::Arc;
 
 use async_trait::async_trait;
-use bitcoin::Block;
-use musig2::secp256k1::{SecretKey, SECP256K1};
+use bitcoin::{
+    secp256k1::{SecretKey, SECP256K1},
+    Block,
+};
 use rand::{rngs::StdRng, SeedableRng};
 use strata_btcio::rpc::{traits::Reader, BitcoinClient};
 use strata_primitives::{

--- a/bin/strata-cli/src/constants.rs
+++ b/bin/strata-cli/src/constants.rs
@@ -1,8 +1,8 @@
 use std::{sync::LazyLock, time::Duration};
 
 use bdk_wallet::bitcoin::{
-    key::{Parity, Secp256k1},
-    secp256k1::{PublicKey, SecretKey},
+    key::Parity,
+    secp256k1::{PublicKey, SecretKey, SECP256K1},
     Amount, Network, XOnlyPublicKey,
 };
 use shrex::hex;
@@ -60,7 +60,7 @@ pub static UNSPENDABLE: LazyLock<XOnlyPublicKey> = LazyLock::new(|| {
     .expect("valid r");
 
     // Calculate rG
-    let r_g = r.public_key(&Secp256k1::new());
+    let r_g = r.public_key(SECP256K1);
 
     // Step 3: Combine H_point with rG to create the final public key: P = H + rG
     let combined_point = h_point.combine(&r_g).expect("Failed to combine points");

--- a/bin/strata-client/src/helpers.rs
+++ b/bin/strata-client/src/helpers.rs
@@ -4,6 +4,7 @@ use anyhow::Context;
 use bitcoin::{
     base58,
     bip32::{Xpriv, Xpub},
+    secp256k1::SECP256K1,
     Address, Network,
 };
 use format_serde_error::SerdeError;
@@ -188,7 +189,7 @@ pub fn load_seqkey(path: &Path) -> anyhow::Result<IdentityData> {
     // Actually do the key derivation from the root key and then derive the pubkey from that.
     let seq_xpriv = keyderiv::derive_seq_xpriv(&root_xpriv)?;
     let seq_sk = Buf32::from(seq_xpriv.private_key.secret_bytes());
-    let seq_xpub = Xpub::from_priv(bitcoin::secp256k1::SECP256K1, &seq_xpriv);
+    let seq_xpub = Xpub::from_priv(SECP256K1, &seq_xpriv);
     let seq_pk = seq_xpub.to_x_only_pub().serialize();
 
     let ik = IdentityKey::Sequencer(seq_sk);

--- a/bin/strata-client/src/keyderiv.rs
+++ b/bin/strata-client/src/keyderiv.rs
@@ -2,7 +2,10 @@
 //! Key derivation logic, copied from datatool.  Pending reorganizataion into
 //! its own crate.
 
-use bitcoin::bip32::{ChildNumber, DerivationPath, Xpriv};
+use bitcoin::{
+    bip32::{ChildNumber, DerivationPath, Xpriv},
+    secp256k1::SECP256K1,
+};
 
 // TODO move some of these into a keyderiv crate
 const DERIV_BASE_IDX: u32 = 56;
@@ -16,7 +19,7 @@ fn derive_strata_scheme_xpriv(master: &Xpriv, last: u32) -> anyhow::Result<Xpriv
         ChildNumber::from_hardened_idx(DERIV_BASE_IDX).unwrap(),
         ChildNumber::from_hardened_idx(last).unwrap(),
     ]);
-    Ok(master.derive_priv(bitcoin::secp256k1::SECP256K1, &derivation_path)?)
+    Ok(master.derive_priv(SECP256K1, &derivation_path)?)
 }
 
 /// Derives the sequencer xpriv.

--- a/crates/bridge-sig-manager/src/manager.rs
+++ b/crates/bridge-sig-manager/src/manager.rs
@@ -434,9 +434,9 @@ mod tests {
     use arbitrary::{Arbitrary, Unstructured};
     use bitcoin::{
         hashes::sha256,
-        secp256k1::{PublicKey, SECP256K1},
+        secp256k1::{Message, PublicKey, SECP256K1},
     };
-    use musig2::{secp256k1::Message, PubNonce};
+    use musig2::PubNonce;
     use strata_primitives::bridge::Musig2PartialSig;
     use strata_test_utils::bridge::{
         generate_keypairs, generate_mock_tx_signing_data, generate_mock_tx_state_ops,

--- a/crates/bridge-tx-builder/src/context.rs
+++ b/crates/bridge-tx-builder/src/context.rs
@@ -2,8 +2,7 @@
 //! [`rust-bitcoin`](bitcoin). These utilities are common to both the bridge-in and bridge-out
 //! processes.
 
-use bitcoin::Network;
-use musig2::secp256k1::XOnlyPublicKey;
+use bitcoin::{secp256k1::XOnlyPublicKey, Network};
 use strata_primitives::bridge::{OperatorIdx, PublickeyTable};
 
 use crate::prelude::get_aggregated_pubkey;

--- a/crates/bridge-tx-builder/src/deposit.rs
+++ b/crates/bridge-tx-builder/src/deposit.rs
@@ -224,7 +224,6 @@ mod tests {
     use bitcoin::{
         hashes::{sha256, Hash},
         hex::{Case, DisplayHex},
-        secp256k1::Secp256k1,
         taproot::{self, TaprootBuilder},
         Address, Network,
     };
@@ -308,14 +307,13 @@ mod tests {
             .add_leaf(1, op_return_script)
             .unwrap();
 
-        let secp = Secp256k1::new();
         let spend_info = taproot_builder
-            .finalize(&secp, *UNSPENDABLE_INTERNAL_KEY)
+            .finalize(SECP256K1, *UNSPENDABLE_INTERNAL_KEY)
             .unwrap();
 
         let network = Network::Regtest;
         let address = Address::p2tr(
-            &secp,
+            SECP256K1,
             *UNSPENDABLE_INTERNAL_KEY,
             spend_info.merkle_root(),
             network,

--- a/crates/bridge-tx-builder/src/operations.rs
+++ b/crates/bridge-tx-builder/src/operations.rs
@@ -9,11 +9,11 @@ use bitcoin::{
         OP_TRUE,
     },
     script::{Builder, PushBytesBuf},
-    secp256k1::{PublicKey, XOnlyPublicKey},
+    secp256k1::{PublicKey, XOnlyPublicKey, SECP256K1},
     taproot::{TaprootBuilder, TaprootSpendInfo},
     transaction, Address, Amount, Network, OutPoint, ScriptBuf, Transaction, TxIn, TxOut, Witness,
 };
-use musig2::{self, secp256k1::SECP256K1, KeyAggContext};
+use musig2::KeyAggContext;
 use strata_primitives::bridge::PublickeyTable;
 
 use super::{

--- a/crates/primitives/src/bridge.rs
+++ b/crates/primitives/src/bridge.rs
@@ -332,7 +332,7 @@ mod tests {
     use arbitrary::{Arbitrary, Unstructured};
     use bitcoin::{
         key::constants::SECRET_KEY_SIZE,
-        secp256k1::{PublicKey, Secp256k1, SecretKey},
+        secp256k1::{PublicKey, SecretKey, SECP256K1},
     };
     use borsh::{BorshDeserialize, BorshSerialize};
 
@@ -595,9 +595,8 @@ mod tests {
 
     // Helper function to create a random secp256k1 PublicKey
     fn generate_public_key() -> PublicKey {
-        let secp = Secp256k1::new();
         let secret_key =
             SecretKey::from_slice(&[0x01; SECRET_KEY_SIZE]).expect("32 bytes, within curve order");
-        PublicKey::from_secret_key(&secp, &secret_key)
+        PublicKey::from_secret_key(SECP256K1, &secret_key)
     }
 }

--- a/crates/test-utils/src/bridge.rs
+++ b/crates/test-utils/src/bridge.rs
@@ -8,12 +8,12 @@ use bitcoin::{
     absolute::LockTime,
     opcodes::all::{OP_PUSHNUM_1, OP_RETURN},
     script::Builder,
-    secp256k1::{rand, Keypair, PublicKey, SecretKey},
+    secp256k1::{Keypair, PublicKey, SecretKey, SECP256K1},
     taproot::{LeafVersion, TaprootBuilder, TaprootSpendInfo},
     transaction::Version,
     Address, Amount, Network, Psbt, ScriptBuf, Sequence, Transaction, TxIn, TxOut, Witness,
 };
-use musig2::{secp256k1::SECP256K1, KeyAggContext, SecNonce};
+use musig2::{KeyAggContext, SecNonce};
 use rand::{Rng, RngCore};
 use strata_db::stubs::bridge::StubTxStateDb;
 use strata_primitives::{

--- a/crates/test-utils/src/l2.rs
+++ b/crates/test-utils/src/l2.rs
@@ -1,7 +1,6 @@
 use std::time::{SystemTime, UNIX_EPOCH};
 
-use bitcoin::key::Secp256k1;
-use musig2::secp256k1::SecretKey;
+use bitcoin::secp256k1::{SecretKey, SECP256K1};
 use rand::{rngs::StdRng, SeedableRng};
 use strata_consensus_logic::genesis::{make_genesis_block, make_genesis_chainstate};
 use strata_primitives::{
@@ -129,10 +128,10 @@ pub fn gen_client_state(params: Option<&Params>) -> ClientState {
 }
 
 pub fn make_dummy_operator_pubkeys_with_seed(seed: u64) -> OperatorPubkeys {
-    let secp = Secp256k1::new();
     let mut rng = StdRng::seed_from_u64(seed);
     let sk = SecretKey::new(&mut rng);
-    let (pk, _) = sk.x_only_public_key(&secp);
+    let x_only_public_key = sk.x_only_public_key(SECP256K1);
+    let (pk, _) = x_only_public_key;
     OperatorPubkeys::new(pk.into(), pk.into())
 }
 

--- a/crates/tx-parser/src/filter.rs
+++ b/crates/tx-parser/src/filter.rs
@@ -98,8 +98,8 @@ mod test {
         absolute::{Height, LockTime},
         block::{Header, Version as BVersion},
         hashes::Hash,
-        key::{Parity, Secp256k1, UntweakedKeypair},
-        secp256k1::XOnlyPublicKey,
+        key::{Parity, UntweakedKeypair},
+        secp256k1::{XOnlyPublicKey, SECP256K1},
         taproot::{ControlBlock, LeafVersion, TaprootMerkleBranch},
         transaction::Version,
         Address, Amount, Block, BlockHash, CompactTarget, Network, ScriptBuf, TapNodeHash,
@@ -178,10 +178,9 @@ mod test {
         let script = generate_inscription_script_test(inscription_data, &rollup_name, 1).unwrap();
 
         // Create controlblock
-        let secp256k1 = Secp256k1::new();
         let mut rand_bytes = [0; 32];
         rand::thread_rng().fill_bytes(&mut rand_bytes);
-        let key_pair = UntweakedKeypair::from_seckey_slice(&secp256k1, &rand_bytes).unwrap();
+        let key_pair = UntweakedKeypair::from_seckey_slice(SECP256K1, &rand_bytes).unwrap();
         let public_key = XOnlyPublicKey::from_keypair(&key_pair).0;
         let nodehash: [TapNodeHash; 0] = [];
         let cb = ControlBlock {

--- a/crates/tx-parser/src/utils.rs
+++ b/crates/tx-parser/src/utils.rs
@@ -2,13 +2,11 @@ use anyhow::anyhow;
 use bitcoin::{
     opcodes::all::OP_PUSHNUM_1,
     script::{Instruction, Instructions},
+    secp256k1::{PublicKey, SECP256K1},
     taproot::TaprootBuilder,
     Address, Network, Opcode, XOnlyPublicKey,
 };
-use musig2::{
-    secp256k1::{PublicKey, SECP256K1},
-    KeyAggContext,
-};
+use musig2::KeyAggContext;
 use strata_primitives::{buf::Buf32, l1::BitcoinAddress};
 
 /// Extract next instruction and try to parse it as an opcode


### PR DESCRIPTION
## Description

- Removes all the generics and other alternate instantiation of `Secp256k1` in favor of the static global `SECP256K1`.
- Favors the imports of `secp256k1` from `bitcoin` instead of `musig2` (more like a good practice but both re-export the same thing).

### Type of Change

-   [ ] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature/Enhancement (non-breaking change which adds functionality or enhances an existing one)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] Documentation update
-   [x] Refactor

## Checklist

-   [x] I have performed a self-review of my code.
-   [x] I have commented my code where necessary.
-   [x] I have updated the documentation if needed.
-   [x] My changes do not introduce new warnings.
-   [x] I have added tests that prove my changes are effective or that my feature works.
-   [x] New and existing tests pass with my changes.

## Related Issues

STR-311
