### PR TITLE
writer: Add retries with exponential backoff when signing fails

### DIFF
--- a/crates/btcio/src/writer/builder.rs
+++ b/crates/btcio/src/writer/builder.rs
@@ -33,6 +33,7 @@ use tracing::trace;
 
 use crate::{
     rpc::{
+        error::ClientError,
         traits::{Reader, Signer, Wallet},
         types::ListUnspent,
     },
@@ -50,6 +51,9 @@ pub enum InscriptionError {
 
     #[error("Error building taproot")]
     Taproot(#[from] TaprootBuilderError),
+
+    #[error("Sign error: {0}")]
+    SigningFailed(#[from] ClientError),
 
     #[error("{0}")]
     Other(#[from] anyhow::Error),

--- a/crates/btcio/src/writer/signer.rs
+++ b/crates/btcio/src/writer/signer.rs
@@ -33,13 +33,8 @@ pub async fn create_and_sign_blob_inscriptions(
 
     let ctxid = commit.compute_txid();
     debug!(commit_txid = ?ctxid, "Signing commit transaction");
-    let signed_commit = client
-        .sign_raw_transaction_with_wallet(&commit)
-        .await
-        .expect("could not sign commit tx")
-        .hex;
-
-    let signed_commit: Transaction = consensus::encode::deserialize_hex(&signed_commit)
+    let signed_tx_raw = client.sign_raw_transaction_with_wallet(&commit).await?.hex;
+    let signed_commit: Transaction = consensus::encode::deserialize_hex(&signed_tx_raw)
         .expect("could not deserialize transaction");
     let cid: Buf32 = signed_commit.compute_txid().into();
     let rid: Buf32 = reveal.compute_txid().into();

--- a/provers/sp1/Cargo.toml
+++ b/provers/sp1/Cargo.toml
@@ -38,5 +38,5 @@ tracing.workspace = true
 
 [features]
 default = ["prover"]
-prover = ["dep:strata-sp1-adapter"]
 docker-build = []
+prover = ["dep:strata-sp1-adapter"]

--- a/provers/sp1/guest-checkpoint/Cargo.toml
+++ b/provers/sp1/guest-checkpoint/Cargo.toml
@@ -22,5 +22,5 @@ strata-zkvm = { path = "../../../crates/zkvm/zkvm" }
 substrate-bn = { git = "https://github.com/sp1-patches/bn", branch = "patch-v0.7.0" }
 
 [patch.crates-io]
-sha2-v0-10-8 = { git = "https://github.com/sp1-patches/RustCrypto-hashes", package = "sha2", branch = "patch-sha2-v0.10.8" }
 secp256k1 = { git = "https://github.com/sp1-patches/rust-secp256k1", branch = "patch-secp256k1-v0.29.1" }
+sha2-v0-10-8 = { git = "https://github.com/sp1-patches/RustCrypto-hashes", package = "sha2", branch = "patch-sha2-v0.10.8" }

--- a/provers/sp1/guest-evm-ee-stf/Cargo.toml
+++ b/provers/sp1/guest-evm-ee-stf/Cargo.toml
@@ -11,8 +11,8 @@ sp1-zkvm = "2.0.0"
 strata-proofimpl-evm-ee-stf = { path = "../../../crates/proof-impl/evm-ee-stf" }
 
 [patch.crates-io]
-secp256k1 = { git = "https://github.com/sp1-patches/rust-secp256k1", branch = "patch-secp256k1-v0.29.1" }
-tiny-keccak = { git = "https://github.com/sp1-patches/tiny-keccak", branch = "patch-v2.0.2" }
-sha2-v0-10-8 = { git = "https://github.com/sp1-patches/RustCrypto-hashes", package = "sha2", branch = "patch-sha2-v0.10.8" }
 revm = { git = "https://github.com/sp1-patches/revm-new", branch = "john/update-for-v1" }
 revm-primitives = { git = "https://github.com/sp1-patches/revm-new", branch = "john/update-for-v1" }
+secp256k1 = { git = "https://github.com/sp1-patches/rust-secp256k1", branch = "patch-secp256k1-v0.29.1" }
+sha2-v0-10-8 = { git = "https://github.com/sp1-patches/RustCrypto-hashes", package = "sha2", branch = "patch-sha2-v0.10.8" }
+tiny-keccak = { git = "https://github.com/sp1-patches/tiny-keccak", branch = "patch-v2.0.2" }

--- a/provers/sp1/guest-l1-batch/Cargo.toml
+++ b/provers/sp1/guest-l1-batch/Cargo.toml
@@ -18,5 +18,5 @@ strata-state = { path = "../../../crates/state" }
 strata-tx-parser = { path = "../../../crates/tx-parser" }
 
 [patch.crates-io]
-sha2-v0-10-8 = { git = "https://github.com/sp1-patches/RustCrypto-hashes", package = "sha2", branch = "patch-sha2-v0.10.8" }
 secp256k1 = { git = "https://github.com/sp1-patches/rust-secp256k1", branch = "patch-secp256k1-v0.29.1" }
+sha2-v0-10-8 = { git = "https://github.com/sp1-patches/RustCrypto-hashes", package = "sha2", branch = "patch-sha2-v0.10.8" }


### PR DESCRIPTION
## Description

This PR adds an exponential backoff based retry when creating/signing of blob inscriptions fails. Currently, the task would fail whenever the inscription failed. Now it fails only if max retries exceeds.

### Type of Change

<!--
Select the type of change your PR introduces (put an `x` in all that apply):-
-->

-   [ ] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature/Enhancement (non-breaking change which adds functionality or enhances an existing one)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] Documentation update
-   [x] Refactor
-   [ ] New or updated tests

## Checklist

<!--
Ensure all the following are checked:
-->

-   [ ] I have performed a self-review of my code.
-   [ ] I have commented my code where necessary.
-   [ ] I have updated the documentation if needed.
-   [ ] My changes do not introduce new warnings.
-   [ ] I have added tests that prove my changes are effective or that my feature works.
-   [ ] New and existing tests pass with my changes.

## Related Issues

<!--
Link any related issues (e.g., `closes #123`, `fixes #456`).
-->
