### PR TITLE
STR-499: overhaul `SlotRng` to be more standard

### DIFF
--- a/crates/chaintsn/src/transition.rs
+++ b/crates/chaintsn/src/transition.rs
@@ -6,6 +6,7 @@ use std::{cmp::max, collections::HashMap};
 
 use bitcoin::{OutPoint, Transaction};
 use borsh::BorshDeserialize;
+use rand_core::{RngCore, SeedableRng};
 use strata_primitives::{
     l1::{BitcoinAmount, L1TxRef, OutputRef},
     params::RollupParams,
@@ -69,7 +70,7 @@ pub fn process_block(
 fn compute_init_slot_rng(state: &StateCache) -> SlotRng {
     // Just take the last block's slot.
     let blkid_buf = *state.state().chain_tip_blockid().as_ref();
-    SlotRng::new_seeded(blkid_buf)
+    SlotRng::from_seed(blkid_buf)
 }
 
 /// Update our view of the L1 state, playing out downstream changes from that.


### PR DESCRIPTION
## Description

This PR overhauls `SlotRng` in a breaking way to make it more standard and future proof by doing several things:
- Switches the underlying CSPRNG to use `ChaCha12Rng` for an improved security margin
- Uses `fill_bytes` from `RngCore` to generate random arrays (via `next_arr`), rather than the existing bespoke implementation
- Implements `CryptoRng`, `RngCore`, and `SeedableRng` for more standard trait support
- Adds tests

Note that in addition to not being backwards-compatible, the public API is also changed to match the more standard trait support.

Because the existing functionality works and this is breaking, this PR is probably controversial. It is opened mainly for discussion.

### Type of Change

-   [ ] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature/Enhancement (non-breaking change which adds functionality or enhances an existing one)
-   [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [x] Documentation update
-   [ ] Refactor
-   [x] New or updated tests

## Checklist

-   [x] I have performed a self-review of my code.
-   [x] I have commented my code where necessary.
-   [x] I have updated the documentation if needed.
-   [x] My changes do not introduce new warnings.
-   [x] I have added tests that prove my changes are effective or that my feature works.
-   [x] New and existing tests pass with my changes.

## Related Issues

None.
