### PR TITLE
ci: update to bitcoin 28.0

### DIFF
--- a/.github/workflows/functional.yml
+++ b/.github/workflows/functional.yml
@@ -8,7 +8,6 @@ on:
 
 env:
   CARGO_TERM_COLOR: always
-
 jobs:
   lint:
     name: Lint test files
@@ -55,11 +54,11 @@ jobs:
 
       - name: Install bitcoind
         env:
-          BITCOIND_VERSION: "27.0"
+          BITCOIND_VERSION: "28.0"
           BITCOIND_ARCH: "x86_64-linux-gnu"
-          SHASUM: "2a6974c5486f528793c79d42694b5987401e4a43c97f62b1383abf35bcee44a8"
+          SHASUM: "7fe294b02b25b51acb8e8e0a0eb5af6bbafa7cd0c5b0e5fcbb61263104a82fbc"
         run: |
-          wget -q "https://bitcoin.org/bin/bitcoin-core-${{ env.BITCOIND_VERSION }}/bitcoin-${{ env.BITCOIND_VERSION }}-${{ env.BITCOIND_ARCH }}.tar.gz"
+          curl -fsSLO --proto "=https" --tlsv1.2 "https://bitcoincore.org/bin/bitcoin-core-${{ env.BITCOIND_VERSION }}/bitcoin-${{ env.BITCOIND_VERSION }}-${{ env.BITCOIND_ARCH }}.tar.gz"
           sha256sum -c <<< "$SHASUM bitcoin-${{ env.BITCOIND_VERSION }}-${{ env.BITCOIND_ARCH }}.tar.gz"
           tar xzf "bitcoin-${{ env.BITCOIND_VERSION }}-${{ env.BITCOIND_ARCH }}.tar.gz"
           sudo install -m 0755 -t /usr/local/bin bitcoin-${{ env.BITCOIND_VERSION }}/bin/*

--- a/crates/btcio/src/rpc/client.rs
+++ b/crates/btcio/src/rpc/client.rs
@@ -11,7 +11,7 @@ use bitcoin::{
     bip32::Xpriv, consensus::encode::serialize_hex, Address, Block, BlockHash, Network,
     Transaction, Txid,
 };
-use bitcoind_json_rpc_types::v26::{GetBlockVerbosityZero, GetBlockchainInfo, GetNewAddress};
+use bitcoind_json_rpc_types::v26::{GetBlockVerbosityZero, GetNewAddress};
 use reqwest::{
     header::{HeaderMap, AUTHORIZATION, CONTENT_TYPE},
     Client,
@@ -28,8 +28,8 @@ use crate::rpc::{
     error::{BitcoinRpcError, ClientError},
     traits::{Broadcaster, Reader, Signer, Wallet},
     types::{
-        CreateWallet, GetTransaction, ImportDescriptor, ImportDescriptorResult, ListDescriptors,
-        ListTransactions, ListUnspent, SignRawTransactionWithWallet,
+        CreateWallet, GetBlockchainInfo, GetTransaction, ImportDescriptor, ImportDescriptorResult,
+        ListDescriptors, ListTransactions, ListUnspent, SignRawTransactionWithWallet,
     },
 };
 

--- a/crates/btcio/src/rpc/traits.rs
+++ b/crates/btcio/src/rpc/traits.rs
@@ -1,12 +1,11 @@
 use async_trait::async_trait;
 use bitcoin::{bip32::Xpriv, Address, Block, BlockHash, Network, Transaction, Txid};
-use bitcoind_json_rpc_types::v26::GetBlockchainInfo;
 
 use crate::rpc::{
     client::ClientResult,
     types::{
-        GetTransaction, ImportDescriptor, ImportDescriptorResult, ListTransactions, ListUnspent,
-        SignRawTransactionWithWallet,
+        GetBlockchainInfo, GetTransaction, ImportDescriptor, ImportDescriptorResult,
+        ListTransactions, ListUnspent, SignRawTransactionWithWallet,
     },
 };
 

--- a/crates/btcio/src/rpc/types.rs
+++ b/crates/btcio/src/rpc/types.rs
@@ -35,6 +35,49 @@ pub enum TransactionCategory {
     Orphan,
 }
 
+/// Result of JSON-RPC method `getblockchaininfo`.
+///
+/// Method call: `getblockchaininfo`
+///
+/// > Returns an object containing various state info regarding blockchain processing.
+#[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+pub struct GetBlockchainInfo {
+    /// Current network name as defined in BIP70 (main, test, signet, regtest).
+    pub chain: String,
+    /// The current number of blocks processed in the server.
+    pub blocks: u64,
+    /// The current number of headers we have validated.
+    pub headers: u64,
+    /// The hash of the currently best block.
+    #[serde(rename = "bestblockhash")]
+    pub best_block_hash: String,
+    /// The current difficulty.
+    pub difficulty: f64,
+    /// Median time for the current best block.
+    #[serde(rename = "mediantime")]
+    pub median_time: u64,
+    /// Estimate of verification progress (between 0 and 1).
+    #[serde(rename = "verificationprogress")]
+    pub verification_progress: f64,
+    /// Estimate of whether this node is in Initial Block Download (IBD) mode.
+    #[serde(rename = "initialblockdownload")]
+    pub initial_block_download: bool,
+    /// Total amount of work in active chain, in hexadecimal.
+    #[serde(rename = "chainwork")]
+    pub chain_work: String,
+    /// The estimated size of the block and undo files on disk.
+    pub size_on_disk: u64,
+    /// If the blocks are subject to pruning.
+    pub pruned: bool,
+    /// Lowest-height complete block stored (only present if pruning is enabled).
+    #[serde(rename = "pruneheight")]
+    pub prune_height: Option<u64>,
+    /// Whether automatic pruning is enabled (only present if pruning is enabled).
+    pub automatic_pruning: Option<bool>,
+    /// The target size used by pruning (only present if automatic pruning is enabled).
+    pub prune_target_size: Option<u64>,
+}
+
 /// Models the result of JSON-RPC method `listunspent`.
 ///
 /// # Note

--- a/crates/btcio/src/test_utils.rs
+++ b/crates/btcio/src/test_utils.rs
@@ -1,5 +1,3 @@
-use std::collections::BTreeMap;
-
 use async_trait::async_trait;
 use bitcoin::{
     bip32::Xpriv,
@@ -8,15 +6,14 @@ use bitcoin::{
     taproot::ControlBlock,
     Address, Amount, Block, BlockHash, Network, ScriptBuf, SignedAmount, Transaction, Txid, Work,
 };
-use bitcoind_json_rpc_types::v26::GetBlockchainInfo;
 use strata_state::tx::InscriptionData;
 
 use crate::{
     rpc::{
         traits::{Broadcaster, Reader, Signer, Wallet},
         types::{
-            GetTransaction, ImportDescriptor, ImportDescriptorResult, ListTransactions,
-            ListUnspent, SignRawTransactionWithWallet,
+            GetBlockchainInfo, GetTransaction, ImportDescriptor, ImportDescriptorResult,
+            ListTransactions, ListUnspent, SignRawTransactionWithWallet,
         },
         ClientResult,
     },
@@ -94,8 +91,6 @@ impl Reader for TestBitcoinClient {
             prune_height: None,
             automatic_pruning: None,
             prune_target_size: None,
-            softforks: BTreeMap::new(),
-            warnings: "".to_string(),
         })
     }
 


### PR DESCRIPTION
## Description

- Updates bitcoin to latest 28.0
- ~Removes a unofficial PPA for the official release in the `bitcoind` docker image~ (moved to an issue in Jira)
- Fixes `GetBlockChainInfo` that had a breaking change in 28.0: see https://github.com/bitcoin/bitcoin/blob/master/doc/release-notes/release-notes-28.0.md#updated-rpcs

### Type of Change

-   [x] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature/Enhancement (non-breaking change which adds functionality or enhances an existing one)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] Documentation update
-   [ ] Refactor
-   [x] Test

## Checklist

-   [x] I have performed a self-review of my code.
-   [x] I have commented my code where necessary.
-   [x] I have updated the documentation if needed.
-   [x] My changes do not introduce new warnings.
-   [x] I have added tests that prove my changes are effective or that my feature works.
-   [x] New and existing tests pass with my changes.