### PR TITLE
poc checkpoint state info

### DIFF
--- a/bin/prover-client/src/rpc_server.rs
+++ b/bin/prover-client/src/rpc_server.rs
@@ -180,6 +180,8 @@ impl StrataProverClientApiServer for ProverClientRpc {
             l1_range,
             l2_range,
             l2_blockid: Default::default(),
+            l1_blockid: Default::default(),
+            commitment: None,
         };
 
         let task_id = self

--- a/crates/consensus-logic/src/client_transition.rs
+++ b/crates/consensus-logic/src/client_transition.rs
@@ -9,7 +9,7 @@ use strata_db::traits::{
 };
 use strata_primitives::prelude::*;
 use strata_state::{
-    batch::{BatchCheckpoint, BatchInfo},
+    batch::{BatchCheckpoint, BatchCheckpointWithCommitment, BatchInfo, CommitmentInfo},
     block,
     client_state::*,
     header::L2Header,
@@ -165,11 +165,12 @@ pub fn process_event<D: Database>(
                 writes.push(ClientStateWrite::CheckpointsReceived(
                     checkpoints
                         .iter()
-                        .map(|x| {
+                        .map(|batchcheckpoint_with_commitment| {
+                            let batchcheckpoint = &batchcheckpoint_with_commitment.batch_checkpoint;
                             L1Checkpoint::new(
-                                x.batch_info().clone(),
-                                x.bootstrap_state().clone(),
-                                !x.proof().is_empty(),
+                                batchcheckpoint.batch_info().clone(),
+                                batchcheckpoint.bootstrap_state().clone(),
+                                !batchcheckpoint.proof().is_empty(),
                                 *height,
                             )
                         })
@@ -278,9 +279,9 @@ fn handle_maturable_height(
 /// A vector containing the valid sequence of `BatchCheckpoint`s, starting from the first valid one.
 pub fn filter_verified_checkpoints(
     state: &ClientState,
-    checkpoints: &[BatchCheckpoint],
+    checkpoints: &[BatchCheckpointWithCommitment],
     params: &RollupParams,
-) -> Vec<BatchCheckpoint> {
+) -> Vec<BatchCheckpointWithCommitment> {
     let l1_view = state.l1_view();
     let last_verified = l1_view.verified_checkpoints().last();
     let last_finalized = l1_view.last_finalized_checkpoint();
@@ -296,14 +297,14 @@ pub fn filter_verified_checkpoints(
     let mut result_checkpoints = Vec::new();
 
     for checkpoint in checkpoints {
-        let curr_idx = checkpoint.batch_info().idx;
+        let curr_idx = checkpoint.batch_checkpoint.batch_info().idx;
         if curr_idx != expected_idx {
             warn!(%expected_idx, %curr_idx, "Received invalid checkpoint idx, ignoring.");
             continue;
         }
-        if expected_idx == 0 && verify_proof(checkpoint, params).is_ok() {
+        if expected_idx == 0 && verify_proof(&checkpoint.batch_checkpoint, params).is_ok() {
             result_checkpoints.push(checkpoint.clone());
-            last_valid_checkpoint = Some(checkpoint.batch_info());
+            last_valid_checkpoint = Some(checkpoint.batch_checkpoint.batch_info());
         } else if expected_idx == 0 {
             warn!(%expected_idx, "Received invalid checkpoint proof, ignoring.");
         } else {
@@ -313,8 +314,8 @@ pub fn filter_verified_checkpoints(
             let last_l2_tsn = last_valid_checkpoint
                 .expect("There should be a last_valid_checkpoint")
                 .l2_transition;
-            let l1_tsn = checkpoint.batch_info().l1_transition;
-            let l2_tsn = checkpoint.batch_info().l2_transition;
+            let l1_tsn = checkpoint.batch_checkpoint.batch_info().l1_transition;
+            let l2_tsn = checkpoint.batch_checkpoint.batch_info().l2_transition;
 
             if l1_tsn.0 == last_l1_tsn.1 {
                 warn!(obtained = ?l1_tsn.0, expected = ?last_l1_tsn.1, "Received invalid checkpoint l1 transition, ignoring.");
@@ -324,9 +325,9 @@ pub fn filter_verified_checkpoints(
                 warn!(obtained = ?l2_tsn.0, expected = ?last_l2_tsn.1, "Received invalid checkpoint l2 transition, ignoring.");
                 continue;
             }
-            if verify_proof(checkpoint, params).is_ok() {
+            if verify_proof(&checkpoint.batch_checkpoint, params).is_ok() {
                 result_checkpoints.push(checkpoint.clone());
-                last_valid_checkpoint = Some(checkpoint.batch_info());
+                last_valid_checkpoint = Some(checkpoint.batch_checkpoint.batch_info());
             } else {
                 warn!(%expected_idx, "Received invalid checkpoint proof, ignoring.");
                 continue;

--- a/crates/consensus-logic/src/duty/extractor.rs
+++ b/crates/consensus-logic/src/duty/extractor.rs
@@ -52,6 +52,13 @@ fn extract_batch_duties(
         return Ok(vec![]);
     };
 
+    // BlockHash of last L1 block covered by the checkpoint
+    let Some(tip_blockid) = state.l1_view().tip_blkid() else {
+        debug!("no blocks read from L1");
+        // Cannot create checkpoint without L1 blocks
+        return Ok(vec![]);
+    };
+
     match state.l1_view().last_finalized_checkpoint() {
         // Cool, we are producing first batch!
         None => {
@@ -102,6 +109,7 @@ fn extract_batch_duties(
                 l1_transition,
                 l2_transition,
                 tip_id,
+                *tip_blockid,
                 (0, current_l1_state.total_accumulated_pow),
                 rollup_params_commitment,
             );
@@ -137,6 +145,7 @@ fn extract_batch_duties(
                 l1_transition,
                 l2_transition,
                 tip_id,
+                *tip_blockid,
                 (
                     checkpoint.l1_pow_transition.1,
                     current_l1_state.total_accumulated_pow,

--- a/crates/consensus-logic/src/worker.rs
+++ b/crates/consensus-logic/src/worker.rs
@@ -213,6 +213,8 @@ fn handle_sync_event<D: Database, E: ExecEngineCtl>(
 
             SyncAction::WriteCheckpoints(_height, checkpoints) => {
                 for c in checkpoints.iter() {
+                    let commitment_info = &c.commitment;
+                    let c = &c.batch_checkpoint;
                     let idx = c.batch_info().idx();
                     let pstatus = CheckpointProvingStatus::ProofReady;
                     let cstatus = CheckpointConfStatus::Confirmed;
@@ -222,14 +224,18 @@ fn handle_sync_event<D: Database, E: ExecEngineCtl>(
                         c.proof().clone(),
                         pstatus,
                         cstatus,
+                        Some(commitment_info.clone().into()),
                     );
 
                     // Store
                     state.checkpoint_db().put_checkpoint_blocking(idx, entry)?;
                 }
             }
+            // FIXME: never called
             SyncAction::FinalizeCheckpoints(_height, checkpoints) => {
                 for c in checkpoints.iter() {
+                    let commitment_info = &c.commitment;
+                    let c = &c.batch_checkpoint;
                     let idx = c.batch_info().idx();
                     let pstatus = CheckpointProvingStatus::ProofReady;
                     let cstatus = CheckpointConfStatus::Finalized;
@@ -239,6 +245,7 @@ fn handle_sync_event<D: Database, E: ExecEngineCtl>(
                         c.proof().clone(),
                         pstatus,
                         cstatus,
+                        Some(commitment_info.clone().into()),
                     );
 
                     // Update

--- a/crates/db/src/types.rs
+++ b/crates/db/src/types.rs
@@ -8,7 +8,7 @@ use bitcoin::{
 use borsh::{BorshDeserialize, BorshSerialize};
 use serde::{Deserialize, Serialize};
 use strata_primitives::buf::Buf32;
-use strata_state::batch::{BatchCheckpoint, BatchInfo, BootstrapState};
+use strata_state::batch::{BatchCheckpoint, BatchInfo, BootstrapState, CommitmentInfo};
 use strata_zkvm::Proof;
 
 /// Represents data for a blob we're still planning to inscribe.
@@ -157,6 +157,9 @@ pub struct CheckpointEntry {
 
     /// Confirmation Status
     pub confirmation_status: CheckpointConfStatus,
+
+    /// checkpoint txn info
+    pub commitment: Option<CheckpointCommitment>,
 }
 
 impl CheckpointEntry {
@@ -166,6 +169,7 @@ impl CheckpointEntry {
         proof: Proof,
         proving_status: CheckpointProvingStatus,
         confirmation_status: CheckpointConfStatus,
+        commitment: Option<CheckpointCommitment>,
     ) -> Self {
         Self {
             batch_info,
@@ -173,6 +177,7 @@ impl CheckpointEntry {
             proof,
             proving_status,
             confirmation_status,
+            commitment,
         }
     }
 
@@ -188,6 +193,7 @@ impl CheckpointEntry {
             Proof::default(),
             CheckpointProvingStatus::PendingProof,
             CheckpointConfStatus::Pending,
+            None,
         )
     }
 
@@ -223,6 +229,23 @@ pub enum CheckpointConfStatus {
     Confirmed,
     /// Finalized on L1
     Finalized,
+}
+
+#[derive(Debug, Clone, PartialEq, BorshSerialize, BorshDeserialize, Arbitrary)]
+pub struct CheckpointCommitment {
+    pub blockhash: Buf32,
+    pub txid: Buf32,
+    pub wtxid: Buf32,
+}
+
+impl From<CommitmentInfo> for CheckpointCommitment {
+    fn from(value: CommitmentInfo) -> Self {
+        Self {
+            blockhash: value.blockhash,
+            txid: value.txid,
+            wtxid: value.wtxid,
+        }
+    }
 }
 
 #[cfg(test)]

--- a/crates/proof-impl/checkpoint/src/lib.rs
+++ b/crates/proof-impl/checkpoint/src/lib.rs
@@ -86,6 +86,7 @@ pub fn process_checkpoint_proof(
             l2_batch_output.final_snapshot.hash,
         ),
         l2_batch_output.final_snapshot.l2_blockid,
+        l1_batch_output.final_snapshot.hash.into(),
         (
             l1_batch_output.initial_snapshot.acc_pow,
             l1_batch_output.final_snapshot.acc_pow,

--- a/crates/rpc/api/src/lib.rs
+++ b/crates/rpc/api/src/lib.rs
@@ -98,7 +98,7 @@ pub trait StrataApi {
 
     /// Get latest checkpoint info
     #[method(name = "getLatestCheckpointIndex")]
-    async fn get_latest_checkpoint_index(&self) -> RpcResult<Option<u64>>;
+    async fn get_latest_checkpoint_index(&self, finalized: Option<bool>) -> RpcResult<Option<u64>>;
 
     /// Get nth checkpoint info if any
     #[method(name = "getCheckpointInfo")]

--- a/crates/rpc/types/src/errors.rs
+++ b/crates/rpc/types/src/errors.rs
@@ -27,6 +27,9 @@ pub enum RpcServerError {
     #[error("tried to call chain-related method before rollup genesis")]
     BeforeGenesis,
 
+    #[error("tried to call checkpoint-related method before first checkpoint")]
+    BeforeCheckpoint,
+
     #[error("unknown idx {0}")]
     UnknownIdx(u32),
 
@@ -76,6 +79,7 @@ impl RpcServerError {
             Self::Db(_) => -32605,
             Self::ClientNotStarted => -32606,
             Self::BeforeGenesis => -32607,
+            Self::BeforeCheckpoint => -32613,
             Self::FetchLimitReached(_, _) => -32608,
             Self::UnknownIdx(_) => -32608,
             Self::MissingL1BlockManifest(_) => -32609,

--- a/crates/rpc/types/src/errors.rs
+++ b/crates/rpc/types/src/errors.rs
@@ -27,9 +27,6 @@ pub enum RpcServerError {
     #[error("tried to call chain-related method before rollup genesis")]
     BeforeGenesis,
 
-    #[error("tried to call checkpoint-related method before first checkpoint")]
-    BeforeCheckpoint,
-
     #[error("unknown idx {0}")]
     UnknownIdx(u32),
 
@@ -79,7 +76,6 @@ impl RpcServerError {
             Self::Db(_) => -32605,
             Self::ClientNotStarted => -32606,
             Self::BeforeGenesis => -32607,
-            Self::BeforeCheckpoint => -32613,
             Self::FetchLimitReached(_, _) => -32608,
             Self::UnknownIdx(_) => -32608,
             Self::MissingL1BlockManifest(_) => -32609,

--- a/crates/state/src/batch.rs
+++ b/crates/state/src/batch.rs
@@ -5,7 +5,7 @@ use strata_crypto::verify_schnorr_sig;
 use strata_primitives::buf::{Buf32, Buf64};
 use strata_zkvm::Proof;
 
-use crate::id::L2BlockId;
+use crate::{id::L2BlockId, l1::L1BlockId};
 
 /// Public parameters for batch proof to be posted to DA.
 /// Will be updated as prover specs evolve.
@@ -119,6 +119,9 @@ pub struct BatchInfo {
     /// The last L2 block upto which this checkpoint covers since the previous checkpoint
     pub l2_blockid: L2BlockId,
 
+    /// The last L1 block upto which this checkpoint covers since the previous checkpoint
+    pub l1_blockid: L1BlockId,
+
     /// PoW transition in the given `l1_range`
     pub l1_pow_transition: (u128, u128),
 
@@ -136,6 +139,7 @@ impl BatchInfo {
         l1_transition: (Buf32, Buf32),
         l2_transition: (Buf32, Buf32),
         l2_blockid: L2BlockId,
+        l1_blockid: L1BlockId,
         l1_pow_transition: (u128, u128),
         rollup_params_commitment: Buf32,
     ) -> Self {
@@ -146,6 +150,7 @@ impl BatchInfo {
             l1_transition,
             l2_transition,
             l2_blockid,
+            l1_blockid,
             l1_pow_transition,
             rollup_params_commitment,
         }
@@ -157,6 +162,10 @@ impl BatchInfo {
 
     pub fn l2_blockid(&self) -> &L2BlockId {
         &self.l2_blockid
+    }
+
+    pub fn l1_blockid(&self) -> &L1BlockId {
+        &self.l1_blockid
     }
 
     pub fn initial_l1_state_hash(&self) -> &Buf32 {
@@ -268,6 +277,42 @@ impl CheckpointProofOutput {
         Self {
             batch_info,
             bootstrap_state,
+        }
+    }
+}
+
+#[derive(
+    Clone, Debug, PartialEq, Eq, Arbitrary, BorshSerialize, BorshDeserialize, Serialize, Deserialize,
+)]
+pub struct CommitmentInfo {
+    pub blockhash: Buf32,
+    pub txid: Buf32,
+    pub wtxid: Buf32,
+}
+
+impl CommitmentInfo {
+    pub fn new(blockhash: Buf32, txid: Buf32, wtxid: Buf32) -> Self {
+        Self {
+            blockhash,
+            txid,
+            wtxid,
+        }
+    }
+}
+
+#[derive(
+    Clone, Debug, PartialEq, Eq, Arbitrary, BorshSerialize, BorshDeserialize, Serialize, Deserialize,
+)]
+pub struct BatchCheckpointWithCommitment {
+    pub batch_checkpoint: BatchCheckpoint,
+    pub commitment: CommitmentInfo,
+}
+
+impl BatchCheckpointWithCommitment {
+    pub fn new(batch_checkpoint: BatchCheckpoint, commitment: CommitmentInfo) -> Self {
+        Self {
+            batch_checkpoint,
+            commitment,
         }
     }
 }

--- a/crates/state/src/operation.rs
+++ b/crates/state/src/operation.rs
@@ -7,7 +7,7 @@ use serde::{Deserialize, Serialize};
 use tracing::*;
 
 use crate::{
-    batch::BatchCheckpoint,
+    batch::BatchCheckpointWithCommitment,
     client_state::{ClientState, L1Checkpoint, SyncState},
     id::L2BlockId,
     l1::{HeaderVerificationState, L1BlockId},
@@ -105,11 +105,10 @@ pub enum SyncAction {
     L2Genesis(L1BlockId),
 
     /// Indicates to the worker to write the checkpoints to checkpoint db
-    WriteCheckpoints(u64, Vec<BatchCheckpoint>),
-
+    WriteCheckpoints(u64, Vec<BatchCheckpointWithCommitment>),
     /// Indicates the worker to write the checkpoints to checkpoint db that appear in given L1
     /// height
-    FinalizeCheckpoints(u64, Vec<BatchCheckpoint>),
+    FinalizeCheckpoints(u64, Vec<BatchCheckpointWithCommitment>),
 }
 
 /// Applies client state writes to a target state.

--- a/crates/state/src/sync_event.rs
+++ b/crates/state/src/sync_event.rs
@@ -3,7 +3,7 @@ use borsh::{BorshDeserialize, BorshSerialize};
 use serde::{Deserialize, Serialize};
 
 use crate::{
-    batch::BatchCheckpoint,
+    batch::BatchCheckpointWithCommitment,
     id::L2BlockId,
     l1::{HeaderVerificationState, L1BlockId},
 };
@@ -20,7 +20,7 @@ pub enum SyncEvent {
     L1Revert(u64),
 
     /// New checkpoint posted to L1 in a DA batch at given height.
-    L1DABatch(u64, Vec<BatchCheckpoint>),
+    L1DABatch(u64, Vec<BatchCheckpointWithCommitment>),
 
     /// We've observed that the `genesis_l1_height` has reached maturity
     L1BlockGenesis(u64, HeaderVerificationState),

--- a/functional-tests/constants.py
+++ b/functional-tests/constants.py
@@ -72,6 +72,10 @@ ROLLUP_PARAMS_FOR_DEPOSIT_TX = {
             }
         ]
     },
+    "proof_publish_mode": {
+        # use an empty proof in batch after this many seconds of not receiving a proof
+        "timeout": 5,
+    },
 }
 
 PROVER_ROLLUP_PARAMS = {

--- a/functional-tests/constants.py
+++ b/functional-tests/constants.py
@@ -92,3 +92,12 @@ PROVER_ROLLUP_PARAMS = {
         ]
     },
 }
+
+FAST_CHECKPOINT_ROLLUP_PARAMS = {
+    **DEFAULT_ROLLUP_PARAMS,
+    "l1_reorg_safe_depth": 2,
+    "proof_publish_mode": {
+        # use an empty proof in batch after this many seconds of not receiving a proof
+        "timeout": 4,
+    },
+}

--- a/functional-tests/fn_bridge_withdrawal_duties.py
+++ b/functional-tests/fn_bridge_withdrawal_duties.py
@@ -47,7 +47,7 @@ class BridgeDepositTest(flexitest.Test):
 
         web3.eth.wait_for_transaction_receipt(last_txid, timeout=5)
 
-        # NOTE: this test might be flaky if new checkpoint is already generated at this point 
+        # NOTE: this test might be flaky if new checkpoint is already generated at this point
         duties_resp = seqrpc.strata_getBridgeDuties(operator_idx, start_index)
         assert (
             len(duties_resp["duties"]) == 0

--- a/functional-tests/fn_bridge_withdrawal_duties.py
+++ b/functional-tests/fn_bridge_withdrawal_duties.py
@@ -1,0 +1,137 @@
+import os
+from typing import List
+
+import flexitest
+from bitcoinlib.services.bitcoind import BitcoindClient
+from web3 import Web3
+
+from constants import (
+    DEFAULT_ROLLUP_PARAMS,
+    PRECOMPILE_BRIDGEOUT_ADDRESS,
+    ROLLUP_PARAMS_FOR_DEPOSIT_TX,
+)
+from entry import BasicEnvConfig
+from utils import get_logger, wait_until
+
+
+@flexitest.register
+class BridgeDepositTest(flexitest.Test):
+    def __init__(self, ctx: flexitest.InitContext):
+        ctx.set_env(BasicEnvConfig(101, rollup_params=ROLLUP_PARAMS_FOR_DEPOSIT_TX))
+        self.logger = get_logger("getBridgeDuties")
+
+    def main(self, ctx: flexitest.RunContext):
+        btc = ctx.get_service("bitcoin")
+        seq = ctx.get_service("sequencer")
+        reth = ctx.get_service("reth")
+        web3: Web3 = reth.create_web3()
+
+        seqrpc = seq.create_rpc()
+        btcrpc: BitcoindClient = btc.create_rpc()
+
+        operator_idx = 0
+        start_index = 0
+
+        num_withdrawals = 5
+
+        # make deposit utxo available for withthdrawals to use
+        # FIXME: use deposit request instead
+        self.assign_mock_deposits(web3, btcrpc, num_withdrawals)
+
+        withdrawal_pubkeys = []
+        last_txid = None
+        for _ in range(num_withdrawals):
+            pubkey = os.urandom(32).hex()
+            last_txid = self.do_withdrawal(web3, pubkey)
+            withdrawal_pubkeys.append(pubkey)
+
+        web3.eth.wait_for_transaction_receipt(last_txid, timeout=5)
+
+        # NOTE: this test might be flaky if new checkpoint is already generated at this point 
+        duties_resp = seqrpc.strata_getBridgeDuties(operator_idx, start_index)
+        assert (
+            len(duties_resp["duties"]) == 0
+        ), "no duties should be generated before checkpoint creation"
+
+        # wait for checkpoint
+        prev_checkpoint_idx = int(seqrpc.strata_getLatestCheckpointIndex())
+        wait_until(
+            lambda: int(seqrpc.strata_getLatestCheckpointIndex()) > prev_checkpoint_idx,
+            error_with="Checkpoint not posted in time",
+            timeout=10,
+        )
+        # checkpoint with withdrawals is created but not finalized
+        duties_resp = seqrpc.strata_getBridgeDuties(operator_idx, start_index)
+        assert (
+            len(duties_resp["duties"]) == 0
+        ), "no duties should be generated before checkpoint finalization"
+        wait_until(
+            lambda: int(seqrpc.strata_getLatestCheckpointIndex()) > prev_checkpoint_idx + 1,
+            error_with="Checkpoint not posted in time",
+            timeout=10,
+        )
+        # checkpoint with withdrawals is finalized
+        duties_resp = seqrpc.strata_getBridgeDuties(operator_idx, start_index)
+        assert (
+            len(duties_resp["duties"]) == num_withdrawals
+        ), "duties should be generated after checkpoint finalization"
+
+    def assign_mock_deposits(self, web3: Web3, btcrpc: BitcoindClient, count: int):
+        addr = "bcrt1pzupt5e8eqvt995r57jmmylxlswqfddsscrrq7njygrkhej3e7q2qur0c76"
+        sats_per_btc = 10**8
+        amount_to_send = DEFAULT_ROLLUP_PARAMS["deposit_amount"] / sats_per_btc
+
+        el_address = "deadf001900dca3ebeefdeadf001900dca3ebeef"
+        magic_bytes = DEFAULT_ROLLUP_PARAMS["rollup_name"].encode("utf-8").hex()
+        outputs = [
+            {addr: amount_to_send},
+            {"data": f"{magic_bytes}{el_address}"},
+        ]
+
+        options = {"changePosition": 2}
+
+        for _ in range(count):
+            self.broadcast_tx(btcrpc, outputs, options)
+
+        wei_per_sat = 10_000_000_000
+
+        expected_deposit_wei = DEFAULT_ROLLUP_PARAMS["deposit_amount"] * wei_per_sat * count
+        wait_until(
+            lambda: web3.eth.get_balance(web3.to_checksum_address(el_address))
+            >= expected_deposit_wei,
+            timeout=10,
+        )
+
+    def do_withdrawal(self, web3: Web3, dest_pk: str) -> str:
+        source = web3.address
+        dest = web3.to_checksum_address(PRECOMPILE_BRIDGEOUT_ADDRESS)
+
+        # 10 rollup btc as wei
+        to_transfer_wei = 10_000_000_000_000_000_000
+
+        txid = web3.eth.send_transaction(
+            {
+                "to": dest,
+                "value": hex(to_transfer_wei),
+                "gas": hex(100000),
+                "from": source,
+                "data": dest_pk,
+            }
+        )
+        # print("txid", txid.to_0x_hex())
+        # receipt = web3.eth.wait_for_transaction_receipt(txid, timeout=5)
+        # assert receipt.status == 1, "precompile transaction failed"
+        return txid
+
+    def broadcast_tx(self, btcrpc: BitcoindClient, outputs: List[dict], options: dict) -> str:
+        psbt_result = btcrpc.proxy.walletcreatefundedpsbt([], outputs, 0, options)
+        psbt = psbt_result["psbt"]
+
+        signed_psbt = btcrpc.proxy.walletprocesspsbt(psbt)
+
+        finalized_psbt = btcrpc.proxy.finalizepsbt(signed_psbt["psbt"])
+        deposit_tx = finalized_psbt["hex"]
+
+        txid = btcrpc.sendrawtransaction(deposit_tx).get("txid", "")
+
+        return txid

--- a/functional-tests/fn_cl_checkpoint.py
+++ b/functional-tests/fn_cl_checkpoint.py
@@ -2,6 +2,10 @@ import time
 
 import flexitest
 
+from constants import (
+    FAST_CHECKPOINT_ROLLUP_PARAMS,
+)
+from entry import BasicEnvConfig
 from utils import wait_until
 
 REORG_DEPTH = 3
@@ -10,7 +14,9 @@ REORG_DEPTH = 3
 @flexitest.register
 class CLBlockWitnessDataGenerationTest(flexitest.Test):
     def __init__(self, ctx: flexitest.InitContext):
-        ctx.set_env("basic")
+        ctx.set_env(
+            BasicEnvConfig(pre_generate_blocks=101, rollup_params=FAST_CHECKPOINT_ROLLUP_PARAMS)
+        )
 
     def main(self, ctx: flexitest.RunContext):
         seq = ctx.get_service("sequencer")
@@ -28,3 +34,15 @@ class CLBlockWitnessDataGenerationTest(flexitest.Test):
 
         ckp = seqrpc.strata_getCheckpointInfo(ckp_idx)
         assert ckp is not None
+        assert ckp["commitment"] is None
+
+        # wait for checkpoint confirmation
+        wait_until(
+            lambda: seqrpc.strata_getLatestCheckpointIndex() > ckp_idx,
+            error_with="Checkpoint was not confirmed on time",
+            timeout=10,
+        )
+        ckp = seqrpc.strata_getCheckpointInfo(ckp_idx)
+        # print(ckp)
+        assert ckp is not None
+        assert ckp["commitment"] is not None

--- a/functional-tests/fn_cl_checkpoint.py
+++ b/functional-tests/fn_cl_checkpoint.py
@@ -1,5 +1,3 @@
-import time
-
 import flexitest
 
 from constants import (
@@ -28,17 +26,15 @@ class CLBlockWitnessDataGenerationTest(flexitest.Test):
             error_with="Sequencer did not start on time",
         )
 
-        time.sleep(1)
         ckp_idx = seqrpc.strata_getLatestCheckpointIndex()
         assert ckp_idx is not None
 
         ckp = seqrpc.strata_getCheckpointInfo(ckp_idx)
         assert ckp is not None
-        assert ckp["commitment"] is None
 
         # wait for checkpoint confirmation
         wait_until(
-            lambda: seqrpc.strata_getLatestCheckpointIndex() > ckp_idx,
+            lambda: seqrpc.strata_getLatestCheckpointIndex(True) >= ckp_idx,
             error_with="Checkpoint was not confirmed on time",
             timeout=10,
         )


### PR DESCRIPTION
## Description
* Generate bridge withdrawal duties from last finalized checkpoint state
* `getLatestCheckpointIndex` rpc call takes optional boolean param to get latest finalized checkpoint index (if passed true, default false)
* `getCheckpointInfo` rpc response has additional fields:
  * `l1_blockid` : blockhash of last L1 block covered by checkpoint
  * `commitment.blockhash` : blockhash of L1 block which contains this checkpoint
  * `commitment.txid` : txid for this checkpoint inscription (reveal) transaction
  * `commitment.wtxid` : wtxid for this checkpoint inscription (reveal) transaction

<!--
Provide a brief summary of the changes and the motivation behind them.
-->

### Type of Change

<!--
Select the type of change your PR introduces (put an `x` in all that apply):-
-->

-   [ ] Bug fix (non-breaking change which fixes an issue)
-   [x] New feature/Enhancement (non-breaking change which adds functionality or enhances an existing one)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] Documentation update
-   [ ] Refactor
-   [ ] New or updated tests

## Checklist

<!--
Ensure all the following are checked:
-->

-   [x] I have performed a self-review of my code.
-   [x] I have commented my code where necessary.
-   [ ] I have updated the documentation if needed.
-   [ ] My changes do not introduce new warnings.
-   [x] I have added tests that prove my changes are effective or that my feature works.
-   [x] New and existing tests pass with my changes.

## Related Issues

<!--
Link any related issues (e.g., `closes #123`, `fixes #456`).
-->
