### PR TITLE
STR-503: use `OsRng` consistently

### DIFF
--- a/bin/strata-cli/src/cmd/change_pwd.rs
+++ b/bin/strata-cli/src/cmd/change_pwd.rs
@@ -1,6 +1,6 @@
 use argh::FromArgs;
 use console::Term;
-use rand::thread_rng;
+use rand::rngs::OsRng;
 use zxcvbn::Score;
 
 use crate::seed::{password::Password, EncryptedSeedPersister, Seed};
@@ -24,7 +24,7 @@ pub async fn change_pwd(_args: ChangePwdArgs, seed: Seed, persister: impl Encryp
                 .as_str(),
         );
     }
-    let encrypted_seed = seed.encrypt(&mut new_pw, &mut thread_rng()).unwrap();
+    let encrypted_seed = seed.encrypt(&mut new_pw, &mut OsRng).unwrap();
     persister.save(&encrypted_seed).unwrap();
     let _ = term.write_line("Password changed successfully");
 }

--- a/bin/strata-cli/src/cmd/faucet.rs
+++ b/bin/strata-cli/src/cmd/faucet.rs
@@ -5,7 +5,7 @@ use argh::FromArgs;
 use bdk_wallet::{bitcoin::Address, KeychainKind};
 use console::Term;
 use indicatif::ProgressBar;
-use rand::{distributions::uniform::SampleRange, thread_rng};
+use rand::{distributions::uniform::SampleRange, rngs::OsRng};
 use reqwest::{StatusCode, Url};
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
@@ -77,7 +77,7 @@ pub async fn faucet(args: FaucetArgs, seed: Seed, settings: Settings) {
         solution.to_le_bytes(),
     ) {
         solution += 1;
-        if (0..100).sample_single(&mut thread_rng()) == 0 {
+        if (0..100).sample_single(&mut OsRng) == 0 {
             pb.set_message(format!("Trying {solution}"));
         }
     }

--- a/bin/strata-cli/src/recovery.rs
+++ b/bin/strata-cli/src/recovery.rs
@@ -13,7 +13,7 @@ use bdk_wallet::{
     miniscript::{descriptor::DescriptorKeyParseError, Descriptor},
     template::DescriptorTemplateOut,
 };
-use rand::{thread_rng, Rng};
+use rand::{rngs::OsRng, RngCore};
 use sha2::{Digest, Sha256};
 use terrors::OneOf;
 use tokio::io::AsyncReadExt;
@@ -101,7 +101,8 @@ impl DescriptorRecovery {
             bytes.extend_from_slice(&net);
         }
 
-        let nonce = Nonce::from(thread_rng().gen::<[u8; 12]>());
+        let mut nonce = Nonce::default();
+        OsRng.fill_bytes(&mut nonce);
 
         // encrypted_bytes | tag (16 bytes) | nonce (12 bytes)
         self.cipher

--- a/bin/strata-cli/src/seed.rs
+++ b/bin/strata-cli/src/seed.rs
@@ -12,7 +12,7 @@ use bip39::{Language, Mnemonic};
 use console::Term;
 use dialoguer::{Confirm, Input};
 use password::{HashVersion, IncorrectPassword, Password};
-use rand::{thread_rng, CryptoRng, RngCore};
+use rand::{rngs::OsRng, CryptoRng, RngCore};
 use sha2::{Digest, Sha256};
 use terrors::OneOf;
 use zxcvbn::Score;
@@ -193,7 +193,7 @@ pub fn load_or_create(
             }
         } else {
             let _ = term.write_line("Creating new wallet");
-            Seed::gen(&mut thread_rng())
+            Seed::gen(&mut OsRng)
         };
 
         let mut password = Password::read(true).map_err(OneOf::new)?;
@@ -208,7 +208,7 @@ pub fn load_or_create(
                     .as_str(),
             );
         }
-        let encrypted_seed = match seed.encrypt(&mut password, &mut thread_rng()) {
+        let encrypted_seed = match seed.encrypt(&mut password, &mut OsRng) {
             Ok(es) => es,
             Err(e) => {
                 let narrowed = e.narrow::<aes_gcm_siv::Error, _>();

--- a/bin/strata-client/src/extractor.rs
+++ b/bin/strata-client/src/extractor.rs
@@ -189,6 +189,7 @@ mod tests {
         transaction::Version,
         ScriptBuf, Sequence, TxIn, TxOut, Witness,
     };
+    use rand::rngs::OsRng;
     use strata_bridge_tx_builder::prelude::{create_taproot_addr, SpendPath};
     use strata_common::logging;
     use strata_db::traits::L1DataStore;
@@ -341,14 +342,14 @@ mod tests {
             "num_blocks and max_tx_per_block must be at least 1"
         );
 
-        let random_block = rand::thread_rng().gen_range(1..num_blocks);
+        let random_block = OsRng.gen_range(1..num_blocks);
 
         let mut num_valid_duties = 0;
         for idx in 0..num_blocks {
-            let num_txs = rand::thread_rng().gen_range(1..max_txs_per_block);
+            let num_txs = OsRng.gen_range(1..max_txs_per_block);
 
             let known_tx_idx = if idx == random_block {
-                Some(rand::thread_rng().gen_range(0..num_txs))
+                Some(OsRng.gen_range(0..num_txs))
             } else {
                 None
             };
@@ -485,7 +486,7 @@ mod tests {
 
         // true => tx invalid
         // false => script_pubkey in tx output invalid
-        let tx_invalid: bool = rand::thread_rng().gen_bool(0.5);
+        let tx_invalid: bool = OsRng.gen_bool(0.5);
 
         if tx_invalid {
             let mut random_tx: Vec<u8> = arb.generate();
@@ -575,9 +576,7 @@ mod tests {
             break;
         }
 
-        let mut rng = rand::thread_rng();
-
-        let random_assignee = rng.gen_range(0..operators.len());
+        let random_assignee = OsRng.gen_range(0..operators.len());
         let random_assignee = operators[random_assignee];
 
         let mut dispatched_deposits = vec![];
@@ -590,7 +589,7 @@ mod tests {
             deposits_table.add_deposits(&tx_ref, &operators, amt);
 
             // dispatch about half of the deposits
-            let should_dispatch = rng.gen_bool(0.5);
+            let should_dispatch = OsRng.gen_bool(0.5);
             if should_dispatch.not() {
                 continue;
             }
@@ -619,7 +618,7 @@ mod tests {
             "some deposits should have been randomly dispatched"
         );
 
-        let needle_index = rand::thread_rng().gen_range(0..dispatched_deposits.len());
+        let needle_index = OsRng.gen_range(0..dispatched_deposits.len());
 
         let needle = dispatched_deposits
             .get(needle_index)

--- a/crates/bridge-sig-manager/src/operations.rs
+++ b/crates/bridge-sig-manager/src/operations.rs
@@ -167,6 +167,7 @@ mod tests {
         Amount, Network, OutPoint, Sequence, Txid, Witness,
     };
     use musig2::{PubNonce, SecNonce};
+    use rand::rngs::OsRng;
     use strata_bridge_tx_builder::prelude::{create_taproot_addr, SpendPath};
     use strata_primitives::bridge::{Musig2PartialSig, OperatorIdx};
     use strata_test_utils::bridge::{
@@ -406,7 +407,7 @@ mod tests {
         // check in reverse (or some permutation)
         for sk in sks.iter() {
             let mut nonce_seed = [0u8; 32];
-            rand::rngs::OsRng.fill_bytes(&mut nonce_seed);
+            OsRng.fill_bytes(&mut nonce_seed);
 
             let sec_nonce = SecNonce::build(nonce_seed)
                 .with_seckey(*sk)

--- a/crates/bridge-tx-builder/src/operations.rs
+++ b/crates/bridge-tx-builder/src/operations.rs
@@ -246,6 +246,7 @@ mod tests {
         key::Keypair,
         secp256k1::{rand, SecretKey},
     };
+    use rand::rngs::OsRng;
 
     use super::*;
 
@@ -281,7 +282,7 @@ mod tests {
             "should work if the number of scripts is not an exact power of 2"
         );
 
-        let secret_key = SecretKey::new(&mut rand::thread_rng());
+        let secret_key = SecretKey::new(&mut OsRng);
         let keypair = Keypair::from_secret_key(SECP256K1, &secret_key);
         let (x_only_public_key, _) = XOnlyPublicKey::from_keypair(&keypair);
 

--- a/crates/btcio/src/writer/builder.rs
+++ b/crates/btcio/src/writer/builder.rs
@@ -24,7 +24,7 @@ use bitcoin::{
     Address, Amount, Network, OutPoint, ScriptBuf, Sequence, Transaction, TxIn, TxOut, Txid,
     Witness,
 };
-use rand::RngCore;
+use rand::{rngs::OsRng, RngCore};
 use strata_state::tx::InscriptionData;
 use strata_tx_parser::inscription::{BATCH_DATA_TAG, ROLLUP_NAME_TAG, VERSION_TAG};
 use thiserror::Error;
@@ -392,7 +392,7 @@ pub fn build_reveal_transaction(
 
 pub fn generate_key_pair() -> Result<UntweakedKeypair, anyhow::Error> {
     let mut rand_bytes = [0; 32];
-    rand::thread_rng().fill_bytes(&mut rand_bytes);
+    OsRng.fill_bytes(&mut rand_bytes);
     Ok(UntweakedKeypair::from_seckey_slice(SECP256K1, &rand_bytes)?)
 }
 
@@ -454,7 +454,7 @@ fn sign_reveal_transaction(
     )?;
 
     let mut randbytes = [0; 32];
-    rand::thread_rng().fill_bytes(&mut randbytes);
+    OsRng.fill_bytes(&mut randbytes);
 
     let signature = SECP256K1.sign_schnorr_with_aux_rand(
         &Message::from_digest_slice(signature_hash.as_byte_array())?,

--- a/crates/consensus-logic/src/reorg.rs
+++ b/crates/consensus-logic/src/reorg.rs
@@ -125,17 +125,15 @@ pub fn compute_reorg(
 
 #[cfg(test)]
 mod tests {
-    use rand::RngCore;
+    use rand::{rngs::OsRng, RngCore};
     use strata_state::id::L2BlockId;
 
     use super::{compute_reorg, Reorg};
     use crate::unfinalized_tracker;
 
     fn rand_blkid() -> L2BlockId {
-        use rand::rngs::OsRng;
-        let mut rng = OsRng;
         let mut buf = [0; 32];
-        rng.fill_bytes(&mut buf);
+        OsRng.fill_bytes(&mut buf);
         L2BlockId::from(strata_primitives::buf::Buf32::from(buf))
     }
 

--- a/crates/crypto/src/lib.rs
+++ b/crates/crypto/src/lib.rs
@@ -35,7 +35,7 @@ pub fn verify_schnorr_sig(sig: &Buf64, msg: &Buf32, pk: &Buf32) -> bool {
 
 #[cfg(test)]
 mod tests {
-    use rand::Rng;
+    use rand::{rngs::OsRng, Rng};
     use secp256k1::{SecretKey, SECP256K1};
     use strata_primitives::buf::Buf32;
 
@@ -43,13 +43,12 @@ mod tests {
 
     #[test]
     fn test_schnorr_signature_pass() {
-        let mut rng = rand::thread_rng();
-        let msg: [u8; 32] = [(); 32].map(|_| rng.gen());
+        let msg: [u8; 32] = [(); 32].map(|_| OsRng.gen());
 
         let mut mod_msg = msg;
         mod_msg.swap(1, 2);
 
-        let sk = SecretKey::new(&mut rng);
+        let sk = SecretKey::new(&mut OsRng);
         let (pk, _) = sk.x_only_public_key(SECP256K1);
 
         let msg = Buf32::from(msg);

--- a/crates/evmexec/src/el_payload.rs
+++ b/crates/evmexec/src/el_payload.rs
@@ -118,14 +118,14 @@ impl From<ElPayload> for ExecutionPayloadV1 {
 #[cfg(test)]
 mod tests {
     use arbitrary::{Arbitrary, Unstructured};
-    use rand::RngCore;
+    use rand::{rngs::OsRng, RngCore};
 
     use super::*;
 
     #[test]
     fn into() {
         let mut rand_data = vec![0u8; 1024];
-        rand::thread_rng().fill_bytes(&mut rand_data);
+        OsRng.fill_bytes(&mut rand_data);
         let mut unstructured = Unstructured::new(&rand_data);
 
         let el_payload = ElPayload::arbitrary(&mut unstructured).unwrap();

--- a/crates/evmexec/src/engine.rs
+++ b/crates/evmexec/src/engine.rs
@@ -403,7 +403,7 @@ fn to_bridge_withdrawal_intent(
 
 #[cfg(test)]
 mod tests {
-    use rand::Rng;
+    use rand::{rngs::OsRng, Rng};
     use reth_primitives::{revm_primitives::FixedBytes, Bloom, Bytes, U256};
     use reth_rpc_types::{engine::ForkchoiceUpdated, ExecutionPayloadV1};
     use strata_eectl::{errors::EngineResult, messages::PayloadEnv};
@@ -419,8 +419,6 @@ mod tests {
     }
 
     fn random_execution_payload_v1() -> ExecutionPayloadV1 {
-        let mut rng = rand::thread_rng();
-
         ExecutionPayloadV1 {
             parent_hash: B256::random(),
             fee_recipient: Address::random(),
@@ -428,10 +426,10 @@ mod tests {
             receipts_root: B256::random(),
             logs_bloom: Bloom::random(),
             prev_randao: B256::random(),
-            block_number: rng.gen(),
+            block_number: OsRng.gen(),
             gas_limit: 200_000u64,
             gas_used: 10_000u64,
-            timestamp: rng.gen(),
+            timestamp: OsRng.gen(),
             extra_data: Bytes::new(),
             base_fee_per_gas: U256::from(50),
             block_hash: B256::random(),

--- a/crates/primitives/src/bridge.rs
+++ b/crates/primitives/src/bridge.rs
@@ -12,6 +12,7 @@ use bitcoin::{
 };
 use borsh::{BorshDeserialize, BorshSerialize};
 use musig2::{errors::KeyAggError, KeyAggContext, NonceSeed, PartialSignature, PubNonce, SecNonce};
+use rand::rngs::OsRng;
 use serde::{Deserialize, Serialize};
 
 use crate::{
@@ -162,7 +163,7 @@ impl BorshDeserialize for Musig2PartialSig {
 
 impl<'a> Arbitrary<'a> for Musig2PartialSig {
     fn arbitrary(_u: &mut Unstructured<'a>) -> arbitrary::Result<Self> {
-        let secret_key = SecretKey::new(&mut rand::thread_rng());
+        let secret_key = SecretKey::new(&mut OsRng);
 
         // Create a PartialSignature from the secret key bytes
         let partial_sig = PartialSignature::from_slice(secret_key.as_ref())

--- a/crates/primitives/src/hash.rs
+++ b/crates/primitives/src/hash.rs
@@ -40,16 +40,15 @@ pub fn sha256d(buf: &[u8]) -> Buf32 {
 #[cfg(test)]
 mod tests {
     use bitcoin::hashes::{sha256d, Hash};
-    use rand::Rng;
+    use rand::{rngs::OsRng, RngCore};
 
     use super::sha256d;
     use crate::buf::Buf32;
 
     #[test]
     fn test_sha256d_equivalence() {
-        let mut rng = rand::thread_rng();
         let mut array = [0u8; 32];
-        rng.fill(&mut array);
+        OsRng.fill_bytes(&mut array);
 
         let expected = Buf32::from(sha256d::Hash::hash(&array).to_byte_array());
         let output = sha256d(&array);

--- a/crates/primitives/src/l1.rs
+++ b/crates/primitives/src/l1.rs
@@ -19,6 +19,7 @@ use bitcoin::{
     Transaction, TxIn, TxOut, Txid, Witness,
 };
 use borsh::{BorshDeserialize, BorshSerialize};
+use rand::rngs::OsRng;
 use reth_primitives::revm_primitives::FixedBytes;
 use serde::{de, Deserialize, Deserializer, Serialize};
 
@@ -839,7 +840,7 @@ impl<'a> Arbitrary<'a> for TaprootSpendPath {
                 };
 
                 // Generate a random secret key and derive the internal key
-                let secret_key = SecretKey::new(&mut rand::thread_rng());
+                let secret_key = SecretKey::new(&mut OsRng);
                 let keypair = Keypair::from_secret_key(SECP256K1, &secret_key);
                 let (internal_key, _) = XOnlyPublicKey::from_keypair(&keypair);
 
@@ -890,7 +891,7 @@ mod tests {
         taproot::{ControlBlock, LeafVersion, TaprootBuilder, TaprootMerkleBranch},
         Address, Amount, Network, ScriptBuf, TapNodeHash, TxOut, XOnlyPublicKey,
     };
-    use rand::Rng;
+    use rand::{rngs::OsRng, Rng};
     use secp256k1::{Parity, SECP256K1};
     use strata_test_utils::ArbitraryGenerator;
 
@@ -915,7 +916,7 @@ mod tests {
 
         let num_possible_networks = possible_networks.len();
 
-        let (secret_key, _) = SECP256K1.generate_keypair(&mut rand::thread_rng());
+        let (secret_key, _) = SECP256K1.generate_keypair(&mut OsRng);
         let keypair = Keypair::from_secret_key(SECP256K1, &secret_key);
         let (internal_key, _) = XOnlyPublicKey::from_keypair(&keypair);
 
@@ -930,7 +931,7 @@ mod tests {
             let invalid_network = match network {
                 Network::Bitcoin => {
                     // get one of the testnets
-                    let index = rand::thread_rng().gen_range(1..num_possible_networks);
+                    let index = OsRng.gen_range(1..num_possible_networks);
 
                     possible_networks[index]
                 }
@@ -1187,7 +1188,7 @@ mod tests {
         let output_key_parity = Parity::Even;
 
         // Generate a random internal key
-        let secret_key = SecretKey::new(&mut rand::thread_rng());
+        let secret_key = SecretKey::new(&mut OsRng);
         let keypair = Keypair::from_secret_key(SECP256K1, &secret_key);
         let (internal_key, _) = XOnlyPublicKey::from_keypair(&keypair);
 

--- a/crates/primitives/src/relay/util.rs
+++ b/crates/primitives/src/relay/util.rs
@@ -129,6 +129,7 @@ pub fn verify_bridge_msg_sig(
 
 #[cfg(test)]
 mod tests {
+    use rand::rngs::OsRng;
     use strata_test_utils::ArbitraryGenerator;
 
     use super::*;
@@ -188,7 +189,7 @@ mod tests {
         let txid: BitcoinTxid = generator.generate();
         let scope = Scope::V0PubNonce(txid);
         let payload: Musig2PubNonce = generator.generate();
-        let keypair = Keypair::new(SECP256K1, &mut rand::thread_rng());
+        let keypair = Keypair::new(SECP256K1, &mut OsRng);
         let msg_signer = MessageSigner::new(0, keypair.secret_key().into());
 
         let signed_message = msg_signer

--- a/crates/primitives/src/relay/util.rs
+++ b/crates/primitives/src/relay/util.rs
@@ -83,11 +83,9 @@ pub fn compute_pubkey_for_privkey(sk: &Buf32) -> Buf32 {
 /// Generates a signature for the message.
 #[cfg(all(feature = "std", feature = "rand"))]
 pub fn sign_msg_hash(sk: &Buf32, msg_hash: &Buf32) -> Buf64 {
-    let mut rng = OsRng;
-
     let keypair = Keypair::from_secret_key(SECP256K1, &SecretKey::from_slice(sk.as_ref()).unwrap());
     let msg = Message::from_digest(*msg_hash.as_ref());
-    let sig = SECP256K1.sign_schnorr_with_rng(&msg, &keypair, &mut rng);
+    let sig = SECP256K1.sign_schnorr_with_rng(&msg, &keypair, &mut OsRng);
 
     Buf64::from(*sig.as_ref())
 }

--- a/crates/proof-impl/btc-blockspace/src/block.rs
+++ b/crates/proof-impl/btc-blockspace/src/block.rs
@@ -129,7 +129,7 @@ pub fn check_pow(block: &Header) -> bool {
 #[cfg(test)]
 mod tests {
     use bitcoin::{hashes::Hash, TxMerkleNode, WitnessMerkleNode};
-    use rand::Rng;
+    use rand::{rngs::OsRng, Rng};
     use strata_state::{l1::generate_l1_tx, tx::ProtocolOperation};
     use strata_test_utils::{bitcoin::get_btc_mainnet_block, ArbitraryGenerator};
 
@@ -161,7 +161,7 @@ mod tests {
         // }
 
         let parsed_tx: ProtocolOperation = ArbitraryGenerator::new().generate();
-        let r = rand::thread_rng().gen_range(1..block.txdata.len()) as u32;
+        let r = OsRng.gen_range(1..block.txdata.len()) as u32;
         let l1_tx = generate_l1_tx(&block, r, parsed_tx);
         assert!(check_witness_commitment(&block, &l1_tx));
 

--- a/crates/proof-impl/btc-blockspace/src/merkle.rs
+++ b/crates/proof-impl/btc-blockspace/src/merkle.rs
@@ -66,21 +66,19 @@ fn merkle_root_r(hashes: &mut [Buf32]) -> Buf32 {
 #[cfg(test)]
 mod tests {
     use bitcoin::{hashes::Hash, TxMerkleNode};
-    use rand::Rng;
+    use rand::{rngs::OsRng, Rng};
     use strata_primitives::buf::Buf32;
 
     use super::calculate_root;
 
     #[test]
     fn test_merkle_root() {
-        let mut rng = rand::thread_rng();
-
-        let n = rng.gen_range(1..1_000);
+        let n = OsRng.gen_range(1..1_000);
         let mut btc_hashes = Vec::with_capacity(n);
         let mut hashes = Vec::with_capacity(n);
 
         for _ in 0..n {
-            let random_bytes: [u8; 32] = rng.gen();
+            let random_bytes: [u8; 32] = OsRng.gen();
             btc_hashes.push(TxMerkleNode::from_byte_array(random_bytes));
             let hash = Buf32::from(random_bytes);
             hashes.push(hash);

--- a/crates/rocksdb-store/src/l1/db.rs
+++ b/crates/rocksdb-store/src/l1/db.rs
@@ -229,6 +229,7 @@ impl L1DataProvider for L1Db {
 #[cfg(test)]
 mod tests {
     use bitcoin::key::rand::{self, Rng};
+    use rand::rngs::OsRng;
     use strata_primitives::l1::L1TxProof;
     use strata_state::tx::ProtocolOperation;
     use strata_test_utils::ArbitraryGenerator;
@@ -536,7 +537,7 @@ mod tests {
             l1_txs.push(l1_tx);
         }
 
-        let offset = rand::thread_rng().gen_range(0..total_num_blocks);
+        let offset = OsRng.gen_range(0..total_num_blocks);
         let expected_num_blocks = total_num_blocks - offset;
         let (actual, latest_idx) = db.get_txs_from(offset as u64).unwrap();
 

--- a/crates/state/src/l1/header_verification.rs
+++ b/crates/state/src/l1/header_verification.rs
@@ -272,7 +272,7 @@ pub fn get_difficulty_adjustment_height(idx: u32, start: u32, params: &BtcParams
 #[cfg(test)]
 mod tests {
     use bitcoin::params::MAINNET;
-    use rand::Rng;
+    use rand::{rngs::OsRng, Rng};
     use strata_test_utils::bitcoin::get_btc_chain;
 
     use super::*;
@@ -283,7 +283,7 @@ mod tests {
         // TODO: figure out why passing btc_params to `check_and_update_full` doesn't work
         let btc_params: BtcParams = MAINNET.clone().into();
         let h1 = get_difficulty_adjustment_height(1, chain.start, &btc_params);
-        let r1 = rand::thread_rng().gen_range(h1..chain.end);
+        let r1 = OsRng.gen_range(h1..chain.end);
         let mut verification_state = chain.get_verification_state(r1, &MAINNET.clone().into());
 
         for header_idx in r1..chain.end {
@@ -295,7 +295,7 @@ mod tests {
     #[test]
     fn test_get_difficulty_adjustment_height() {
         let start = 0;
-        let idx = rand::thread_rng().gen_range(1..1000);
+        let idx = OsRng.gen_range(1..1000);
         let h = get_difficulty_adjustment_height(idx, start, &MAINNET.clone().into());
         assert_eq!(h, MAINNET.difficulty_adjustment_interval() as u32 * idx);
     }

--- a/crates/test-utils/src/bridge.rs
+++ b/crates/test-utils/src/bridge.rs
@@ -14,7 +14,7 @@ use bitcoin::{
     Address, Amount, Network, Psbt, ScriptBuf, Sequence, Transaction, TxIn, TxOut, Witness,
 };
 use musig2::{KeyAggContext, SecNonce};
-use rand::{Rng, RngCore};
+use rand::{rngs::OsRng, Rng, RngCore};
 use strata_db::stubs::bridge::StubTxStateDb;
 use strata_primitives::{
     bridge::{OperatorIdx, PublickeyTable, TxSigningData},
@@ -183,7 +183,7 @@ pub fn generate_sec_nonce(
     let aggregated_pubkey: PublicKey = key_agg_ctx.aggregated_pubkey();
 
     let mut nonce_seed = [0u8; 32];
-    rand::rngs::OsRng.fill_bytes(&mut nonce_seed);
+    OsRng.fill_bytes(&mut nonce_seed);
 
     let sec_nonce = SecNonce::build(nonce_seed)
         .with_seckey(seckey)

--- a/crates/test-utils/src/bridge.rs
+++ b/crates/test-utils/src/bridge.rs
@@ -31,7 +31,7 @@ pub fn generate_keypairs(count: usize) -> (Vec<PublicKey>, Vec<SecretKey>) {
     let mut pubkeys_set: HashSet<PublicKey> = HashSet::new();
 
     while pubkeys_set.len() != count {
-        let sk = SecretKey::new(&mut rand::thread_rng());
+        let sk = SecretKey::new(&mut OsRng);
         let keypair = Keypair::from_secret_key(SECP256K1, &sk);
         let pubkey = PublicKey::from_keypair(&keypair);
 
@@ -198,7 +198,7 @@ pub fn generate_sec_nonce(
 /// This is used to generate random order for indices in a list (for example, list of pubkeys,
 /// nonces, etc.)
 pub fn permute<T: Clone>(list: &mut [T]) {
-    let num_permutations = rand::thread_rng().gen_range(0..list.len());
+    let num_permutations = OsRng.gen_range(0..list.len());
 
     generate_permutation(list, num_permutations);
 }

--- a/crates/test-utils/src/lib.rs
+++ b/crates/test-utils/src/lib.rs
@@ -1,7 +1,7 @@
 use std::sync::atomic::{AtomicUsize, Ordering};
 
 use arbitrary::{Arbitrary, Unstructured};
-use rand::RngCore;
+use rand::{rngs::OsRng, RngCore};
 
 pub mod bitcoin;
 pub mod bridge;
@@ -27,9 +27,8 @@ impl ArbitraryGenerator {
     }
 
     pub fn new_with_size(n: usize) -> Self {
-        let mut rng = rand::thread_rng();
         let mut buf = vec![0; n];
-        rng.fill_bytes(&mut buf); // 128 wasn't enough
+        OsRng.fill_bytes(&mut buf); // 128 wasn't enough
         let off = AtomicUsize::new(0);
         ArbitraryGenerator { buf, off }
     }

--- a/crates/tx-parser/src/filter.rs
+++ b/crates/tx-parser/src/filter.rs
@@ -105,7 +105,7 @@ mod test {
         Address, Amount, Block, BlockHash, CompactTarget, Network, ScriptBuf, TapNodeHash,
         Transaction, TxMerkleNode, TxOut,
     };
-    use rand::RngCore;
+    use rand::{rngs::OsRng, RngCore};
     use strata_btcio::test_utils::{
         build_reveal_transaction_test, generate_inscription_script_test,
     };
@@ -179,7 +179,7 @@ mod test {
 
         // Create controlblock
         let mut rand_bytes = [0; 32];
-        rand::thread_rng().fill_bytes(&mut rand_bytes);
+        OsRng.fill_bytes(&mut rand_bytes);
         let key_pair = UntweakedKeypair::from_seckey_slice(SECP256K1, &rand_bytes).unwrap();
         let public_key = XOnlyPublicKey::from_keypair(&key_pair).0;
         let nodehash: [TapNodeHash; 0] = [];

--- a/crates/util/shrex/src/lib.rs
+++ b/crates/util/shrex/src/lib.rs
@@ -277,7 +277,7 @@ impl From<HexChar> for char {
 
 #[cfg(test)]
 mod tests {
-    use rand::{thread_rng, Rng};
+    use rand::{rngs::OsRng, Rng};
 
     use super::*;
 
@@ -306,7 +306,7 @@ mod tests {
 
     #[test]
     fn e2e() {
-        let buf: [u8; 32] = thread_rng().gen();
+        let buf: [u8; 32] = OsRng.gen();
         let string = encode(&buf);
         let mut debuf = [0u8; 32];
         assert!(decode(&string, &mut debuf).is_ok());

--- a/tests/cooperative-bridge-flow.rs
+++ b/tests/cooperative-bridge-flow.rs
@@ -11,6 +11,7 @@ use bitcoind::{
     BitcoinD,
 };
 use common::bridge::{perform_rollup_actions, perform_user_actions, setup, BridgeDuty, User};
+use rand::rngs::OsRng;
 use strata_bridge_tx_builder::prelude::{
     create_taproot_addr, get_aggregated_pubkey, CooperativeWithdrawalInfo, SpendPath,
 };
@@ -82,7 +83,7 @@ async fn full_flow() {
     let unspent_utxos_prewithdrawal = user.agent().get_unspent_utxos().await;
     event!(Level::DEBUG, event = "got unspent utxos from requester before withdrawal", num_unspent_utxos = %unspent_utxos_prewithdrawal.len());
 
-    let assigned_operator_idx = rand::thread_rng().gen_range(0..num_operators) as OperatorIdx;
+    let assigned_operator_idx = OsRng.gen_range(0..num_operators) as OperatorIdx;
     event!(Level::INFO, event = "assigning withdrawal", operator_idx = %assigned_operator_idx);
 
     let withdrawal_info =

--- a/tests/cooperative-bridge-out-flow.rs
+++ b/tests/cooperative-bridge-out-flow.rs
@@ -11,6 +11,7 @@ use bitcoin::{
 };
 use bitcoind::BitcoinD;
 use common::bridge::{setup, BridgeDuty, User, MIN_MINER_REWARD_CONFS};
+use rand::rngs::OsRng;
 use strata_bridge_tx_builder::prelude::{
     create_taproot_addr, create_tx, create_tx_ins, create_tx_outs, get_aggregated_pubkey,
     CooperativeWithdrawalInfo, SpendPath, BRIDGE_DENOMINATION,
@@ -47,7 +48,7 @@ async fn withdrawal_flow() {
 
     event!(Level::INFO, event = "created user to initiate withdrawal", user_x_only_pk = ?user_x_only_pk);
 
-    let assigned_operator_idx = rand::thread_rng().gen_range(0..num_operators) as OperatorIdx;
+    let assigned_operator_idx = OsRng.gen_range(0..num_operators) as OperatorIdx;
     event!(Level::INFO, event = "assigning withdrawal", operator_idx = %assigned_operator_idx);
 
     let withdrawal_info =


### PR DESCRIPTION
## Description

Switches all uses of `thread_rng()` to `OsRng`. Standardizes existing uses of `OsRng`.

### Type of Change

-   [x] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature/Enhancement (non-breaking change which adds functionality or enhances an existing one)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] Documentation update
-   [ ] Refactor

## Checklist

-   [x] I have performed a self-review of my code.
-   [x] I have commented my code where necessary.
-   [x] I have updated the documentation if needed.
-   [x] My changes do not introduce new warnings.
-   [ ] I have added tests that prove my changes are effective or that my feature works.
-   [x] New and existing tests pass with my changes.

## Related Issues

None.
