### PR TITLE
STR-525 sync preconditions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12758,6 +12758,7 @@ dependencies = [
  "futures",
  "rand 0.8.5",
  "secp256k1",
+ "serde",
  "strata-btcio",
  "strata-chaintsn",
  "strata-crypto",

--- a/crates/consensus-logic/Cargo.toml
+++ b/crates/consensus-logic/Cargo.toml
@@ -25,6 +25,7 @@ bitcoin.workspace = true
 borsh.workspace = true
 futures.workspace = true
 secp256k1 = { workspace = true, features = ["rand-std"] }
+serde.workspace = true
 thiserror.workspace = true
 threadpool.workspace = true
 tokio.workspace = true

--- a/crates/consensus-logic/src/lib.rs
+++ b/crates/consensus-logic/src/lib.rs
@@ -9,6 +9,7 @@ pub mod fork_choice_manager;
 pub mod genesis;
 pub mod l1_handler;
 pub mod message;
+pub mod precondition;
 pub mod reorg;
 pub mod state_tracker;
 pub mod sync_manager;

--- a/crates/consensus-logic/src/precondition.rs
+++ b/crates/consensus-logic/src/precondition.rs
@@ -1,0 +1,44 @@
+//! Describes precondition checks that could prevent a sync event from being
+//! executed.
+
+use serde::{Deserialize, Serialize};
+use strata_state::{l1::L1BlockId, sync_event::SyncEvent};
+
+use crate::errors::Error;
+
+/// Precondtion predicate we can evaluate over the current state.
+#[derive(Clone, Debug, Eq, PartialEq, Deserialize, Serialize)]
+pub enum SyncPrecond {
+    /// Must have L1 blocks up to some height in the database.
+    L1BlockHeight(u64),
+
+    /// Must have a particular L1 blockid in the database.
+    L1BlockPresent(u64, L1BlockId),
+}
+
+/// Contains infra for checking preconditions.
+pub struct PrecondChecker {
+    // TODO
+}
+
+impl PrecondChecker {
+    /// Checks the precondition and returning if it passes or not, or returns an error.
+    pub fn check_precond(&self, precond: &SyncPrecond) -> Result<bool, Error> {
+        Ok(true)
+    }
+}
+
+/// Computes a list of preconditions for some sync event data.
+pub fn compute_sync_event_preconditions(ev: &SyncEvent) -> Vec<SyncPrecond> {
+    let p = match ev {
+        SyncEvent::L1Block(h, id) => SyncPrecond::L1BlockPresent(*h, *id),
+        SyncEvent::L1Revert(h) => SyncPrecond::L1BlockHeight(*h),
+        SyncEvent::L1DABatch(h, _) => SyncPrecond::L1BlockHeight(*h),
+        SyncEvent::L1BlockGenesis(h, _) => SyncPrecond::L1BlockHeight(*h),
+
+        // By default we don't produce any preconditions.
+        _ => return Vec::new(),
+    };
+
+    vec![p]
+}


### PR DESCRIPTION
## Description

This introduces a concept called a "precondition" which we can check based on a sync event.  A sync event can produce one of a couple of basic preconditions that we can run on the database first and abort early before trying to execute the sync event to determine if we should proceed.

This is in the interest of troubleshooting the sync issue we have.

### Type of Change

-   [x] Bug fix (non-breaking change which fixes an issue)
-   [x] New feature/Enhancement (non-breaking change which adds functionality or enhances an existing one)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] Documentation update
-   [ ] Refactor

## Checklist

-   [ ] I have performed a self-review of my code.
-   [ ] I have commented my code where necessary.
-   [ ] I have updated the documentation if needed.
-   [ ] My changes do not introduce new warnings.
-   [ ] I have added tests that prove my changes are effective or that my feature works.
-   [ ] New and existing tests pass with my changes.
