### PR TITLE
fix:(cli) default to broadcast min when esplora doesn't return a fee

### DIFF
--- a/bin/strata-cli/src/signet.rs
+++ b/bin/strata-cli/src/signet.rs
@@ -40,8 +40,6 @@ pub fn print_explorer_url(txid: &Txid, term: &Term, settings: &Settings) -> Resu
 pub enum FeeRateError {
     InvalidDueToOverflow,
     BelowBroadcastMin,
-    /// Esplora didn't have a fee for the requested target
-    FeeMissing,
     EsploraError(esplora_client::Error),
 }
 
@@ -59,7 +57,7 @@ pub async fn get_fee_rate(
             .map(|frs| frs.get(&target).cloned())
             .map_err(FeeRateError::EsploraError)?
             .and_then(|fr| FeeRate::from_sat_per_vb(fr as u64))
-            .ok_or(FeeRateError::FeeMissing)?
+            .unwrap_or(FeeRate::BROADCAST_MIN)
     };
 
     if fee_rate < FeeRate::BROADCAST_MIN {


### PR DESCRIPTION
## Description

<!--
Provide a brief summary of the changes and the motivation behind them.
-->

Defaults to BROADCAST_MIN for fee rate when esplora doesn't return a valid fee rate for the requested target

### Type of Change

<!--
Select the type of change your PR introduces (put an `x` in all that apply):-
-->

-   [x] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature/Enhancement (non-breaking change which adds functionality or enhances an existing one)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] Documentation update
-   [ ] Refactor
-   [ ] New or updated tests

## Checklist

<!--
Ensure all the following are checked:
-->

-   [ ] I have performed a self-review of my code.
-   [ ] I have commented my code where necessary.
-   [ ] I have updated the documentation if needed.
-   [ ] My changes do not introduce new warnings.
-   [ ] I have added tests that prove my changes are effective or that my feature works.
-   [ ] New and existing tests pass with my changes.

## Related Issues

<!--
Link any related issues (e.g., `closes #123`, `fixes #456`).
-->
