### PR TITLE
fix: allow existing balance on bridge precompile address

### DIFF
--- a/crates/reth/evm/src/precompiles/bridge.rs
+++ b/crates/reth/evm/src/precompiles/bridge.rs
@@ -75,7 +75,10 @@ impl<DB: Database> ContextStatefulPrecompile<DB> for BridgeoutPrecompile {
                 msg: "Failed to load BRIDGEOUT_ADDRESS account".into(),
             })?;
 
-        account.info.balance = U256::ZERO;
+        // NOTE: account balance will always be greater or equal to value sent in tx
+        let new_balance = account.info.balance.saturating_sub(withdrawal_amount);
+
+        account.info.balance = new_balance;
 
         // TODO: Properly calculate and deduct gas for the bridge out operation
         let gas_cost = 0;


### PR DESCRIPTION
## Description
Fixes an edge case where withdrawals fail if precompile address has balance.
ref: https://alpen-labs.slack.com/archives/C060N6GHHAL/p1729072962244399?thread_ts=1728655610.279579&cid=C060N6GHHAL 

<!--
Provide a brief summary of the changes and the motivation behind them.
-->

### Type of Change

<!--
Select the type of change your PR introduces (put an `x` in all that apply):-
-->

-   [x] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature/Enhancement (non-breaking change which adds functionality or enhances an existing one)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] Documentation update
-   [ ] Refactor
-   [ ] New or updated tests

## Checklist

<!--
Ensure all the following are checked:
-->

-   [ ] I have performed a self-review of my code.
-   [ ] I have commented my code where necessary.
-   [ ] I have updated the documentation if needed.
-   [ ] My changes do not introduce new warnings.
-   [ ] I have added tests that prove my changes are effective or that my feature works.
-   [ ] New and existing tests pass with my changes.

## Related Issues

<!--
Link any related issues (e.g., `closes #123`, `fixes #456`).
-->
