### PR TITLE
chore: bump bitcoin to 0.32.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2067,9 +2067,9 @@ checksum = "349f9b6a179ed607305526ca489b34ad0a41aed5f7980fa90eb03160b69598fb"
 
 [[package]]
 name = "bitcoin"
-version = "0.32.1"
+version = "0.32.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4bf33434c870e98ecc8608588ccc990c5daba9ba9ad39733dc85fba22c211504"
+checksum = "0032b0e8ead7074cda7fc4f034409607e3f03a6f71d66ade8a307f79b4d99e73"
 dependencies = [
  "base58ck",
  "base64 0.21.7",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -121,7 +121,7 @@ argh = "0.1"
 async-trait = "0.1.80"
 base64 = "0.22.1"
 bincode = "1.3.3"
-bitcoin = { version = "=0.32.1", features = ["serde"] }
+bitcoin = { version = "=0.32.3", features = ["serde"] }
 bitcoind = { version = "0.36.0", features = ["26_0"] }
 borsh = { version = "1.5.0", features = ["derive"] }
 bytes = "1.6.0"


### PR DESCRIPTION
## Description

Bumps `rust-bitcoin` from 0.32.1 to 0.32.3

### Type of Change

-   [ ] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature/Enhancement (non-breaking change which adds functionality or enhances an existing one)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] Documentation update
-   [ ] Refactor
-   [ ] New or updated tests
-   [x] Dependency bump

## Checklist

<!--
Ensure all the following are checked:
-->

-   [x] I have performed a self-review of my code.
-   [x] I have commented my code where necessary.
-   [x] I have updated the documentation if needed.
-   [x] My changes do not introduce new warnings.
-   [x] I have added tests that prove my changes are effective or that my feature works.
-   [x] New and existing tests pass with my changes.
