### PR TITLE
STR-506: test seed encryption

### DIFF
--- a/bin/strata-cli/src/seed.rs
+++ b/bin/strata-cli/src/seed.rs
@@ -257,3 +257,86 @@ mod keychain;
 pub use keychain::*;
 
 pub mod password;
+
+#[cfg(test)]
+mod test {
+    use rand::rngs::OsRng;
+
+    use super::*;
+
+    #[test]
+    // Test valid seed encryption and decryption
+    fn seed_encrypt_decrypt() {
+        let mut password = Password::new(String::from("swordfish"));
+        let seed = Seed::gen(&mut OsRng);
+
+        let encrypted_seed = seed.encrypt(&mut password, &mut OsRng).unwrap();
+        let decrypted_seed = encrypted_seed.decrypt(&mut password).unwrap();
+
+        assert_eq!(seed.0, decrypted_seed.0);
+    }
+
+    #[test]
+    // Using an evil password fails decryption
+    fn evil_password() {
+        let mut password = Password::new(String::from("swordfish"));
+        let mut evil_password = Password::new(String::from("evil"));
+        let seed = Seed::gen(&mut OsRng);
+
+        let encrypted_seed = seed.encrypt(&mut password, &mut OsRng).unwrap();
+
+        assert!(encrypted_seed.decrypt(&mut evil_password).is_err());
+    }
+
+    #[test]
+    // Using an evil salt fails decryption
+    fn evil_salt() {
+        let mut password = Password::new(String::from("swordfish"));
+        let seed = Seed::gen(&mut OsRng);
+
+        let mut encrypted_seed = seed.encrypt(&mut password, &mut OsRng).unwrap();
+        let index = 0;
+        encrypted_seed.0[index] = !encrypted_seed.0[index];
+
+        assert!(encrypted_seed.decrypt(&mut password).is_err());
+    }
+
+    #[test]
+    // Using an evil nonce fails decryption
+    fn evil_nonce() {
+        let mut password = Password::new(String::from("swordfish"));
+        let seed = Seed::gen(&mut OsRng);
+
+        let mut encrypted_seed = seed.encrypt(&mut password, &mut OsRng).unwrap();
+        let index = PW_SALT_LEN;
+        encrypted_seed.0[index] = !encrypted_seed.0[index];
+
+        assert!(encrypted_seed.decrypt(&mut password).is_err());
+    }
+
+    #[test]
+    // Using an evil seed fails decryption
+    fn evil_seed() {
+        let mut password = Password::new(String::from("swordfish"));
+        let seed = Seed::gen(&mut OsRng);
+
+        let mut encrypted_seed = seed.encrypt(&mut password, &mut OsRng).unwrap();
+        let index = PW_SALT_LEN + AES_NONCE_LEN;
+        encrypted_seed.0[index] = !encrypted_seed.0[index];
+
+        assert!(encrypted_seed.decrypt(&mut password).is_err());
+    }
+
+    #[test]
+    // Using an evil tag fails decryption
+    fn evil_tag() {
+        let mut password = Password::new(String::from("swordfish"));
+        let seed = Seed::gen(&mut OsRng);
+
+        let mut encrypted_seed = seed.encrypt(&mut password, &mut OsRng).unwrap();
+        let index = PW_SALT_LEN + AES_NONCE_LEN + SEED_LEN;
+        encrypted_seed.0[index] = !encrypted_seed.0[index];
+
+        assert!(encrypted_seed.decrypt(&mut password).is_err());
+    }
+}

--- a/bin/strata-cli/src/seed/password.rs
+++ b/bin/strata-cli/src/seed/password.rs
@@ -29,6 +29,13 @@ impl HashVersion {
 }
 
 impl Password {
+    /// Constructs a password from a string. (The complexity of the password is not checked.)
+    pub fn new(password: String) -> Self {
+        Self { inner: password }
+    }
+
+    /// Constructs a password from user interaction. (The complexity of the password is not
+    /// checked.)
     pub fn read(new: bool) -> Result<Self, dialoguer::Error> {
         let mut input = InputPassword::new().allow_empty_password(true);
         if new {
@@ -44,7 +51,7 @@ impl Password {
 
         let password = input.interact()?;
 
-        Ok(Self { inner: password })
+        Ok(Self::new(password))
     }
 
     /// Returns the password entropy.
@@ -52,6 +59,7 @@ impl Password {
         zxcvbn(self.inner.as_str(), &[])
     }
 
+    /// Derives a seed encryption key from a password.
     pub fn seed_encryption_key(
         &mut self,
         salt: &[u8; PW_SALT_LEN],


### PR DESCRIPTION
## Description

This PR tests successful seed encryption and decryption, as well as failed decryption caused by  a bad passphrase or malleation.

To do this, it adds the ability to create a `Password` from a string; this is necessary since current functionality requires interactive user input, which is not suitable for automated testing.

### Type of Change

-   [ ] Bug fix (non-breaking change which fixes an issue)
-   [x] New feature/Enhancement (non-breaking change which adds functionality or enhances an existing one)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] Documentation update
-   [ ] Refactor

## Checklist

-   [x] I have performed a self-review of my code.
-   [x] I have commented my code where necessary.
-   [x] I have updated the documentation if needed.
-   [x] My changes do not introduce new warnings.
-   [x] I have added tests that prove my changes are effective or that my feature works.
-   [x] New and existing tests pass with my changes.

## Related Issues

None.