### PR TITLE
consensus-logic: Use ClientUpdateNotif instead of FCMessage::NewState

### DIFF
--- a/crates/consensus-logic/src/fork_choice_manager.rs
+++ b/crates/consensus-logic/src/fork_choice_manager.rs
@@ -191,12 +191,6 @@ fn process_early_fcm_msg(msg: ForkChoiceMessage) -> Option<Arc<ClientState>> {
             }
         }
 
-        ForkChoiceMessage::NewState(state, _) => {
-            if state.is_chain_active() && state.sync().is_some() {
-                return Some(state);
-            }
-        }
-
         ForkChoiceMessage::NewBlock(blkid) => {
             error!(blkid = ?blkid, "got unexpected early FCM new block message");
         }
@@ -363,11 +357,6 @@ fn process_fc_message<D: Database, E: ExecEngineCtl>(
     match msg {
         ForkChoiceMessage::CsmResume(_) => {
             warn!("got unexpected late CSM resume message, ignoring");
-        }
-
-        ForkChoiceMessage::NewState(cs, output) => {
-            // NOTE: this might not be needed
-            handle_new_state(fcm_state, cs.as_ref(), output.as_ref())?;
         }
 
         ForkChoiceMessage::NewBlock(blkid) => {

--- a/crates/consensus-logic/src/message.rs
+++ b/crates/consensus-logic/src/message.rs
@@ -15,9 +15,6 @@ pub enum ForkChoiceMessage {
     /// Signals the CSM resuming from some state.
     CsmResume(Arc<ClientState>),
 
-    /// New client state with the output that produced it.
-    NewState(Arc<ClientState>, Arc<ClientUpdateOutput>),
-
     /// New block coming in from over the network to be considered.
     NewBlock(L2BlockId),
 }

--- a/crates/consensus-logic/src/sync_manager.rs
+++ b/crates/consensus-logic/src/sync_manager.rs
@@ -114,6 +114,7 @@ pub fn start_sync_tasks<
     let fcm_engine = engine.clone();
     let fcm_csm_controller = csm_controller.clone();
     let fcm_params = params.clone();
+    let crx_clone = cupdate_tx.subscribe();
     executor.spawn_critical("fork_choice_manager::tracker_task", |shutdown| {
         // TODO this should be simplified into a builder or something
         fork_choice_manager::tracker_task(
@@ -124,6 +125,7 @@ pub fn start_sync_tasks<
             fcm_rx,
             fcm_csm_controller,
             fcm_params,
+            crx_clone,
         )
     });
 

--- a/crates/consensus-logic/src/sync_manager.rs
+++ b/crates/consensus-logic/src/sync_manager.rs
@@ -114,7 +114,7 @@ pub fn start_sync_tasks<
     let fcm_engine = engine.clone();
     let fcm_csm_controller = csm_controller.clone();
     let fcm_params = params.clone();
-    let crx_clone = cupdate_tx.subscribe();
+    let status_rx = status_bundle.1.clone();
     executor.spawn_critical("fork_choice_manager::tracker_task", |shutdown| {
         // TODO this should be simplified into a builder or something
         fork_choice_manager::tracker_task(
@@ -125,7 +125,7 @@ pub fn start_sync_tasks<
             fcm_rx,
             fcm_csm_controller,
             fcm_params,
-            crx_clone,
+            status_rx,
         )
     });
 


### PR DESCRIPTION
## Description

This PR removes the cycle between FCM worker and CSM worker by having CSM send `NewState` message to FCM via `ClientUpdateNotif` instead of `ForkChoiceMessage::NewState`.

### Type of Change

<!--
Select the type of change your PR introduces (put an `x` in all that apply):-
-->

-   [x] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature/Enhancement (non-breaking change which adds functionality or enhances an existing one)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] Documentation update
-   [x] Refactor
-   [ ] New or updated tests

## Checklist

<!--
Ensure all the following are checked:
-->

-   [ ] I have performed a self-review of my code.
-   [ ] I have commented my code where necessary.
-   [ ] I have updated the documentation if needed.
-   [ ] My changes do not introduce new warnings.
-   [ ] I have added tests that prove my changes are effective or that my feature works.
-   [ ] New and existing tests pass with my changes.

## Related Issues

<!--
Link any related issues (e.g., `closes #123`, `fixes #456`).
-->
