### PR TITLE
refactor(btcio): remove bitcoind_json_rpc_types

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2169,18 +2169,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "bitcoind-json-rpc-types"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "80270bb74df085641b0acab8ee00c42eb531cb7ed869bfb0d9ed37f7fb23c230"
-dependencies = [
- "bitcoin",
- "bitcoin-internals",
- "serde",
- "serde_json",
-]
-
-[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -12693,7 +12681,6 @@ dependencies = [
  "base64 0.22.1",
  "bitcoin",
  "bitcoind",
- "bitcoind-json-rpc-types",
  "borsh",
  "bytes",
  "hex",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -123,7 +123,6 @@ base64 = "0.22.1"
 bincode = "1.3.3"
 bitcoin = { version = "=0.32.1", features = ["serde"] }
 bitcoind = { version = "0.36.0", features = ["26_0"] }
-bitcoind-json-rpc-types = "0.3.0"
 borsh = { version = "1.5.0", features = ["derive"] }
 bytes = "1.6.0"
 chrono = "0.4.38"

--- a/crates/btcio/Cargo.toml
+++ b/crates/btcio/Cargo.toml
@@ -17,7 +17,6 @@ anyhow.workspace = true
 async-trait.workspace = true
 base64.workspace = true
 bitcoin.workspace = true
-bitcoind-json-rpc-types.workspace = true
 borsh.workspace = true
 bytes.workspace = true
 hex.workspace = true

--- a/crates/btcio/src/rpc/client.rs
+++ b/crates/btcio/src/rpc/client.rs
@@ -11,7 +11,6 @@ use bitcoin::{
     bip32::Xpriv, consensus::encode::serialize_hex, Address, Block, BlockHash, Network,
     Transaction, Txid,
 };
-use bitcoind_json_rpc_types::v26::{GetBlockVerbosityZero, GetNewAddress};
 use reqwest::{
     header::{HeaderMap, AUTHORIZATION, CONTENT_TYPE},
     Client,
@@ -28,8 +27,9 @@ use crate::rpc::{
     error::{BitcoinRpcError, ClientError},
     traits::{Broadcaster, Reader, Signer, Wallet},
     types::{
-        CreateWallet, GetBlockchainInfo, GetTransaction, ImportDescriptor, ImportDescriptorResult,
-        ListDescriptors, ListTransactions, ListUnspent, SignRawTransactionWithWallet,
+        CreateWallet, GetBlockVerbosityZero, GetBlockchainInfo, GetNewAddress, GetTransaction,
+        ImportDescriptor, ImportDescriptorResult, ListDescriptors, ListTransactions, ListUnspent,
+        SignRawTransactionWithWallet,
     },
 };
 

--- a/crates/btcio/src/rpc/types.rs
+++ b/crates/btcio/src/rpc/types.rs
@@ -1,8 +1,9 @@
 use bitcoin::{
-    absolute::Height, address::NetworkUnchecked, consensus, Address, Amount, BlockHash,
-    SignedAmount, Transaction, Txid,
+    absolute::Height,
+    address::{self, NetworkUnchecked},
+    consensus::{self, encode},
+    Address, Amount, Block, BlockHash, SignedAmount, Transaction, Txid,
 };
-use bitcoind_json_rpc_types::v26::GetTransactionDetail;
 use serde::{
     de::{self, IntoDeserializer, Visitor},
     Deserialize, Deserializer, Serialize,
@@ -78,6 +79,118 @@ pub struct GetBlockchainInfo {
     pub prune_target_size: Option<u64>,
 }
 
+/// Result of JSON-RPC method `getblock` with verbosity set to 0.
+///
+/// A string that is serialized, hex-encoded data for block 'hash'.
+///
+/// Method call: `getblock "blockhash" ( verbosity )`
+#[derive(Clone, PartialEq, Debug, Deserialize, Serialize)]
+pub struct GetBlockVerbosityZero(pub String);
+
+impl GetBlockVerbosityZero {
+    /// Converts json straight to a [`Block`].
+    pub fn block(self) -> Result<Block, encode::FromHexError> {
+        let block: Block = encode::deserialize_hex(&self.0)?;
+        Ok(block)
+    }
+}
+
+/// Result of JSON-RPC method `getblock` with verbosity set to 1.
+#[derive(Clone, PartialEq, Debug, Deserialize, Serialize)]
+pub struct GetBlockVerbosityOne {
+    /// The block hash (same as provided) in RPC call.
+    pub hash: String,
+    /// The number of confirmations, or -1 if the block is not on the main chain.
+    pub confirmations: i32,
+    /// The block size.
+    pub size: usize,
+    /// The block size excluding witness data.
+    #[serde(rename = "strippedsize")]
+    pub stripped_size: Option<usize>,
+    /// The block weight as defined in BIP-141.
+    pub weight: u64,
+    /// The block height or index.
+    pub height: usize,
+    /// The block version.
+    pub version: i32,
+    /// The block version formatted in hexadecimal.
+    #[serde(rename = "versionHex")]
+    pub version_hex: String,
+    /// The merkle root
+    #[serde(rename = "merkleroot")]
+    pub merkle_root: String,
+    /// The transaction ids
+    pub tx: Vec<String>,
+    /// The block time expressed in UNIX epoch time.
+    pub time: usize,
+    /// The median block time expressed in UNIX epoch time.
+    #[serde(rename = "mediantime")]
+    pub median_time: Option<usize>,
+    /// The nonce
+    pub nonce: u32,
+    /// The bits.
+    pub bits: String,
+    /// The difficulty.
+    pub difficulty: f64,
+    /// Expected number of hashes required to produce the chain up to this block (in hex).
+    #[serde(rename = "chainwork")]
+    pub chain_work: String,
+    /// The number of transactions in the block.
+    #[serde(rename = "nTx")]
+    pub n_tx: u32,
+    /// The hash of the previous block (if available).
+    #[serde(rename = "previousblockhash")]
+    pub previous_block_hash: Option<String>,
+    /// The hash of the next block (if available).
+    #[serde(rename = "nextblockhash")]
+    pub next_block_hash: Option<String>,
+}
+
+/// Result of JSON-RPC method `gettxout`.
+///
+/// # Note
+///
+/// This assumes that the UTXOs are present in the underlying Bitcoin
+/// client's wallet.
+#[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+pub struct GetTransactionDetail {
+    pub address: String,
+    pub category: GetTransactionDetailCategory,
+    pub amount: f64,
+    pub label: Option<String>,
+    pub vout: u32,
+    pub fee: Option<f64>,
+    pub abandoned: Option<bool>,
+}
+
+/// Enum to represent the category of a transaction.
+#[derive(Copy, Clone, PartialEq, Eq, Debug, Deserialize, Serialize)]
+#[serde(rename_all = "lowercase")]
+pub enum GetTransactionDetailCategory {
+    Send,
+    Receive,
+    Generate,
+    Immature,
+    Orphan,
+}
+
+/// Result of the JSON-RPC method `getnewaddress`.
+///
+/// # Note
+///
+/// This assumes that the UTXOs are present in the underlying Bitcoin
+/// client's wallet.
+#[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+pub struct GetNewAddress(pub String);
+
+impl GetNewAddress {
+    /// Converts json straight to a [`Address`].
+    pub fn address(self) -> Result<Address<NetworkUnchecked>, address::ParseError> {
+        let address = self.0.parse::<Address<_>>()?;
+        Ok(address)
+    }
+}
+
 /// Models the result of JSON-RPC method `listunspent`.
 ///
 /// # Note
@@ -88,8 +201,6 @@ pub struct GetBlockchainInfo {
 /// Careful with the amount field. It is a [`SignedAmount`], hence can be negative.
 /// Negative amounts for the [`TransactionCategory::Send`], and is positive
 /// for all other categories.
-///
-/// We can upstream this to [`bitcoind_json_rpc_types`].
 #[derive(Clone, Debug, PartialEq, Deserialize)]
 pub struct GetTransaction {
     /// The signed amount in BTC.
@@ -140,8 +251,6 @@ impl GetTransaction {
 ///
 /// This assumes that the UTXOs are present in the underlying Bitcoin
 /// client's wallet.
-///
-/// We can upstream this to [`bitcoind_json_rpc_types`].
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
 pub struct ListUnspent {
     /// The transaction id.
@@ -183,8 +292,6 @@ pub struct ListUnspent {
 /// Careful with the amount field. It is a [`SignedAmount`], hence can be negative.
 /// Negative amounts for the [`TransactionCategory::Send`], and is positive
 /// for all other categories.
-///
-/// We can upstream this to [`bitcoind_json_rpc_types`].
 #[derive(Clone, Debug, PartialEq, Deserialize)]
 pub struct ListTransactions {
     /// The Bitcoin address.
@@ -216,8 +323,6 @@ pub struct ListTransactions {
 ///
 /// This assumes that the transactions are present in the underlying Bitcoin
 /// client's wallet.
-///
-/// We can upstream this to [`bitcoind_json_rpc_types`].
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
 pub struct SignRawTransactionWithWallet {
     /// The Transaction ID.


### PR DESCRIPTION
It does not make sense to have this dep since we're already half-baking
our own custom types on top of it and using only a tiny minority of the
types as being the ones provided by bitcoind_json_rpc_types.
