### PR TITLE
STR-504: add sanity test for key generation

### DIFF
--- a/bin/strata-cli/src/seed.rs
+++ b/bin/strata-cli/src/seed.rs
@@ -261,8 +261,24 @@ pub mod password;
 #[cfg(test)]
 mod test {
     use rand::rngs::OsRng;
+    use sha2::digest::generic_array::GenericArray;
 
     use super::*;
+
+    #[test]
+    // Sanity check on private key construction
+    fn invalid_keys() {
+        // The key can't be zero
+        assert!(PrivateKeySigner::from_field_bytes(GenericArray::from_slice(&[0u8; 32])).is_err());
+
+        // The key can be within the group order
+        assert!(PrivateKeySigner::from_field_bytes(GenericArray::from_slice(&[1u8; 32])).is_ok());
+
+        // The key can't exceed the group order
+        assert!(
+            PrivateKeySigner::from_field_bytes(GenericArray::from_slice(&[u8::MAX; 32])).is_err()
+        );
+    }
 
     #[test]
     // Test valid seed encryption and decryption


### PR DESCRIPTION
## Description

It wasn't clear how the library handles generation of ECDSA signing keys when provided with bytes representing a value that overflows the curve order, since simply performing modular reduction induces bias. It turns out that this case is properly rejected, even though the documentation wasn't particularly clear that this would occur.

This PR adds a sanity test demonstrating rejection cases (and a success case, just for the heck of it).

### Type of Change

-   [ ] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature/Enhancement (non-breaking change which adds functionality or enhances an existing one)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] Documentation update
-   [ ] Refactor
-   [x] New or updated tests

## Checklist

<!--
Ensure all the following are checked:
-->

-   [x] I have performed a self-review of my code.
-   [x] I have commented my code where necessary.
-   [x] I have updated the documentation if needed.
-   [x] My changes do not introduce new warnings.
-   [x] I have added tests that prove my changes are effective or that my feature works.
-   [x] New and existing tests pass with my changes.

## Related Issues

None.