### PR TITLE
Minor trait syntax clarification for the analyzer

### DIFF
--- a/bin/strata-cli/src/recovery.rs
+++ b/bin/strata-cli/src/recovery.rs
@@ -38,7 +38,7 @@ impl DescriptorRecovery {
         let db_key = {
             let mut key = Vec::from(recover_at.to_be_bytes());
             // this will actually write the private key inside the descriptor so we hash it
-            let mut hasher = Sha256::new();
+            let mut hasher = <Sha256 as Digest>::new(); // this is to appease the analyzer
             hasher.update(desc_string.as_bytes());
             key.extend_from_slice(hasher.finalize().as_ref());
             key

--- a/bin/strata-cli/src/seed.rs
+++ b/bin/strata-cli/src/seed.rs
@@ -43,7 +43,7 @@ impl Seed {
     }
 
     pub fn descriptor_recovery_key(&self) -> [u8; 32] {
-        let mut hasher = Sha256::new();
+        let mut hasher = <Sha256 as Digest>::new(); // this is to appease the analyzer
         hasher.update(b"alpen labs strata descriptor recovery file 2024");
         hasher.update(self.0);
         hasher.finalize().into()
@@ -94,7 +94,7 @@ impl Seed {
 
     pub fn strata_wallet(&self) -> EthereumWallet {
         let l2_private_bytes = {
-            let mut hasher = Sha256::new();
+            let mut hasher = <Sha256 as Digest>::new(); // this is to appease the analyzer
             hasher.update(b"alpen labs strata l2 wallet 2024");
             hasher.update(self.0);
             hasher.finalize()


### PR DESCRIPTION
## Description

There are a few instances where the analyzer gets confused about `Sha256::new()` calls. It should use the `Digest` trait, for which the call is valid. However, it seems to get hung up on the `KeyInit` trait used elsewhere for AES operations, for which the call would expect an argument.

This PR adds fully-qualified trait syntax to appease the analyzer and help improve sanity.

### Type of Change

-   [ ] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature/Enhancement (non-breaking change which adds functionality or enhances an existing one)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] Documentation update
-   [ ] Refactor

## Checklist

-   [x] I have performed a self-review of my code.
-   [x] I have commented my code where necessary.
-   [x] I have updated the documentation if needed.
-   [x] My changes do not introduce new warnings.
-   [ ] I have added tests that prove my changes are effective or that my feature works.
-   [x] New and existing tests pass with my changes.

## Related Issues

None.