### PR TITLE
func-tests: Bridge Deposit Reclaim Path

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13116,7 +13116,9 @@ dependencies = [
  "reth-primitives",
  "shrex",
  "strata-btcio",
+ "strata-common",
  "tokio",
+ "tracing",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13104,7 +13104,7 @@ dependencies = [
 
 [[package]]
 name = "strata-python-utils"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "bdk_bitcoind_rpc",

--- a/crates/util/python-utils/Cargo.toml
+++ b/crates/util/python-utils/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "strata-python-utils"
-version = "0.2.0"
+version = "0.3.0"
 edition = "2021"
 
 [lib]

--- a/crates/util/python-utils/Cargo.toml
+++ b/crates/util/python-utils/Cargo.toml
@@ -31,6 +31,8 @@ pyo3-build-config = "0.22.5"
 anyhow.workspace = true
 bitcoind.workspace = true
 tokio.workspace = true
+tracing.workspace = true
 
 # Internal crates
 strata-btcio.workspace = true
+strata-common.workspace = true

--- a/crates/util/python-utils/pyproject.toml
+++ b/crates/util/python-utils/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "strata_utils"
-version = "0.2.0"
+version = "0.3.0"
 license = { text = "MIT" }
 
 [tool.maturin]

--- a/crates/util/python-utils/src/constants.rs
+++ b/crates/util/python-utils/src/constants.rs
@@ -68,3 +68,19 @@ pub(crate) static DESCRIPTOR: LazyLock<&'static str> =
 /// The Taproot-enable wallet's internal descriptor.
 pub(crate) static CHANGE_DESCRIPTOR: LazyLock<&'static str> =
     LazyLock::new(|| Box::leak(format!("tr({XPRIV}/86'/1'/0'/1/*)").into_boxed_str()));
+
+#[cfg(test)]
+mod tests {
+    use bdk_wallet::bitcoin::Address;
+
+    use super::*;
+
+    #[test]
+    fn unspendable() {
+        let unspendable_address = Address::p2tr(SECP256K1, *UNSPENDABLE, None, NETWORK);
+        assert_eq!(
+            unspendable_address.to_string(),
+            "bcrt1plh4vmrc7ejjt66d8rj5nx8hsvslw9ps9rp3a0v7kzq37ekt5lggskf39fp"
+        );
+    }
+}

--- a/crates/util/python-utils/src/drt.rs
+++ b/crates/util/python-utils/src/drt.rs
@@ -104,7 +104,7 @@ fn deposit_request_transaction_inner(
     op_return_data[MBL + TNHL..].copy_from_slice(el_address.as_slice());
 
     // For regtest 2 sat/vbyte is enough
-    let fee_rate = FeeRate::from_sat_per_vb(2).expect("valid fee rate");
+    let fee_rate = FeeRate::from_sat_per_vb_unchecked(2);
 
     // Before signing the transaction, we need to sync the wallet with bitcoind
     sync_wallet(&mut wallet, &client)?;
@@ -193,7 +193,7 @@ fn spend_recovery_path_inner(
     let mut wallet = recovery_wallet(musig_bridge_pk)?;
 
     // For regtest 2 sat/vbyte is enough
-    let fee_rate = FeeRate::from_sat_per_vb(2).expect("valid fee rate");
+    let fee_rate = FeeRate::from_sat_per_vb_unchecked(2);
 
     // Instantiate the BitcoinD client
     let client = new_client(

--- a/crates/util/python-utils/src/drt.rs
+++ b/crates/util/python-utils/src/drt.rs
@@ -16,7 +16,7 @@ use crate::{
     constants::{BRIDGE_IN_AMOUNT, MAGIC_BYTES, NETWORK, RECOVER_DELAY, UNSPENDABLE, XPRIV},
     error::Error,
     parse::{parse_address, parse_el_address, parse_xonly_pk},
-    taproot::{bridge_wallet, new_client, sync_wallet, taproot_wallet, ExtractP2trPubkey},
+    taproot::{bridge_wallet, new_bitcoind_client, sync_wallet, taproot_wallet, ExtractP2trPubkey},
 };
 
 /// Generates a deposit request transaction (DRT).
@@ -76,7 +76,7 @@ fn deposit_request_transaction_inner(
     let musig_bridge_pk = parse_xonly_pk(musig_bridge_pk)?;
 
     // Instantiate the BitcoinD client
-    let client = new_client(
+    let client = new_bitcoind_client(
         bitcoind_url,
         None,
         Some(bitcoind_user),
@@ -196,7 +196,7 @@ fn spend_recovery_path_inner(
     let fee_rate = FeeRate::from_sat_per_vb_unchecked(2);
 
     // Instantiate the BitcoinD client
-    let client = new_client(
+    let client = new_bitcoind_client(
         bitcoind_url,
         None,
         Some(bitcoind_user),
@@ -403,8 +403,8 @@ mod tests {
         let url = bitcoind.rpc_url();
         let (user, password) = get_auth(&bitcoind);
         let client = BitcoinClient::new(url.clone(), user.clone(), password.clone()).unwrap();
-        let wallet_client =
-            new_client(&url, None, Some(&user), Some(&password)).expect("valid wallet client");
+        let wallet_client = new_bitcoind_client(&url, None, Some(&user), Some(&password))
+            .expect("valid wallet client");
 
         // Get the taproot wallet.
         let mut wallet = taproot_wallet().unwrap();

--- a/crates/util/python-utils/src/drt.rs
+++ b/crates/util/python-utils/src/drt.rs
@@ -118,7 +118,7 @@ fn deposit_request_transaction_inner(
     let fee_rate = FeeRate::from_sat_per_vb(2).expect("valid fee rate");
 
     // Before signing the transaction, we need to sync the wallet with bitcoind
-    sync_wallet(&mut wallet, client)?;
+    sync_wallet(&mut wallet, &client)?;
 
     let mut psbt = wallet
         .build_tx()

--- a/crates/util/python-utils/src/drt.rs
+++ b/crates/util/python-utils/src/drt.rs
@@ -2,10 +2,9 @@ use std::str::FromStr;
 
 use bdk_wallet::{
     bitcoin::{
-        consensus::encode::serialize, hashes::Hash, secp256k1::SECP256K1, taproot::LeafVersion,
-        Address, FeeRate, TapNodeHash, Transaction, XOnlyPublicKey,
+        consensus::encode::serialize, hashes::Hash, taproot::LeafVersion, Address, FeeRate,
+        TapNodeHash, Transaction, XOnlyPublicKey,
     },
-    descriptor::IntoWalletDescriptor,
     miniscript::{miniscript::Tap, Miniscript},
     template::DescriptorTemplateOut,
     KeychainKind, TxOrdering, Wallet,
@@ -14,10 +13,10 @@ use pyo3::prelude::*;
 use reth_primitives::Address as RethAddress;
 
 use crate::{
-    constants::{BRIDGE_IN_AMOUNT, MAGIC_BYTES, NETWORK, RECOVER_DELAY, UNSPENDABLE},
+    constants::{BRIDGE_IN_AMOUNT, MAGIC_BYTES, NETWORK, RECOVER_DELAY, UNSPENDABLE, XPRIV},
     error::Error,
-    parse::{parse_el_address, parse_xonly_pk},
-    taproot::{new_client, sync_wallet, taproot_wallet, ExtractP2trPubkey},
+    parse::{parse_address, parse_el_address, parse_xonly_pk},
+    taproot::{bridge_wallet, new_client, sync_wallet, taproot_wallet, ExtractP2trPubkey},
 };
 
 /// Generates a deposit request transaction (DRT).
@@ -32,7 +31,7 @@ use crate::{
 ///
 /// # Returns
 ///
-/// A signed (with the `private_key`) and serialized Deposit Request transaction.
+/// A signed (with the `private_key`) and serialized transaction.
 #[pyfunction]
 pub(crate) fn deposit_request_transaction(
     el_address: String,
@@ -64,7 +63,7 @@ pub(crate) fn deposit_request_transaction(
 ///
 /// # Returns
 ///
-/// A signed (with the `private_key`) and serialized Deposit Request transaction.
+/// A signed (with the `private_key`) and serialized transaction.
 fn deposit_request_transaction_inner(
     el_address: &str,
     musig_bridge_pk: &str,
@@ -87,21 +86,11 @@ fn deposit_request_transaction_inner(
     // Get the address and the bridge descriptor
     let mut wallet = taproot_wallet()?;
     let recovery_address = wallet.reveal_next_address(KeychainKind::External).address;
-    let (bridge_in_desc, recovery_script_hash) =
-        bridge_in_descriptor(musig_bridge_pk, recovery_address)
-            .expect("valid bridge in descriptor");
+    let (_, recovery_script_hash) = bridge_in_descriptor(musig_bridge_pk, recovery_address.clone())
+        .expect("valid bridge in descriptor");
 
-    let desc = bridge_in_desc
-        .clone()
-        .into_wallet_descriptor(SECP256K1, NETWORK)
-        .expect("valid descriptor");
-
-    let mut temp_wallet = Wallet::create_single(desc.clone())
-        .network(NETWORK)
-        .create_wallet_no_persist()
-        .expect("valid wallet");
-
-    let bridge_in_address = temp_wallet
+    let mut bridge_wallet = bridge_wallet(musig_bridge_pk, recovery_address)?;
+    let bridge_in_address = bridge_wallet
         .reveal_next_address(KeychainKind::External)
         .address;
 
@@ -136,6 +125,111 @@ fn deposit_request_transaction_inner(
     Ok(tx)
 }
 
+/// Spends the take back script path of the deposit request transaction (DRT).
+///
+/// # Arguments
+///
+/// - `address_to_send`: Address to send the funds to.
+/// - `musig_bridge_pk`: MuSig bridge X-only public key.
+/// - `bitcoind_url`: URL of the `bitcoind` instance.
+/// - `bitcoind_user`: Username for the `bitcoind` instance.
+/// - `bitcoind_password`: Password for the `bitcoind` instance.
+///
+/// # Note
+///
+/// The take back script path is relative-timelocked to [`RECOVER_DELAY`] blocks.
+///
+/// # Returns
+///
+/// A signed (with the private key) and serialized transaction.
+#[pyfunction]
+pub(crate) fn take_back_transaction(
+    address_to_send: String,
+    musig_bridge_pk: String,
+    bitcoind_url: String,
+    bitcoind_user: String,
+    bitcoind_password: String,
+) -> PyResult<Vec<u8>> {
+    let signed_tx = spend_recovery_path_inner(
+        address_to_send.as_str(),
+        musig_bridge_pk.as_str(),
+        bitcoind_url.as_str(),
+        bitcoind_user.as_str(),
+        bitcoind_password.as_str(),
+    )?;
+    let signed_tx = serialize(&signed_tx);
+    Ok(signed_tx)
+}
+
+/// Spends the take back script path of the deposit request transaction (DRT).
+///
+/// # Arguments
+///
+/// - `address_to_send`: Address to send the funds to.
+/// - `musig_bridge_pk`: MuSig bridge X-only public key.
+/// - `bitcoind_url`: URL of the `bitcoind` instance.
+/// - `bitcoind_user`: Username for the `bitcoind` instance.
+/// - `bitcoind_password`: Password for the `bitcoind` instance.
+///
+/// # Note
+///
+/// The take back script path is relative-timelocked to [`RECOVER_DELAY`] blocks.
+///
+/// # Returns
+///
+/// A signed (with the private key) and serialized transaction.
+fn spend_recovery_path_inner(
+    address_to_send: &str,
+    musig_bridge_pk: &str,
+    bitcoind_url: &str,
+    bitcoind_user: &str,
+    bitcoind_password: &str,
+) -> Result<Transaction, Error> {
+    // Parse stuff
+    let address_to_send = parse_address(address_to_send)?;
+    let musig_bridge_pk = parse_xonly_pk(musig_bridge_pk)?;
+
+    // Get the recovery wallet
+    let mut wallet = recovery_wallet(musig_bridge_pk)?;
+
+    // For regtest 2 sat/vbyte is enough
+    let fee_rate = FeeRate::from_sat_per_vb(2).expect("valid fee rate");
+
+    // Instantiate the BitcoinD client
+    let client = new_client(
+        bitcoind_url,
+        None,
+        Some(bitcoind_user),
+        Some(bitcoind_password),
+    )?;
+
+    let external_policy = wallet
+        .policies(KeychainKind::External)
+        .expect("valid policy")
+        .expect("valid policy");
+    let root_id = external_policy.id;
+    // child #2 is and_v(v:pk(xkey),older(1008))
+    let path = vec![(root_id, vec![2])].into_iter().collect();
+
+    // Before signing the transaction, we need to sync the wallet with bitcoind
+    sync_wallet(&mut wallet, &client)?;
+
+    // Spend the recovery path
+    let mut psbt = wallet
+        .build_tx()
+        .policy_path(path, KeychainKind::External)
+        .drain_wallet()
+        .drain_to(address_to_send.script_pubkey())
+        .fee_rate(fee_rate)
+        .clone()
+        .finish()
+        .expect("valid psbt");
+    wallet.sign(&mut psbt, Default::default()).unwrap();
+
+    let tx = psbt.extract_tx().expect("valid tx");
+    Ok(tx)
+}
+
 /// The descriptor for the bridge-in transaction.
 ///
 /// # Note
@@ -148,7 +242,7 @@ fn deposit_request_transaction_inner(
 /// # Returns
 ///
 /// The descriptor and the script hash for the recovery path.
-fn bridge_in_descriptor(
+pub(crate) fn bridge_in_descriptor(
     bridge_pubkey: XOnlyPublicKey,
     recovery_address: Address,
 ) -> Result<(DescriptorTemplateOut, TapNodeHash), Error> {
@@ -166,8 +260,7 @@ fn bridge_in_descriptor(
     // i have tried to extract it directly from the desc above
     // it is a massive pita
     let recovery_script = Miniscript::<XOnlyPublicKey, Tap>::from_str(&format!(
-        "and_v(v:pk({}),older(1008))",
-        recovery_xonly_pubkey
+        "and_v(v:pk({recovery_xonly_pubkey}),older(1008))",
     ))
     .expect("valid recovery script")
     .encode();
@@ -177,12 +270,68 @@ fn bridge_in_descriptor(
     Ok((desc, recovery_script_hash))
 }
 
+/// The descriptor for the take-back script path of the
+/// deposit request transaction (DRT).
+///
+/// # Note
+///
+/// The descriptor is a Tapscript that enforces the following conditions:
+///
+/// - The funds can be spent by the bridge operator.
+/// - The funds can be spent by the recovery address after a delay.
+///
+/// # Returns
+///
+/// The descriptor and the script hash for the recovery path.
+pub(crate) fn take_back_descriptor(
+    bridge_pubkey: XOnlyPublicKey,
+) -> Result<DescriptorTemplateOut, Error> {
+    let xkey = format!("{XPRIV}/86'/1'/0'/0/*");
+    let desc = bdk_wallet::descriptor!(
+        tr(UNSPENDABLE, {
+            pk(bridge_pubkey),
+            and_v(v:pk(xkey.as_str()),older(RECOVER_DELAY))
+        })
+    )
+    .expect("valid descriptor");
+
+    Ok(desc)
+}
+
+/// The recovery wallet used for the take-back script path of the
+/// deposit request transaction (DRT).
+///
+/// # Note
+///
+/// This uses the hardcoded [`XPRIV`] key.
+pub(crate) fn recovery_wallet(bridge_pubkey: XOnlyPublicKey) -> Result<Wallet, Error> {
+    let desc = take_back_descriptor(bridge_pubkey)?;
+    Ok(Wallet::create_single(desc)
+        .network(NETWORK)
+        .create_wallet_no_persist()
+        .map_err(|_| Error::Wallet))?
+}
+
+/// Gets a (receiving/external) address from the [`recovery_wallet`] at the given `index`.
+#[pyfunction]
+pub(crate) fn get_recovery_address(index: u32, musig_bridge_pk: String) -> PyResult<String> {
+    let musig_bridge_pk = parse_xonly_pk(&musig_bridge_pk)?;
+    let wallet = recovery_wallet(musig_bridge_pk)?;
+    let address = wallet
+        .peek_address(KeychainKind::External, index)
+        .address
+        .to_string();
+    Ok(address)
+}
+
 #[cfg(test)]
 mod tests {
-    use bdk_wallet::KeychainKind;
+    use bdk_wallet::{KeychainKind, LocalOutput};
     use bitcoind::{bitcoincore_rpc::RpcApi, BitcoinD};
     use strata_btcio::rpc::{traits::Broadcaster, BitcoinClient};
     use strata_common::logging;
+    use tokio::time::{sleep, Duration};
+    use tracing::{debug, trace};
 
     use super::*;
     use crate::taproot::taproot_wallet;
@@ -229,16 +378,107 @@ mod tests {
 
         let mut wallet = taproot_wallet().unwrap();
         let address = wallet.reveal_next_address(KeychainKind::External).address;
+        debug!(%address, "wallet receiving address");
 
         // Mine and get the last UTXO which should have 50 BTC.
         mine_blocks(&bitcoind, 101, Some(address)).unwrap();
+        debug!("mined 101 blocks");
 
         let signed_tx =
             deposit_request_transaction_inner(EL_ADDRESS, MUSIG_BRIDGE_PK, &url, &user, &password)
                 .unwrap();
+        trace!(?signed_tx, "signed drt tx");
 
         let txid = client.send_raw_transaction(&signed_tx).await.unwrap();
+        debug!(%txid, "sent drt tx");
 
         assert_eq!(txid, signed_tx.compute_txid());
+    }
+
+    #[tokio::test]
+    async fn recovery_path_mempool_accept() {
+        logging::init(logging::LoggerConfig::with_base_name("recovery-path-tests"));
+
+        let bitcoind = BitcoinD::from_downloaded().unwrap();
+        let url = bitcoind.rpc_url();
+        let (user, password) = get_auth(&bitcoind);
+        let client = BitcoinClient::new(url.clone(), user.clone(), password.clone()).unwrap();
+        let wallet_client =
+            new_client(&url, None, Some(&user), Some(&password)).expect("valid wallet client");
+
+        // Get the taproot wallet.
+        let mut wallet = taproot_wallet().unwrap();
+        let address = wallet.reveal_next_address(KeychainKind::External).address;
+        debug!(%address, "wallet receiving address");
+        let change_address = wallet.reveal_next_address(KeychainKind::Internal).address;
+        debug!(%change_address, "wallet change address");
+
+        // Get the recocery wallet.
+        let musig_bridge_pk = parse_xonly_pk(MUSIG_BRIDGE_PK).unwrap();
+        debug!(?musig_bridge_pk, "musig bridge pk");
+        let mut recovery_wallet = recovery_wallet(musig_bridge_pk).unwrap();
+        let recovery_address = recovery_wallet
+            .reveal_next_address(KeychainKind::External)
+            .address;
+        debug!(%recovery_address, "recovery address");
+
+        // Mine and get the last UTXO which should have 50 BTC.
+        mine_blocks(&bitcoind, 101, Some(address)).unwrap();
+        debug!("mined 101 blocks");
+
+        // Mine one block to the recovery address so that it has fees for the recovery path.
+        mine_blocks(&bitcoind, 1, Some(recovery_address)).unwrap();
+
+        // Sleep for a while to let the transactions propagate.
+        sleep(Duration::from_millis(200)).await;
+
+        sync_wallet(&mut wallet, &wallet_client).unwrap();
+        debug!("wallet synced with bitcoind");
+        let wallet_utxos = wallet.list_unspent().collect::<Vec<LocalOutput>>();
+        trace!(?wallet_utxos, "wallet utxos");
+        let coinbase_utxo = wallet_utxos.first().unwrap();
+        trace!(?coinbase_utxo, "coinbase utxo");
+        let coinbase_outpoint = coinbase_utxo.outpoint.to_string();
+        trace!(%coinbase_outpoint, "coinbase outpoint");
+
+        let signed_tx =
+            deposit_request_transaction_inner(EL_ADDRESS, MUSIG_BRIDGE_PK, &url, &user, &password)
+                .unwrap();
+        trace!(?signed_tx, "signed drt tx");
+
+        let txid = client.send_raw_transaction(&signed_tx).await.unwrap();
+        debug!(%txid, "sent drt tx");
+
+        // Mine blocks enough for the spending policy (1008 blocks).
+        // Need to break this into chunks to avoid bitcoind crashing.
+        let blocks_for_maturity = RECOVER_DELAY;
+        let chunks = 8u32;
+        let chunk_size = blocks_for_maturity / chunks;
+        for _ in 0..chunks {
+            mine_blocks(&bitcoind, chunk_size as _, None).unwrap();
+        }
+
+        let recovery_tx = spend_recovery_path_inner(
+            change_address.to_string().as_str(),
+            MUSIG_BRIDGE_PK,
+            &url,
+            &user,
+            &password,
+        )
+        .unwrap();
+        let txid = client.send_raw_transaction(&recovery_tx).await.unwrap();
+        assert_eq!(txid, recovery_tx.compute_txid());
+    }
+
+    #[test]
+    fn recovery_wallet_address() {
+        let musig_bridge_pk = parse_xonly_pk(MUSIG_BRIDGE_PK).unwrap();
+        let mut wallet = recovery_wallet(musig_bridge_pk).unwrap();
+        let address = wallet
+            .reveal_next_address(KeychainKind::External)
+            .address
+            .to_string();
+        let expected_address = "bcrt1p5wh09dkrfmr44zq85y55x92f5zjhkj2l0kvepd3fskw6aj8tch5q8t44sr";
+        assert_eq!(address, expected_address);
     }
 }

--- a/crates/util/python-utils/src/drt.rs
+++ b/crates/util/python-utils/src/drt.rs
@@ -20,7 +20,7 @@ use crate::{
     taproot::{new_client, sync_wallet, taproot_wallet, ExtractP2trPubkey},
 };
 
-/// Generates a Deposit Request transaction (DRT).
+/// Generates a deposit request transaction (DRT).
 ///
 /// # Arguments
 ///
@@ -52,7 +52,7 @@ pub(crate) fn deposit_request_transaction(
     Ok(signed_tx)
 }
 
-/// Generates a Deposit Request transaction (DRT).
+/// Generates a deposit request transaction (DRT).
 ///
 /// # Arguments
 ///
@@ -182,6 +182,7 @@ mod tests {
     use bdk_wallet::KeychainKind;
     use bitcoind::{bitcoincore_rpc::RpcApi, BitcoinD};
     use strata_btcio::rpc::{traits::Broadcaster, BitcoinClient};
+    use strata_common::logging;
 
     use super::*;
     use crate::taproot::taproot_wallet;
@@ -217,8 +218,10 @@ mod tests {
         Ok(())
     }
 
-    #[tokio::test()]
+    #[tokio::test]
     async fn drt_mempool_accept() {
+        logging::init(logging::LoggerConfig::with_base_name("drt-tests"));
+
         let bitcoind = BitcoinD::from_downloaded().unwrap();
         let url = bitcoind.rpc_url();
         let (user, password) = get_auth(&bitcoind);

--- a/crates/util/python-utils/src/error.rs
+++ b/crates/util/python-utils/src/error.rs
@@ -15,6 +15,9 @@ pub(crate) enum Error {
     /// Invalid PublicKey
     PublicKey,
 
+    /// Invalid Outpoint.
+    OutPoint,
+
     /// Not a Taproot address.
     NotTaprootAddress,
 
@@ -40,6 +43,7 @@ impl From<Error> for PyErr {
                 PyErr::new::<PyTypeError, _>("Invalid X-only public key".to_owned())
             }
             Error::PublicKey => PyErr::new::<PyTypeError, _>("Invalid public key".to_owned()),
+            Error::OutPoint => PyErr::new::<PyTypeError, _>("Invalid outpoint".to_owned()),
             Error::NotTaprootAddress => {
                 PyErr::new::<PyTypeError, _>("Not a P2TR address".to_owned())
             }

--- a/crates/util/python-utils/src/lib.rs
+++ b/crates/util/python-utils/src/lib.rs
@@ -9,7 +9,7 @@ mod taproot;
 use drt::{deposit_request_transaction, get_recovery_address, take_back_transaction};
 use taproot::{
     convert_to_xonly_pk, drain_wallet, extract_p2tr_pubkey, get_address, get_change_address,
-    musig_aggregate_pks,
+    musig_aggregate_pks, unspendable_address,
 };
 
 /// A Python module implemented in Rust. The name of this function must match
@@ -22,6 +22,7 @@ fn strata_utils(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(get_change_address, m)?)?;
     m.add_function(wrap_pyfunction!(musig_aggregate_pks, m)?)?;
     m.add_function(wrap_pyfunction!(extract_p2tr_pubkey, m)?)?;
+    m.add_function(wrap_pyfunction!(unspendable_address, m)?)?;
     m.add_function(wrap_pyfunction!(drain_wallet, m)?)?;
     m.add_function(wrap_pyfunction!(convert_to_xonly_pk, m)?)?;
     m.add_function(wrap_pyfunction!(take_back_transaction, m)?)?;

--- a/crates/util/python-utils/src/lib.rs
+++ b/crates/util/python-utils/src/lib.rs
@@ -6,7 +6,7 @@ mod error;
 mod parse;
 mod taproot;
 
-use drt::deposit_request_transaction;
+use drt::{deposit_request_transaction, get_recovery_address, take_back_transaction};
 use taproot::{
     convert_to_xonly_pk, drain_wallet, extract_p2tr_pubkey, get_address, get_change_address,
     musig_aggregate_pks,
@@ -24,6 +24,8 @@ fn strata_utils(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(extract_p2tr_pubkey, m)?)?;
     m.add_function(wrap_pyfunction!(drain_wallet, m)?)?;
     m.add_function(wrap_pyfunction!(convert_to_xonly_pk, m)?)?;
+    m.add_function(wrap_pyfunction!(take_back_transaction, m)?)?;
+    m.add_function(wrap_pyfunction!(get_recovery_address, m)?)?;
 
     Ok(())
 }

--- a/crates/util/python-utils/src/parse.rs
+++ b/crates/util/python-utils/src/parse.rs
@@ -1,4 +1,4 @@
-use bdk_wallet::bitcoin::{PublicKey, XOnlyPublicKey};
+use bdk_wallet::bitcoin::{OutPoint, PublicKey, Txid, XOnlyPublicKey};
 use reth_primitives::Address as RethAddress;
 
 use crate::error::Error;
@@ -23,6 +23,17 @@ pub(crate) fn parse_pk(pk: &str) -> Result<PublicKey, Error> {
     pk.parse::<PublicKey>().map_err(|_| Error::PublicKey)
 }
 
+/// Parse an [`OutPoint`] from a string.
+pub(crate) fn parse_outpoint(outpoint: &str) -> Result<OutPoint, Error> {
+    let parts: Vec<&str> = outpoint.split(':').collect();
+    if parts.len() != 2 {
+        return Err(Error::OutPoint);
+    }
+    let txid = parts[0].parse::<Txid>().map_err(|_| Error::OutPoint)?;
+    let vout = parts[1].parse::<u32>().map_err(|_| Error::OutPoint)?;
+    Ok(OutPoint { txid, vout })
+}
+
 #[cfg(test)]
 mod tests {
 
@@ -44,5 +55,19 @@ mod tests {
     fn parse_pk() {
         let pk = "028b71ab391bc0a0f5fd8d136458e8a5bd1e035e27b8cef77b12d057b4767c31c8";
         assert!(super::parse_pk(pk).is_ok());
+    }
+
+    #[test]
+    fn parse_outpoint() {
+        let outpoint = "ae86b8c8912594427bf148eb7660a86378f2fb4ac9c8d2ea7d3cb7f3fcfd7c1c:0";
+        assert!(super::parse_outpoint(outpoint).is_ok());
+        let outpoint_without_vout =
+            "ae86b8c8912594427bf148eb7660a86378f2fb4ac9c8d2ea7d3cb7f3fcfd7c1c";
+        assert!(super::parse_outpoint(outpoint_without_vout).is_err());
+        let outpoint_with_vout_out_of_bonds = {
+            let vout = u32::MAX as u64 + 1;
+            format!("ae86b8c8912594427bf148eb7660a86378f2fb4ac9c8d2ea7d3cb7f3fcfd7c1c:{vout}")
+        };
+        assert!(super::parse_outpoint(&outpoint_with_vout_out_of_bonds).is_err());
     }
 }

--- a/crates/util/python-utils/src/parse.rs
+++ b/crates/util/python-utils/src/parse.rs
@@ -32,6 +32,7 @@ pub(super) fn parse_address(address: &str) -> Result<Address, Error> {
 }
 
 /// Parses an [`OutPoint`] from a string.
+#[allow(dead_code)] // This might be useful in the future
 pub(crate) fn parse_outpoint(outpoint: &str) -> Result<OutPoint, Error> {
     let parts: Vec<&str> = outpoint.split(':').collect();
     if parts.len() != 2 {

--- a/crates/util/python-utils/src/parse.rs
+++ b/crates/util/python-utils/src/parse.rs
@@ -1,4 +1,4 @@
-use bdk_wallet::bitcoin::{OutPoint, PublicKey, Txid, XOnlyPublicKey};
+use bdk_wallet::bitcoin::{Address, OutPoint, PublicKey, Txid, XOnlyPublicKey};
 use reth_primitives::Address as RethAddress;
 
 use crate::error::Error;
@@ -11,19 +11,27 @@ pub(crate) fn parse_el_address(el_address: &str) -> Result<RethAddress, Error> {
     Ok(el_address)
 }
 
-/// Parse an [`XOnlyPublicKey`] from a hex string.
+/// Parses an [`XOnlyPublicKey`] from a hex string.
 pub(crate) fn parse_xonly_pk(x_only_pk: &str) -> Result<XOnlyPublicKey, Error> {
     x_only_pk
         .parse::<XOnlyPublicKey>()
         .map_err(|_| Error::XOnlyPublicKey)
 }
 
-/// Parse a [`PublicKey`] from a hex string.
+/// Parses a [`PublicKey`] from a hex string.
 pub(crate) fn parse_pk(pk: &str) -> Result<PublicKey, Error> {
     pk.parse::<PublicKey>().map_err(|_| Error::PublicKey)
 }
 
-/// Parse an [`OutPoint`] from a string.
+/// Parses an [`Address`] from a string.
+pub(super) fn parse_address(address: &str) -> Result<Address, Error> {
+    Ok(address
+        .parse::<Address<_>>()
+        .map_err(|_| Error::BitcoinAddress)?
+        .assume_checked())
+}
+
+/// Parses an [`OutPoint`] from a string.
 pub(crate) fn parse_outpoint(outpoint: &str) -> Result<OutPoint, Error> {
     let parts: Vec<&str> = outpoint.split(':').collect();
     if parts.len() != 2 {
@@ -69,5 +77,11 @@ mod tests {
             format!("ae86b8c8912594427bf148eb7660a86378f2fb4ac9c8d2ea7d3cb7f3fcfd7c1c:{vout}")
         };
         assert!(super::parse_outpoint(&outpoint_with_vout_out_of_bonds).is_err());
+    }
+
+    #[test]
+    fn parse_address() {
+        let address = "bcrt1phcnl4zcl2fu047pv4wx6y058v8u0n02at6lthvm7pcf2wrvjm5tqatn90k";
+        assert!(super::parse_address(address).is_ok());
     }
 }

--- a/crates/util/python-utils/src/taproot.rs
+++ b/crates/util/python-utils/src/taproot.rs
@@ -78,9 +78,9 @@ pub(crate) fn bridge_wallet(
 /// # Note
 ///
 /// This function should be only used with Regtest.
-pub(crate) fn sync_wallet(wallet: &mut Wallet, rpc_client: Client) -> Result<(), Error> {
+pub(crate) fn sync_wallet(wallet: &mut Wallet, rpc_client: &Client) -> Result<(), Error> {
     let wallet_tip = wallet.latest_checkpoint();
-    let mut emitter = Emitter::new(&rpc_client, wallet_tip, 0);
+    let mut emitter = Emitter::new(rpc_client, wallet_tip, 0);
     while let Some(block) = emitter.next_block().expect("valid block") {
         let height = block.block_height();
         let connected_to = block.connected_to();
@@ -239,7 +239,7 @@ fn drain_wallet_inner(
     let fee_rate = FeeRate::from_sat_per_vb(2).expect("valid fee rate");
 
     // Before signing the transaction, we need to sync the wallet with bitcoind
-    sync_wallet(&mut wallet, client)?;
+    sync_wallet(&mut wallet, &client)?;
 
     let mut psbt = wallet
         .build_tx()

--- a/crates/util/python-utils/src/taproot.rs
+++ b/crates/util/python-utils/src/taproot.rs
@@ -17,7 +17,7 @@ use musig2::KeyAggContext;
 use pyo3::prelude::*;
 
 use crate::{
-    constants::{CHANGE_DESCRIPTOR, DESCRIPTOR, NETWORK},
+    constants::{CHANGE_DESCRIPTOR, DESCRIPTOR, NETWORK, UNSPENDABLE},
     drt::bridge_in_descriptor,
     error::Error,
     parse::{parse_pk, parse_xonly_pk},
@@ -40,6 +40,15 @@ impl ExtractP2trPubkey for Address {
 
         Ok(XOnlyPublicKey::from_slice(&script_pubkey.as_bytes()[2..]).expect("valid pub key"))
     }
+}
+
+/// Unspendabled Taproot address.
+///
+/// This is based on the [`UNSPENDABLE`] public key.
+#[pyfunction]
+pub fn unspendable_address() -> String {
+    let address = Address::p2tr(SECP256K1, *UNSPENDABLE, None, NETWORK);
+    address.to_string()
 }
 
 /// A simple Taproot-enable wallet.
@@ -310,6 +319,15 @@ mod tests {
         ))
         .unwrap();
         assert_eq!(pk, expected);
+    }
+
+    #[test]
+    fn unspendable_address() {
+        let address = super::unspendable_address();
+        assert_eq!(
+            address,
+            "bcrt1plh4vmrc7ejjt66d8rj5nx8hsvslw9ps9rp3a0v7kzq37ekt5lggskf39fp"
+        );
     }
 
     #[test]

--- a/crates/util/python-utils/src/taproot.rs
+++ b/crates/util/python-utils/src/taproot.rs
@@ -122,7 +122,7 @@ pub(crate) fn musig_aggregate_pks_inner(pks: Vec<XOnlyPublicKey>) -> Result<XOnl
     Ok(key_agg_ctx.aggregated_pubkey())
 }
 
-/// Gets a (receiving/external) address from the wallet at the given `index`.
+/// Gets a (receiving/external) address from the [`taproot_wallet`] at the given `index`.
 #[pyfunction]
 pub(crate) fn get_address(index: u32) -> PyResult<String> {
     let wallet = taproot_wallet()?;

--- a/crates/util/python-utils/src/taproot.rs
+++ b/crates/util/python-utils/src/taproot.rs
@@ -101,7 +101,7 @@ pub(crate) fn sync_wallet(wallet: &mut Wallet, rpc_client: &Client) -> Result<()
 }
 
 /// Creates a new `bitcoind` RPC client.
-pub(crate) fn new_client(
+pub(crate) fn new_bitcoind_client(
     url: &str,
     rpc_cookie: Option<&PathBuf>,
     rpc_user: Option<&str>,
@@ -237,7 +237,7 @@ fn drain_wallet_inner(
         .assume_checked();
 
     // Instantiate the BitcoinD client
-    let client = new_client(
+    let client = new_bitcoind_client(
         bitcoind_url,
         None,
         Some(bitcoind_user),

--- a/functional-tests/constants.py
+++ b/functional-tests/constants.py
@@ -16,6 +16,10 @@ ERROR_CHECKPOINT_DOESNOT_EXIST = -32610
 # custom precompiles
 PRECOMPILE_BRIDGEOUT_ADDRESS = "0x5400000000000000000000000000000000000001"
 
+# Unspendable address
+# Taken from python-strata-utils:
+UNSPENDABLE_ADDRESS = "bcrt1plh4vmrc7ejjt66d8rj5nx8hsvslw9ps9rp3a0v7kzq37ekt5lggskf39fp"
+
 # Network times and stuff
 DEFAULT_BLOCK_TIME_SEC = 1
 DEFAULT_EPOCH_SLOTS = 64

--- a/functional-tests/constants.py
+++ b/functional-tests/constants.py
@@ -22,6 +22,7 @@ DEFAULT_EPOCH_SLOTS = 64
 DEFAULT_GENESIS_TRIGGER_HT = 5
 DEFAULT_OPERATOR_CNT = 2
 DEFAULT_PROOF_TIMEOUT = 5  # Secs
+DEFAULT_TAKEBACK_TIMEOUT = 1008  # Blocks (1 week)
 
 # magic values
 # TODO Remove every single one of these

--- a/functional-tests/fn_bridge_deposit_happy.py
+++ b/functional-tests/fn_bridge_deposit_happy.py
@@ -22,7 +22,7 @@ class BridgeDepositHappyTest(flexitest.Test):
     """
 
     def __init__(self, ctx: flexitest.InitContext):
-        ctx.set_env(BasicEnvConfig(101))
+        ctx.set_env(BasicEnvConfig(pre_generate_blocks=101))
         self.logger = get_logger("BridgeDepositHappyTest")
 
     def main(self, ctx: flexitest.RunContext):

--- a/functional-tests/fn_bridge_deposit_reclaim.py
+++ b/functional-tests/fn_bridge_deposit_reclaim.py
@@ -1,0 +1,166 @@
+import time
+
+import flexitest
+from bitcoinlib.services.bitcoind import BitcoindClient
+from strata_utils import (
+    deposit_request_transaction,
+    get_address,
+    get_recovery_address,
+    take_back_transaction,
+    unspendable_address,
+)
+
+from constants import DEFAULT_TAKEBACK_TIMEOUT
+from entry import BasicEnvConfig
+from utils import get_bridge_pubkey, get_logger
+
+
+@flexitest.register
+class BridgeDepositReclaimTest(flexitest.Test):
+    """
+    A test class for reclaim path scenarios of bridge deposits.
+
+    It tests the functionality of broadcasting a deposit request transaction (DRT) for the bridge
+    and verifying that the reclaim path works as expected.
+
+    In the test we stop one of the bridge operators to prevent the DRT from being processed.
+    """
+
+    def __init__(self, ctx: flexitest.InitContext):
+        ctx.set_env(BasicEnvConfig(pre_generate_blocks=101))
+        self.logger = get_logger("BridgeDepositReclaimTest")
+
+    def main(self, ctx: flexitest.RunContext):
+        btc = ctx.get_service("bitcoin")
+        reth = ctx.get_service("reth")
+        seq = ctx.get_service("sequencer")
+        # We just need to stop one bridge operator
+        bridge_operator = ctx.get_service("bridge.0")
+
+        btcrpc: BitcoindClient = btc.create_rpc()
+        btc_url = btcrpc.base_url
+        btc_user = btc.props["rpc_user"]
+        btc_password = btc.props["rpc_password"]
+
+        rethrpc = reth.create_rpc()
+
+        seqrpc = seq.create_rpc()
+
+        self.logger.debug(f"BTC URL: {btc_url}")
+        self.logger.debug(f"BTC user: {btc_user}")
+        self.logger.debug(f"BTC password: {btc_password}")
+
+        bridge_pk = get_bridge_pubkey(seqrpc)
+        el_address = "deadf001900dca3ebeefdeadf001900dca3ebeef"
+        addr = get_address(0)
+        change_addr = btcrpc.proxy.getnewaddress()
+        recovery_addr = get_recovery_address(0, bridge_pk)
+        unspendable_addr = unspendable_address()
+
+        # Generate Plenty of BTC to address for the DRT
+        self.logger.debug(f"Generating 102 blocks to address: {addr}")
+        btcrpc.proxy.generatetoaddress(102, addr)
+        self.logger.debug(f"Generated 102 blocks to address: {addr}")
+        time.sleep(0.5)
+
+        # Generate Plenty of BTC to recovery address for the take back path
+        self.logger.debug(f"Generating 102 blocks to recovery address: {recovery_addr}")
+        btcrpc.proxy.generatetoaddress(102, recovery_addr)
+        self.logger.debug(f"Generated 110 blocks to recovery address: {recovery_addr}")
+        time.sleep(0.5)
+
+        # DRT same block
+        txid_drt = self.make_drt(ctx, el_address, bridge_pk, maturity=0)
+        self.logger.debug(f"Deposit Request Transaction: {txid_drt}")
+        time.sleep(0.5)
+
+        # Kill the operator so the bridge does not process the DRT transaction
+        bridge_operator.stop()
+        seq.stop()  # FIXME: Don't know why we need to stop the sequencer as well
+        self.logger.debug("Bridge operators stopped")
+
+        # Now we need to generate a bunch of blocks
+        # since they will be able to spend the DRT output.
+        # We need to wait for the reclaim path 1008 blocks to mature
+        # so that we can use the take back path to spend the DRT output.
+        # Breaking by chunks
+        chunks = 8
+        blocks_to_generate = DEFAULT_TAKEBACK_TIMEOUT // chunks
+        self.logger.debug(f"Generating {DEFAULT_TAKEBACK_TIMEOUT} blocks in {chunks} chunks")
+        for i in range(chunks):
+            self.logger.debug(f"Generating {blocks_to_generate} blocks in chunk {i+1}/{chunks}")
+            btcrpc.proxy.generatetoaddress(blocks_to_generate, unspendable_addr)
+
+        # wait up a little bit
+        time.sleep(1)
+
+        # Spend the take back path
+        take_back_tx = bytes(
+            take_back_transaction(change_addr, bridge_pk, btc_url, btc_user, btc_password)
+        ).hex()
+        self.logger.debug("Take back tx generated")
+
+        # Send the transaction to the Bitcoin network
+        txid = btcrpc.proxy.sendrawtransaction(take_back_tx)
+        self.logger.debug(f"sent take back tx with txid = {txid} for address {el_address}")
+        # this transaction is not in the bitcoind wallet, so we cannot use gettransaction
+        btcrpc.proxy.generatetoaddress(1, unspendable_addr)
+        time.sleep(1)
+
+        rpc_transaction = btcrpc.proxy.gettransaction(txid)
+        assert rpc_transaction["confirmations"] > 0, "transaction is not confirmed"
+
+        # Now let's see if the EVM side has no funds
+        # Make sure that the el_address has zero balance
+        balance = int(rethrpc.eth_getBalance(f"0x{el_address}"), 16)
+
+        assert balance == 0, "EVM balance is not zero"
+
+        # Restart the bridge operator
+        seq.start()  # FIXME: Don't know why we need to stop the sequencer as well
+        bridge_operator.start()
+
+        return True
+
+    def make_drt(self, ctx: flexitest.RunContext, el_address, musig_bridge_pk, maturity=0):
+        """
+        Deposit Request Transaction
+        """
+        # Get relevant data
+        btc = ctx.get_service("bitcoin")
+        seq = ctx.get_service("sequencer")
+
+        btcrpc: BitcoindClient = btc.create_rpc()
+        btc_url = btcrpc.base_url
+        btc_user = btc.props["rpc_user"]
+        btc_password = btc.props["rpc_password"]
+
+        seq_addr = seq.get_prop("address")
+
+        self.logger.debug(f"BTC URL: {btc_url}")
+        self.logger.debug(f"BTC user: {btc_user}")
+        self.logger.debug(f"BTC password: {btc_password}")
+
+        # Create the deposit request transaction
+        tx = bytes(
+            deposit_request_transaction(
+                el_address, musig_bridge_pk, btc_url, btc_user, btc_password
+            )
+        ).hex()
+        self.logger.debug(f"Deposit request tx: {tx}")
+
+        # Send the transaction to the Bitcoin network
+        txid = btcrpc.proxy.sendrawtransaction(tx)
+        self.logger.debug(f"sent deposit request with txid = {txid} for address {el_address}")
+        # this transaction is not in the bitcoind wallet, so we cannot use gettransaction
+        time.sleep(1)
+
+        # time to mature DRT
+        if maturity > 0:
+            btcrpc.proxy.generatetoaddress(maturity, seq_addr)
+            time.sleep(3)
+
+        return txid
+
+    def reclaim_deposit(self, ctx: flexitest.RunContext, txid_drt, maturity=0):
+        return True

--- a/functional-tests/fn_bridge_deposit_reclaim.py
+++ b/functional-tests/fn_bridge_deposit_reclaim.py
@@ -7,10 +7,9 @@ from strata_utils import (
     get_address,
     get_recovery_address,
     take_back_transaction,
-    unspendable_address,
 )
 
-from constants import DEFAULT_TAKEBACK_TIMEOUT
+from constants import DEFAULT_TAKEBACK_TIMEOUT, UNSPENDABLE_ADDRESS
 from entry import BasicEnvConfig
 from utils import get_bridge_pubkey, get_logger
 
@@ -55,7 +54,6 @@ class BridgeDepositReclaimTest(flexitest.Test):
         addr = get_address(0)
         change_addr = btcrpc.proxy.getnewaddress()
         recovery_addr = get_recovery_address(0, bridge_pk)
-        unspendable_addr = unspendable_address()
 
         # Generate Plenty of BTC to address for the DRT
         self.logger.debug(f"Generating 102 blocks to address: {addr}")
@@ -89,7 +87,7 @@ class BridgeDepositReclaimTest(flexitest.Test):
         self.logger.debug(f"Generating {DEFAULT_TAKEBACK_TIMEOUT} blocks in {chunks} chunks")
         for i in range(chunks):
             self.logger.debug(f"Generating {blocks_to_generate} blocks in chunk {i+1}/{chunks}")
-            btcrpc.proxy.generatetoaddress(blocks_to_generate, unspendable_addr)
+            btcrpc.proxy.generatetoaddress(blocks_to_generate, UNSPENDABLE_ADDRESS)
 
         # wait up a little bit
         time.sleep(1)
@@ -104,7 +102,7 @@ class BridgeDepositReclaimTest(flexitest.Test):
         txid = btcrpc.proxy.sendrawtransaction(take_back_tx)
         self.logger.debug(f"sent take back tx with txid = {txid} for address {el_address}")
         # this transaction is not in the bitcoind wallet, so we cannot use gettransaction
-        btcrpc.proxy.generatetoaddress(1, unspendable_addr)
+        btcrpc.proxy.generatetoaddress(1, UNSPENDABLE_ADDRESS)
         time.sleep(1)
 
         rpc_transaction = btcrpc.proxy.gettransaction(txid)
@@ -161,6 +159,3 @@ class BridgeDepositReclaimTest(flexitest.Test):
             time.sleep(3)
 
         return txid
-
-    def reclaim_deposit(self, ctx: flexitest.RunContext, txid_drt, maturity=0):
-        return True


### PR DESCRIPTION
## Description

Tests the unhappy path of a deposit request transaction (DRT),
i.e. when the bridge has failed to process DRT into a deposit
transaction (DT) after the recover delay (here ~1 week, or 1008 blocks).

### Type of Change

-   [ ] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature/Enhancement (non-breaking change which adds functionality or enhances an existing one)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] Documentation update
-   [ ] Refactor
-   [x] New or updated tests

## Checklist

-   [x] I have performed a self-review of my code.
-   [x] I have commented my code where necessary.
-   [x] I have updated the documentation if needed.
-   [x] My changes do not introduce new warnings.
-   [x] I have added tests that prove my changes are effective or that my feature works.
-   [x] New and existing tests pass with my changes.

## Related Issues

STR-418
