### PR TITLE
backport: print strata explorer links if configured (#453)

### DIFF
--- a/bin/strata-cli/src/cmd/deposit.rs
+++ b/bin/strata-cli/src/cmd/deposit.rs
@@ -21,7 +21,7 @@ use crate::{
     recovery::DescriptorRecovery,
     seed::Seed,
     settings::Settings,
-    signet::{get_fee_rate, log_fee_rate, print_explorer_url, SignetWallet},
+    signet::{get_fee_rate, log_fee_rate, print_bitcoin_explorer_url, SignetWallet},
     strata::StrataWallet,
     taproot::{ExtractP2trPubkey, NotTaprootAddress},
 };
@@ -148,7 +148,7 @@ pub async fn deposit(
         .expect("successful broadcast");
     let txid = tx.compute_txid();
     pb.finish_with_message(format!("Transaction {} broadcasted", txid));
-    let _ = print_explorer_url(&txid, &term, &settings);
+    let _ = print_bitcoin_explorer_url(&txid, &term, &settings);
     let _ = term.write_line(&format!(
         "Expect transaction confirmation in ~{:?}. Funds will take longer than this to be available on Strata.",
         SIGNET_BLOCK_TIME

--- a/bin/strata-cli/src/cmd/drain.rs
+++ b/bin/strata-cli/src/cmd/drain.rs
@@ -12,8 +12,8 @@ use crate::{
     constants::SATS_TO_WEI,
     seed::Seed,
     settings::Settings,
-    signet::{get_fee_rate, log_fee_rate, print_explorer_url, SignetWallet},
-    strata::StrataWallet,
+    signet::{get_fee_rate, log_fee_rate, print_bitcoin_explorer_url, SignetWallet},
+    strata::{print_strata_explorer_url, StrataWallet},
 };
 
 /// Drains the internal wallet to the provided
@@ -83,7 +83,7 @@ pub async fn drain(
         l1w.sign(&mut psbt, Default::default()).unwrap();
         let tx = psbt.extract_tx().expect("fully signed tx");
         settings.signet_backend.broadcast_tx(&tx).await.unwrap();
-        let _ = print_explorer_url(&tx.compute_txid(), &term, &settings);
+        let _ = print_bitcoin_explorer_url(&tx.compute_txid(), &term, &settings);
         let _ = term.write_line(&format!("Drained signet wallet to {}", address,));
     }
 
@@ -108,7 +108,9 @@ pub async fn drain(
 
         let tx = l2w.transaction_request().to(address).value(max_send_amount);
 
-        let _ = l2w.send_transaction(tx).await.unwrap();
+        let res = l2w.send_transaction(tx).await.unwrap();
+
+        let _ = print_strata_explorer_url(res.tx_hash(), &term, &settings);
 
         let _ = term.write_line(&format!(
             "Drained {} from Strata wallet to {}",

--- a/bin/strata-cli/src/cmd/faucet.rs
+++ b/bin/strata-cli/src/cmd/faucet.rs
@@ -23,7 +23,7 @@ use crate::{
 use crate::{
     seed::Seed,
     settings::Settings,
-    signet::{print_explorer_url, SignetWallet},
+    signet::{print_bitcoin_explorer_url, SignetWallet},
 };
 
 /// Request some bitcoin from the faucet
@@ -170,14 +170,14 @@ pub async fn faucet(args: FaucetArgs, seed: Seed, settings: Settings) {
     if status == StatusCode::OK {
         #[cfg(feature = "strata_faucet")]
         if network_type == NetworkType::Signet {
-            let _ = print_explorer_url(
+            let _ = print_bitcoin_explorer_url(
                 &Txid::from_str(&body).expect("valid txid"),
                 &term,
                 &settings,
             );
         }
         #[cfg(not(feature = "strata_faucet"))]
-        let _ = print_explorer_url(
+        let _ = print_bitcoin_explorer_url(
             &Txid::from_str(&body).expect("valid txid"),
             &term,
             &settings,

--- a/bin/strata-cli/src/cmd/send.rs
+++ b/bin/strata-cli/src/cmd/send.rs
@@ -15,8 +15,8 @@ use crate::{
     net_type::{net_type_or_exit, NetworkType},
     seed::Seed,
     settings::Settings,
-    signet::{get_fee_rate, log_fee_rate, print_explorer_url, SignetWallet},
-    strata::StrataWallet,
+    signet::{get_fee_rate, log_fee_rate, print_bitcoin_explorer_url, SignetWallet},
+    strata::{print_strata_explorer_url, StrataWallet},
 };
 
 /// Send some bitcoin from the internal wallet.
@@ -72,7 +72,7 @@ pub async fn send(args: SendArgs, seed: Seed, settings: Settings) {
                 .broadcast_tx(&tx)
                 .await
                 .expect("successful broadcast");
-            let _ = print_explorer_url(&tx.compute_txid(), &term, &settings);
+            let _ = print_bitcoin_explorer_url(&tx.compute_txid(), &term, &settings);
         }
         NetworkType::Strata => {
             let l2w = StrataWallet::new(&seed, &settings.strata_endpoint).expect("valid wallet");
@@ -84,7 +84,7 @@ pub async fn send(args: SendArgs, seed: Seed, settings: Settings) {
                 .send_transaction(tx)
                 .await
                 .expect("successful broadcast");
-            let _ = term.write_line(&format!("Transaction {} sent", res.tx_hash()));
+            let _ = print_strata_explorer_url(res.tx_hash(), &term, &settings);
         }
     };
 

--- a/bin/strata-cli/src/cmd/withdraw.rs
+++ b/bin/strata-cli/src/cmd/withdraw.rs
@@ -14,7 +14,7 @@ use crate::{
     seed::Seed,
     settings::Settings,
     signet::SignetWallet,
-    strata::StrataWallet,
+    strata::{print_strata_explorer_url, StrataWallet},
     taproot::ExtractP2trPubkey,
 };
 
@@ -69,6 +69,6 @@ pub async fn withdraw(args: WithdrawArgs, seed: Seed, settings: Settings) {
     let pb = ProgressBar::new_spinner().with_message("Broadcasting transaction");
     pb.enable_steady_tick(Duration::from_millis(100));
     let res = l2w.send_transaction(tx).await.unwrap();
-    let txid = res.tx_hash();
-    pb.finish_with_message(format!("Broadcast successful. Txid: {}", txid));
+    pb.finish_with_message("Broadcast successful");
+    let _ = print_strata_explorer_url(res.tx_hash(), &term, &settings);
 }

--- a/bin/strata-cli/src/settings.rs
+++ b/bin/strata-cli/src/settings.rs
@@ -29,7 +29,8 @@ pub struct SettingsFromFile {
     pub bitcoind_rpc_endpoint: Option<String>,
     pub strata_endpoint: String,
     pub faucet_endpoint: String,
-    pub mempool_endpoint: String,
+    pub mempool_endpoint: Option<String>,
+    pub blockscout_endpoint: Option<String>,
     pub bridge_pubkey: Option<Hex<[u8; 32]>>,
     pub network: Option<Network>,
 }
@@ -44,7 +45,8 @@ pub struct Settings {
     pub faucet_endpoint: String,
     pub bridge_musig2_pubkey: XOnlyPublicKey,
     pub descriptor_db: PathBuf,
-    pub mempool_endpoint: String,
+    pub mempool_space_endpoint: Option<String>,
+    pub blockscout_endpoint: Option<String>,
     pub bridge_strata_address: StrataAddress,
     pub linux_seed_file: PathBuf,
     pub network: Network,
@@ -106,7 +108,6 @@ impl Settings {
             strata_endpoint: from_file.strata_endpoint,
             data_dir: proj_dirs.data_dir().to_owned(),
             faucet_endpoint: from_file.faucet_endpoint,
-            mempool_endpoint: from_file.mempool_endpoint,
             bridge_musig2_pubkey: XOnlyPublicKey::from_slice(&match from_file.bridge_pubkey {
                 Some(key) => key.0,
                 None => {
@@ -116,12 +117,14 @@ impl Settings {
                 }
             })
             .expect("valid length"),
-            config_file: CONFIG_FILE.clone(),
-            network: from_file.network.unwrap_or(DEFAULT_NETWORK),
             descriptor_db: descriptor_file,
+            mempool_space_endpoint: from_file.mempool_endpoint,
+            blockscout_endpoint: from_file.blockscout_endpoint,
             bridge_strata_address: StrataAddress::from_str(BRIDGE_STRATA_ADDRESS)
                 .expect("valid strata address"),
             linux_seed_file,
+            network: from_file.network.unwrap_or(DEFAULT_NETWORK),
+            config_file: CONFIG_FILE.clone(),
             signet_backend: sync_backend,
         })
     }

--- a/bin/strata-cli/src/signet.rs
+++ b/bin/strata-cli/src/signet.rs
@@ -44,11 +44,18 @@ pub async fn get_fee_rate(
     }
 }
 
-pub fn print_explorer_url(txid: &Txid, term: &Term, settings: &Settings) -> Result<(), io::Error> {
-    term.write_line(&format!(
-        "View transaction at {}",
-        style(format!("{}/tx/{txid}", settings.mempool_endpoint)).blue()
-    ))
+pub fn print_bitcoin_explorer_url(
+    txid: &Txid,
+    term: &Term,
+    settings: &Settings,
+) -> Result<(), io::Error> {
+    term.write_line(&match settings.mempool_space_endpoint {
+        Some(ref url) => format!(
+            "View transaction at {}",
+            style(format!("{url}/tx/{txid}")).blue()
+        ),
+        None => format!("Transaction ID: {txid}"),
+    })
 }
 
 #[derive(Clone, Debug)]

--- a/bin/strata-cli/src/strata.rs
+++ b/bin/strata-cli/src/strata.rs
@@ -1,7 +1,11 @@
-use std::ops::{Deref, DerefMut};
+use std::{
+    io,
+    ops::{Deref, DerefMut},
+};
 
 use alloy::{
     network::{Ethereum, EthereumWallet},
+    primitives::TxHash,
     providers::{
         fillers::{
             BlobGasFiller, ChainIdFiller, FillProvider, GasFiller, JoinFill, NonceFiller,
@@ -11,8 +15,23 @@ use alloy::{
     },
     transports::http::{Client, Http},
 };
+use console::{style, Term};
 
-use crate::seed::Seed;
+use crate::{seed::Seed, settings::Settings};
+
+pub fn print_strata_explorer_url(
+    txid: &TxHash,
+    term: &Term,
+    settings: &Settings,
+) -> Result<(), io::Error> {
+    term.write_line(&match settings.blockscout_endpoint {
+        Some(ref url) => format!(
+            "View transaction at {}",
+            style(format!("{url}/tx/{txid}")).blue()
+        ),
+        None => format!("Transaction ID: {txid}"),
+    })
+}
 
 // alloy moment 💀
 type Provider = FillProvider<


### PR DESCRIPTION
## Description

Backport `strata-cli` feature to show blockscout links to withdraw transactions.

Blocked by https://github.com/alpenlabs/private-docs/pull/51

- [ ] Tag `0.1.1` since https://github.com/alpenlabs/private-docs/pull/51/commits/7ba2d2143fd41dba1119d6c628bdaa7dfbe58b0a

### Type of Change


-   [ ] Bug fix (non-breaking change which fixes an issue)
-   [x] New feature/Enhancement (non-breaking change which adds functionality or enhances an existing one)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] Documentation update
-   [ ] Refactor
-   [ ] New or updated tests

## Checklist


-   [x] I have performed a self-review of my code.
-   [x] I have commented my code where necessary.
-   [x] I have updated the documentation if needed.
-   [x] My changes do not introduce new warnings.
-   [x] I have added tests that prove my changes are effective or that my feature works.
-   [x] New and existing tests pass with my changes.

## Related Issues

STR-554