### PR TITLE
func-test: bridge deposit reclaim operator seen DRT

### DIFF
--- a/functional-tests/constants.py
+++ b/functional-tests/constants.py
@@ -43,7 +43,8 @@ SEQ_PUBKEY = Key(SEQ_KEY.hex()).x_hex
 # TODO initialize this with the new genesis tool instead of having it hardcoded
 DEFAULT_ROLLUP_PARAMS: dict = {
     "rollup_name": "alpenstrata",
-    "block_time": DEFAULT_BLOCK_TIME_SEC * 1000,
+    "block_time": int(DEFAULT_BLOCK_TIME_SEC * 1_000),
+    "message_interval": int((DEFAULT_BLOCK_TIME_SEC * 1_000) / 2),
     "cred_rule": {
         "schnorr_key": SEQ_PUBKEY,
     },

--- a/functional-tests/entry.py
+++ b/functional-tests/entry.py
@@ -368,9 +368,11 @@ def main(argv):
     }
 
     global_envs = {
+        # Basic env is the default env for all tests.
         "basic": BasicEnvConfig(101),
-        # TODO can we consolidate this with the basic env now?
-        "premined_blocks": BasicEnvConfig(101),
+        # Operator lag is a test that checks if the bridge can handle operator lag.
+        # It is also useful for testing the reclaim path.
+        "operator_lag": BasicEnvConfig(101, message_interval=10 * 60 * 1_000),
         "fast_batches": BasicEnvConfig(101, rollup_settings=net_settings.get_fast_batch_settings()),
         "hub1": HubNetworkEnvConfig(),
         "prover": BasicEnvConfig(101, enable_prover_client=True),

--- a/functional-tests/entry.py
+++ b/functional-tests/entry.py
@@ -64,6 +64,7 @@ class BasicEnvConfig(flexitest.EnvConfig):
         enable_prover_client: bool = False,
         pre_fund_addrs: bool = True,
         n_operators: int = 2,
+        message_interval: int = DEFAULT_ROLLUP_PARAMS["message_interval"],
     ):
         super().__init__()
         self.pre_generate_blocks = pre_generate_blocks
@@ -72,6 +73,7 @@ class BasicEnvConfig(flexitest.EnvConfig):
         self.enable_prover_client = enable_prover_client
         self.pre_fund_addrs = pre_fund_addrs
         self.n_operators = n_operators
+        self.message_interval = message_interval
 
     def init(self, ctx: flexitest.EnvContext) -> flexitest.LiveEnv:
         btc_fac = ctx.get_factory("bitcoin")
@@ -189,7 +191,9 @@ class BasicEnvConfig(flexitest.EnvConfig):
             with open(xpriv_path) as f:
                 xpriv = f.read().strip()
             seq_url = sequencer.get_prop("rpc_url")
-            br = bridge_fac.create_operator(xpriv, seq_url, bitcoind_config)
+            br = bridge_fac.create_operator(
+                xpriv, seq_url, bitcoind_config, message_interval=self.message_interval
+            )
             name = f"bridge.{i}"
             svcs[name] = br
 

--- a/functional-tests/factory.py
+++ b/functional-tests/factory.py
@@ -312,6 +312,7 @@ class BridgeClientFactory(flexitest.Factory):
         node_url: str,
         bitcoind_config: dict,
         ctx: flexitest.EnvContext,
+        message_interval: int = DEFAULT_ROLLUP_PARAMS["message_interval"],
     ):
         idx = self.next_idx()
         name = f"bridge.{idx}"
@@ -332,6 +333,7 @@ class BridgeClientFactory(flexitest.Factory):
             "--btc-user", bitcoind_config["bitcoind_user"],
             "--btc-pass", bitcoind_config["bitcoind_pass"],
             "--rollup-url", node_url,
+            "--message-interval", str(message_interval),
         ]
         # fmt: on
 

--- a/functional-tests/fn_bridge_deposit_reclaim.py
+++ b/functional-tests/fn_bridge_deposit_reclaim.py
@@ -9,131 +9,68 @@ from strata_utils import (
     take_back_transaction,
 )
 
-from constants import (
-    DEFAULT_ROLLUP_PARAMS,
-    DEFAULT_TAKEBACK_TIMEOUT,
-    UNSPENDABLE_ADDRESS,
-)
-from entry import BasicEnvConfig
-from utils import get_bridge_pubkey, get_logger, wait_until
-
-# Local constants
-# D BTC
-DEPOSIT_AMOUNT = DEFAULT_ROLLUP_PARAMS["deposit_amount"]
-# Fee for the take back path at 2 sat/vbyte
-TAKE_BACK_FEE = 17_243
+from constants import DEFAULT_ROLLUP_PARAMS, DEFAULT_TAKEBACK_TIMEOUT, UNSPENDABLE_ADDRESS
+from utils import get_bridge_pubkey, get_logger
 
 
 @flexitest.register
-class BridgeDepositReclaimDrtSeenTest(flexitest.Test):
+class BridgeDepositReclaimTest(flexitest.Test):
     """
-    Tests the functionality of broadcasting a deposit request transaction (DRT) for the bridge
+    A test class for reclaim path scenarios of bridge deposits.
+
+    It tests the functionality of broadcasting a deposit request transaction (DRT) for the bridge
     and verifying that the reclaim path works as expected.
 
     In the test we stop one of the bridge operators to prevent the DRT from being processed.
-    However, we let the operator be aware of the DRT before stopping it
     """
 
     def __init__(self, ctx: flexitest.InitContext):
-        ctx.set_env(
-            BasicEnvConfig(
-                pre_generate_blocks=101,
-                auto_generate_blocks=False,
-            )
-        )
-        self.logger = get_logger("BridgeDepositReclaimDrtSeenTest")
+        ctx.set_env("basic")
+        self.logger = get_logger("BridgeDepositReclaimTest")
 
     def main(self, ctx: flexitest.RunContext):
         btc = ctx.get_service("bitcoin")
-        seq = ctx.get_service("sequencer")
         reth = ctx.get_service("reth")
-
-        seqrpc = seq.create_rpc()
-        btcrpc: BitcoindClient = btc.create_rpc()
-        rethrpc = reth.create_rpc()
-
+        seq = ctx.get_service("sequencer")
         # We just need to stop one bridge operator
         bridge_operator = ctx.get_service("bridge.0")
         # Kill the operator so the bridge does not process the DRT transaction
         bridge_operator.stop()
         self.logger.debug("Bridge operators stopped")
 
+        btcrpc: BitcoindClient = btc.create_rpc()
         btc_url = btcrpc.base_url
         btc_user = btc.props["rpc_user"]
         btc_password = btc.props["rpc_password"]
+
+        rethrpc = reth.create_rpc()
+
+        seqrpc = seq.create_rpc()
 
         self.logger.debug(f"BTC URL: {btc_url}")
         self.logger.debug(f"BTC user: {btc_user}")
         self.logger.debug(f"BTC password: {btc_password}")
 
         bridge_pk = get_bridge_pubkey(seqrpc)
-        self.logger.debug(f"Bridge pubkey: {bridge_pk}")
-        el_address = "deadf001900dca3ebeefdeadf001900dca3ebeef"
-        self.logger.debug(f"EL address: {el_address}")
-        addr = get_address(0)
-        self.logger.debug(f"Address: {addr}")
-        refund_addr = get_address(1)
-        self.logger.debug(f"Refund address: {refund_addr}")
-        recovery_addr = get_recovery_address(0, bridge_pk)
-        self.logger.debug(f"Recovery Address: {recovery_addr}")
-
-        seq_addr = seq.get_prop("address")
-        self.logger.debug(f"Sequencer Address: {seq_addr}")
+        el_address = ctx.env.gen_el_address()
+        refund_addr = ctx.env.gen_ext_btc_address()
+        recovery_addr = ctx.env.gen_rec_btc_address()
 
         # First let's see if the EVM side has no funds
         # Make sure that the el_address has zero balance
         balance = int(rethrpc.eth_getBalance(f"0x{el_address}"), 16)
         assert balance == 0, "EVM balance is not zero"
 
-        # Also make sure that the all addresses have zero balance
-        btc_addr_balance = get_balance(
-            addr,
-            btc_url,
-            btc_user,
-            btc_password,
-        )
-        self.logger.debug(f"Address BTC balance (before DRT): {btc_addr_balance}")
-        assert btc_addr_balance == 0, "Address BTC balance is not zero"
-        btc_refund_balance = get_balance(
+        # Make sure that the BTC refund address has the expected balance
+        initial_refund_btc_balance = get_balance(
             refund_addr,
             btc_url,
             btc_user,
             btc_password,
         )
-        self.logger.debug(f"Refund BTC balance (before DRT): {btc_refund_balance}")
-        assert btc_refund_balance == 0, "Refund BTC balance is not zero"
-        btc_recovery_balance = get_balance_recovery(
-            recovery_addr,
-            bridge_pk,
-            btc_url,
-            btc_user,
-            btc_password,
-        )
-        self.logger.debug(f"DRT BTC balance (before DRT): {btc_recovery_balance}")
-        assert btc_recovery_balance == 0, "Recovery BTC balance is not zero"
-
-        # Generate Plenty of BTC to address for the DRT
-        self.logger.debug(f"Generating 102 blocks to address: {addr}")
-        btcrpc.proxy.generatetoaddress(102, addr)
-        self.logger.debug(f"Generated 102 blocks to address: {addr}")
-        wait_until(lambda: get_balance(addr, btc_url, btc_user, btc_password) > 0)
-
-        # Generate Plenty of BTC to recovery address for the take back path
-        self.logger.debug(f"Generating 102 blocks to recovery address: {recovery_addr}")
-        btcrpc.proxy.generatetoaddress(102, recovery_addr)
-        self.logger.debug(f"Generated 110 blocks to recovery address: {recovery_addr}")
-        wait_until(
-            lambda: get_balance_recovery(recovery_addr, bridge_pk, btc_url, btc_user, btc_password)
-            > 0
-        )
-        balance_recovery = get_balance_recovery(
-            recovery_addr, bridge_pk, btc_url, btc_user, btc_password
-        )
-        self.logger.debug(f"Recovery BTC balance: {balance_recovery}")
-        assert balance_recovery > 0, "Recovery BTC balance is not positive"
 
         # DRT same block
-        txid_drt = self.make_drt(ctx, el_address, bridge_pk)
+        txid_drt = self.make_drt(ctx, el_address, bridge_pk, maturity=0)
         self.logger.debug(f"Deposit Request Transaction: {txid_drt}")
         time.sleep(1)
 
@@ -150,7 +87,7 @@ class BridgeDepositReclaimDrtSeenTest(flexitest.Test):
             btcrpc.proxy.generatetoaddress(blocks_to_generate, UNSPENDABLE_ADDRESS)
 
         # wait up a little bit
-        time.sleep(1)
+        time.sleep(0.25)
 
         # Make sure that the BTC refund address has the expected balance
         refund_btc_balance = get_balance(
@@ -159,8 +96,8 @@ class BridgeDepositReclaimDrtSeenTest(flexitest.Test):
             btc_user,
             btc_password,
         )
-        self.logger.debug(f"Refund BTC balance (before takeback): {refund_btc_balance}")
-        assert refund_btc_balance == 0, "Refund BTC balance is not zero"
+        self.logger.debug(f"User BTC balance (before takeback): {refund_btc_balance}")
+        assert refund_btc_balance == initial_refund_btc_balance, "BTC balance has changed"
 
         # Spend the take back path
         take_back_tx = bytes(
@@ -172,40 +109,59 @@ class BridgeDepositReclaimDrtSeenTest(flexitest.Test):
         txid = btcrpc.proxy.sendrawtransaction(take_back_tx)
         self.logger.debug(f"sent take back tx with txid = {txid} for address {el_address}")
         btcrpc.proxy.generatetoaddress(2, UNSPENDABLE_ADDRESS)
-        wait_until(lambda: get_balance(refund_addr, btc_url, btc_user, btc_password) > 0)
+        time.sleep(1)
+
+        # Make sure that the BTC recovery address has 0 BTC
+        btc_balance = get_balance_recovery(
+            recovery_addr,
+            bridge_pk,
+            btc_url,
+            btc_user,
+            btc_password,
+        )
+        self.logger.debug(f"DRT BTC balance (after takeback): {btc_balance}")
+        assert btc_balance == 0, "BTC balance is not zero"
 
         # Make sure that the BTC refund address has the expected balance
-        refund_btc_balance_post = get_balance(
+        refund_btc_balance = get_balance(
             refund_addr,
             btc_url,
             btc_user,
             btc_password,
         )
-        self.logger.debug(f"Refund BTC balance (after takeback): {refund_btc_balance_post}")
+        self.logger.debug(f"User BTC balance (after takeback): {refund_btc_balance}")
+        expected_balance_lower_bound = DEFAULT_ROLLUP_PARAMS["deposit_amount"] - 100_000_000
+        assert refund_btc_balance >= expected_balance_lower_bound, "BTC balance is not as expected"
 
-        assert (
-            refund_btc_balance_post == balance_recovery - TAKE_BACK_FEE
-        ), "Refund BTC balance is not expected"
+        # Now let's see if the EVM side has no funds
+        # Make sure that the el_address has zero balance
+        balance = int(rethrpc.eth_getBalance(f"0x{el_address}"), 16)
+        self.logger.debug(f"EVM balance (after takeback): {balance}")
+        assert balance == 0, "EVM balance is not zero"
 
-        # Get the balance of the EL address after the deposits
-        balance_post = int(rethrpc.eth_getBalance(el_address), 16)
-        self.logger.debug(f"Strata Balance after deposits: {balance_post}")
-        assert balance_post == 0, "Strata balance is not zero"
+        # Restart the bridge operator
+        bridge_operator.start()
 
         return True
 
-    def make_drt(self, ctx: flexitest.RunContext, el_address, musig_bridge_pk):
+    def make_drt(self, ctx: flexitest.RunContext, el_address, musig_bridge_pk, maturity=0):
         """
         Deposit Request Transaction
         """
         # Get relevant data
         btc = ctx.get_service("bitcoin")
         seq = ctx.get_service("sequencer")
+
         btcrpc: BitcoindClient = btc.create_rpc()
         btc_url = btcrpc.base_url
         btc_user = btc.props["rpc_user"]
         btc_password = btc.props["rpc_password"]
+
         seq_addr = seq.get_prop("address")
+
+        self.logger.debug(f"BTC URL: {btc_url}")
+        self.logger.debug(f"BTC user: {btc_user}")
+        self.logger.debug(f"BTC password: {btc_password}")
 
         # Create the deposit request transaction
         tx = bytes(
@@ -218,12 +174,12 @@ class BridgeDepositReclaimDrtSeenTest(flexitest.Test):
         # Send the transaction to the Bitcoin network
         txid = btcrpc.proxy.sendrawtransaction(tx)
         self.logger.debug(f"sent deposit request with txid = {txid} for address {el_address}")
+        # this transaction is not in the bitcoind wallet, so we cannot use gettransaction
         time.sleep(1)
 
         # time to mature DRT
-        btcrpc.proxy.generatetoaddress(6, seq_addr)
-        time.sleep(3)
+        if maturity > 0:
+            btcrpc.proxy.generatetoaddress(maturity, seq_addr)
+            time.sleep(3)
 
-        # time to mature DT
-        btcrpc.proxy.generatetoaddress(6, seq_addr)
-        time.sleep(3)
+        return txid

--- a/functional-tests/fn_bridge_deposit_reclaim.py
+++ b/functional-tests/fn_bridge_deposit_reclaim.py
@@ -12,6 +12,12 @@ from strata_utils import (
 from constants import DEFAULT_ROLLUP_PARAMS, DEFAULT_TAKEBACK_TIMEOUT, UNSPENDABLE_ADDRESS
 from utils import get_bridge_pubkey, get_logger
 
+# Local constants
+# D BTC
+DEPOSIT_AMOUNT = DEFAULT_ROLLUP_PARAMS["deposit_amount"]
+# Fee for the take back path at 2 sat/vbyte
+TAKE_BACK_FEE = 17_243
+
 
 @flexitest.register
 class BridgeDepositReclaimTest(flexitest.Test):
@@ -68,6 +74,7 @@ class BridgeDepositReclaimTest(flexitest.Test):
             btc_user,
             btc_password,
         )
+        self.logger.debug(f"Initial refund BTC balance: {initial_refund_btc_balance}")
 
         # DRT same block
         txid_drt = self.make_drt(ctx, el_address, bridge_pk, maturity=0)
@@ -130,8 +137,8 @@ class BridgeDepositReclaimTest(flexitest.Test):
             btc_password,
         )
         self.logger.debug(f"User BTC balance (after takeback): {refund_btc_balance}")
-        expected_balance_lower_bound = DEFAULT_ROLLUP_PARAMS["deposit_amount"] - 100_000_000
-        assert refund_btc_balance >= expected_balance_lower_bound, "BTC balance is not as expected"
+        expected_balance = 5 * DEPOSIT_AMOUNT - TAKE_BACK_FEE
+        assert refund_btc_balance >= expected_balance, "BTC balance is not as expected"
 
         # Now let's see if the EVM side has no funds
         # Make sure that the el_address has zero balance

--- a/functional-tests/fn_bridge_deposit_reclaim.py
+++ b/functional-tests/fn_bridge_deposit_reclaim.py
@@ -9,68 +9,131 @@ from strata_utils import (
     take_back_transaction,
 )
 
-from constants import DEFAULT_ROLLUP_PARAMS, DEFAULT_TAKEBACK_TIMEOUT, UNSPENDABLE_ADDRESS
-from utils import get_bridge_pubkey, get_logger
+from constants import (
+    DEFAULT_ROLLUP_PARAMS,
+    DEFAULT_TAKEBACK_TIMEOUT,
+    UNSPENDABLE_ADDRESS,
+)
+from entry import BasicEnvConfig
+from utils import get_bridge_pubkey, get_logger, wait_until
+
+# Local constants
+# D BTC
+DEPOSIT_AMOUNT = DEFAULT_ROLLUP_PARAMS["deposit_amount"]
+# Fee for the take back path at 2 sat/vbyte
+TAKE_BACK_FEE = 17_243
 
 
 @flexitest.register
-class BridgeDepositReclaimTest(flexitest.Test):
+class BridgeDepositReclaimDrtSeenTest(flexitest.Test):
     """
-    A test class for reclaim path scenarios of bridge deposits.
-
-    It tests the functionality of broadcasting a deposit request transaction (DRT) for the bridge
+    Tests the functionality of broadcasting a deposit request transaction (DRT) for the bridge
     and verifying that the reclaim path works as expected.
 
     In the test we stop one of the bridge operators to prevent the DRT from being processed.
+    However, we let the operator be aware of the DRT before stopping it
     """
 
     def __init__(self, ctx: flexitest.InitContext):
-        ctx.set_env("basic")
-        self.logger = get_logger("BridgeDepositReclaimTest")
+        ctx.set_env(
+            BasicEnvConfig(
+                pre_generate_blocks=101,
+                auto_generate_blocks=False,
+            )
+        )
+        self.logger = get_logger("BridgeDepositReclaimDrtSeenTest")
 
     def main(self, ctx: flexitest.RunContext):
         btc = ctx.get_service("bitcoin")
-        reth = ctx.get_service("reth")
         seq = ctx.get_service("sequencer")
+        reth = ctx.get_service("reth")
+
+        seqrpc = seq.create_rpc()
+        btcrpc: BitcoindClient = btc.create_rpc()
+        rethrpc = reth.create_rpc()
+
         # We just need to stop one bridge operator
         bridge_operator = ctx.get_service("bridge.0")
         # Kill the operator so the bridge does not process the DRT transaction
         bridge_operator.stop()
         self.logger.debug("Bridge operators stopped")
 
-        btcrpc: BitcoindClient = btc.create_rpc()
         btc_url = btcrpc.base_url
         btc_user = btc.props["rpc_user"]
         btc_password = btc.props["rpc_password"]
-
-        rethrpc = reth.create_rpc()
-
-        seqrpc = seq.create_rpc()
 
         self.logger.debug(f"BTC URL: {btc_url}")
         self.logger.debug(f"BTC user: {btc_user}")
         self.logger.debug(f"BTC password: {btc_password}")
 
         bridge_pk = get_bridge_pubkey(seqrpc)
-        el_address = ctx.env.gen_el_address()
-        refund_addr = ctx.env.gen_ext_btc_address()
-        recovery_addr = ctx.env.gen_rec_btc_address()
+        self.logger.debug(f"Bridge pubkey: {bridge_pk}")
+        el_address = "deadf001900dca3ebeefdeadf001900dca3ebeef"
+        self.logger.debug(f"EL address: {el_address}")
+        addr = get_address(0)
+        self.logger.debug(f"Address: {addr}")
+        refund_addr = get_address(1)
+        self.logger.debug(f"Refund address: {refund_addr}")
+        recovery_addr = get_recovery_address(0, bridge_pk)
+        self.logger.debug(f"Recovery Address: {recovery_addr}")
+
+        seq_addr = seq.get_prop("address")
+        self.logger.debug(f"Sequencer Address: {seq_addr}")
 
         # First let's see if the EVM side has no funds
         # Make sure that the el_address has zero balance
         balance = int(rethrpc.eth_getBalance(f"0x{el_address}"), 16)
         assert balance == 0, "EVM balance is not zero"
 
-        # Make sure that the BTC refund address has the expected balance
-        initial_refund_btc_balance = get_balance(
+        # Also make sure that the all addresses have zero balance
+        btc_addr_balance = get_balance(
+            addr,
+            btc_url,
+            btc_user,
+            btc_password,
+        )
+        self.logger.debug(f"Address BTC balance (before DRT): {btc_addr_balance}")
+        assert btc_addr_balance == 0, "Address BTC balance is not zero"
+        btc_refund_balance = get_balance(
             refund_addr,
             btc_url,
             btc_user,
             btc_password,
         )
+        self.logger.debug(f"Refund BTC balance (before DRT): {btc_refund_balance}")
+        assert btc_refund_balance == 0, "Refund BTC balance is not zero"
+        btc_recovery_balance = get_balance_recovery(
+            recovery_addr,
+            bridge_pk,
+            btc_url,
+            btc_user,
+            btc_password,
+        )
+        self.logger.debug(f"DRT BTC balance (before DRT): {btc_recovery_balance}")
+        assert btc_recovery_balance == 0, "Recovery BTC balance is not zero"
+
+        # Generate Plenty of BTC to address for the DRT
+        self.logger.debug(f"Generating 102 blocks to address: {addr}")
+        btcrpc.proxy.generatetoaddress(102, addr)
+        self.logger.debug(f"Generated 102 blocks to address: {addr}")
+        wait_until(lambda: get_balance(addr, btc_url, btc_user, btc_password) > 0)
+
+        # Generate Plenty of BTC to recovery address for the take back path
+        self.logger.debug(f"Generating 102 blocks to recovery address: {recovery_addr}")
+        btcrpc.proxy.generatetoaddress(102, recovery_addr)
+        self.logger.debug(f"Generated 110 blocks to recovery address: {recovery_addr}")
+        wait_until(
+            lambda: get_balance_recovery(recovery_addr, bridge_pk, btc_url, btc_user, btc_password)
+            > 0
+        )
+        balance_recovery = get_balance_recovery(
+            recovery_addr, bridge_pk, btc_url, btc_user, btc_password
+        )
+        self.logger.debug(f"Recovery BTC balance: {balance_recovery}")
+        assert balance_recovery > 0, "Recovery BTC balance is not positive"
 
         # DRT same block
-        txid_drt = self.make_drt(ctx, el_address, bridge_pk, maturity=0)
+        txid_drt = self.make_drt(ctx, el_address, bridge_pk)
         self.logger.debug(f"Deposit Request Transaction: {txid_drt}")
         time.sleep(1)
 
@@ -87,7 +150,7 @@ class BridgeDepositReclaimTest(flexitest.Test):
             btcrpc.proxy.generatetoaddress(blocks_to_generate, UNSPENDABLE_ADDRESS)
 
         # wait up a little bit
-        time.sleep(0.25)
+        time.sleep(1)
 
         # Make sure that the BTC refund address has the expected balance
         refund_btc_balance = get_balance(
@@ -96,8 +159,8 @@ class BridgeDepositReclaimTest(flexitest.Test):
             btc_user,
             btc_password,
         )
-        self.logger.debug(f"User BTC balance (before takeback): {refund_btc_balance}")
-        assert refund_btc_balance == initial_refund_btc_balance, "BTC balance has changed"
+        self.logger.debug(f"Refund BTC balance (before takeback): {refund_btc_balance}")
+        assert refund_btc_balance == 0, "Refund BTC balance is not zero"
 
         # Spend the take back path
         take_back_tx = bytes(
@@ -109,59 +172,40 @@ class BridgeDepositReclaimTest(flexitest.Test):
         txid = btcrpc.proxy.sendrawtransaction(take_back_tx)
         self.logger.debug(f"sent take back tx with txid = {txid} for address {el_address}")
         btcrpc.proxy.generatetoaddress(2, UNSPENDABLE_ADDRESS)
-        time.sleep(1)
-
-        # Make sure that the BTC recovery address has 0 BTC
-        btc_balance = get_balance_recovery(
-            recovery_addr,
-            bridge_pk,
-            btc_url,
-            btc_user,
-            btc_password,
-        )
-        self.logger.debug(f"DRT BTC balance (after takeback): {btc_balance}")
-        assert btc_balance == 0, "BTC balance is not zero"
+        wait_until(lambda: get_balance(refund_addr, btc_url, btc_user, btc_password) > 0)
 
         # Make sure that the BTC refund address has the expected balance
-        refund_btc_balance = get_balance(
+        refund_btc_balance_post = get_balance(
             refund_addr,
             btc_url,
             btc_user,
             btc_password,
         )
-        self.logger.debug(f"User BTC balance (after takeback): {refund_btc_balance}")
-        expected_balance_lower_bound = DEFAULT_ROLLUP_PARAMS["deposit_amount"] - 100_000_000
-        assert refund_btc_balance >= expected_balance_lower_bound, "BTC balance is not as expected"
+        self.logger.debug(f"Refund BTC balance (after takeback): {refund_btc_balance_post}")
 
-        # Now let's see if the EVM side has no funds
-        # Make sure that the el_address has zero balance
-        balance = int(rethrpc.eth_getBalance(f"0x{el_address}"), 16)
-        self.logger.debug(f"EVM balance (after takeback): {balance}")
-        assert balance == 0, "EVM balance is not zero"
+        assert (
+            refund_btc_balance_post == balance_recovery - TAKE_BACK_FEE
+        ), "Refund BTC balance is not expected"
 
-        # Restart the bridge operator
-        bridge_operator.start()
+        # Get the balance of the EL address after the deposits
+        balance_post = int(rethrpc.eth_getBalance(el_address), 16)
+        self.logger.debug(f"Strata Balance after deposits: {balance_post}")
+        assert balance_post == 0, "Strata balance is not zero"
 
         return True
 
-    def make_drt(self, ctx: flexitest.RunContext, el_address, musig_bridge_pk, maturity=0):
+    def make_drt(self, ctx: flexitest.RunContext, el_address, musig_bridge_pk):
         """
         Deposit Request Transaction
         """
         # Get relevant data
         btc = ctx.get_service("bitcoin")
         seq = ctx.get_service("sequencer")
-
         btcrpc: BitcoindClient = btc.create_rpc()
         btc_url = btcrpc.base_url
         btc_user = btc.props["rpc_user"]
         btc_password = btc.props["rpc_password"]
-
         seq_addr = seq.get_prop("address")
-
-        self.logger.debug(f"BTC URL: {btc_url}")
-        self.logger.debug(f"BTC user: {btc_user}")
-        self.logger.debug(f"BTC password: {btc_password}")
 
         # Create the deposit request transaction
         tx = bytes(
@@ -174,12 +218,12 @@ class BridgeDepositReclaimTest(flexitest.Test):
         # Send the transaction to the Bitcoin network
         txid = btcrpc.proxy.sendrawtransaction(tx)
         self.logger.debug(f"sent deposit request with txid = {txid} for address {el_address}")
-        # this transaction is not in the bitcoind wallet, so we cannot use gettransaction
         time.sleep(1)
 
         # time to mature DRT
-        if maturity > 0:
-            btcrpc.proxy.generatetoaddress(maturity, seq_addr)
-            time.sleep(3)
+        btcrpc.proxy.generatetoaddress(6, seq_addr)
+        time.sleep(3)
 
-        return txid
+        # time to mature DT
+        btcrpc.proxy.generatetoaddress(6, seq_addr)
+        time.sleep(3)

--- a/functional-tests/fn_bridge_deposit_reclaim_drt_seen.py
+++ b/functional-tests/fn_bridge_deposit_reclaim_drt_seen.py
@@ -14,57 +14,72 @@ from strata_utils import (
 from constants import (
     DEFAULT_ROLLUP_PARAMS,
     DEFAULT_TAKEBACK_TIMEOUT,
-    SATS_TO_WEI,
     UNSPENDABLE_ADDRESS,
 )
 from entry import BasicEnvConfig
-from utils import get_bridge_pubkey, get_logger
+from utils import get_bridge_pubkey, get_logger, wait_until
 
 # Local constants
-ROLLUP_DEPOSIT_AMOUNT = DEFAULT_ROLLUP_PARAMS["deposit_amount"]
-STRATA_DEPOSIT_LOWER_BOUND = ROLLUP_DEPOSIT_AMOUNT * SATS_TO_WEI
+# D BTC
+DEPOSIT_AMOUNT = DEFAULT_ROLLUP_PARAMS["deposit_amount"]
+# Fee for the take back path at 2 sat/vbyte
+TAKE_BACK_FEE = 17_243
 
 
 @flexitest.register
-class BridgeDepositReclaimDRTSeenTest(flexitest.Test):
+class BridgeDepositReclaimDrtSeenTest(flexitest.Test):
     """
-    A test class for reclaim path scenarios of bridge deposits.
-
-    It tests the functionality of broadcasting a deposit request transaction (DRT) for the bridge
+    Tests the functionality of broadcasting a deposit request transaction (DRT) for the bridge
     and verifying that the reclaim path works as expected.
 
     In the test we stop one of the bridge operators to prevent the DRT from being processed.
-    However, we let the operator be aware of the DRT before stopping it.
+    However, we let the operator be aware of the DRT before stopping it
     """
 
     def __init__(self, ctx: flexitest.InitContext):
-        ctx.set_env(BasicEnvConfig(pre_generate_blocks=101))
-        self.logger = get_logger("BridgeDepositReclaimTest")
+        ctx.set_env(
+            BasicEnvConfig(
+                pre_generate_blocks=101,
+                auto_generate_blocks=False,
+                # Set a high message interval to make sure the DRT is not processed.
+                # This is 10 minutes.
+                # NOTE: Alternatively, we could take one bridge operator down
+                #       to prevent the DRT from being processed.
+                message_interval=int(10 * 60 * 1_000),
+            )
+        )
+        self.logger = get_logger("BridgeDepositReclaimDrtSeenTest")
 
     def main(self, ctx: flexitest.RunContext):
         btc = ctx.get_service("bitcoin")
-        reth = ctx.get_service("reth")
         seq = ctx.get_service("sequencer")
-        # We just need to stop one bridge operator
-        bridge_operator = ctx.get_service("bridge.0")
+        reth = ctx.get_service("reth")
+
+        seqrpc = seq.create_rpc()
         btcrpc: BitcoindClient = btc.create_rpc()
+        rethrpc = reth.create_rpc()
+
         btc_url = btcrpc.base_url
         btc_user = btc.props["rpc_user"]
         btc_password = btc.props["rpc_password"]
-
-        rethrpc = reth.create_rpc()
-
-        seqrpc = seq.create_rpc()
 
         self.logger.debug(f"BTC URL: {btc_url}")
         self.logger.debug(f"BTC user: {btc_user}")
         self.logger.debug(f"BTC password: {btc_password}")
 
         bridge_pk = get_bridge_pubkey(seqrpc)
+        self.logger.debug(f"Bridge pubkey: {bridge_pk}")
         el_address = "deadf001900dca3ebeefdeadf001900dca3ebeef"
+        self.logger.debug(f"EL address: {el_address}")
         addr = get_address(0)
+        self.logger.debug(f"Address: {addr}")
         refund_addr = get_address(1)
+        self.logger.debug(f"Refund address: {refund_addr}")
         recovery_addr = get_recovery_address(0, bridge_pk)
+        self.logger.debug(f"Recovery Address: {recovery_addr}")
+
+        seq_addr = seq.get_prop("address")
+        self.logger.debug(f"Sequencer Address: {seq_addr}")
 
         # First let's see if the EVM side has no funds
         # Make sure that the el_address has zero balance
@@ -79,7 +94,7 @@ class BridgeDepositReclaimDRTSeenTest(flexitest.Test):
             btc_password,
         )
         self.logger.debug(f"Address BTC balance (before DRT): {btc_addr_balance}")
-        assert btc_addr_balance == 0, "BTC balance is not zero"
+        assert btc_addr_balance == 0, "Address BTC balance is not zero"
         btc_refund_balance = get_balance(
             refund_addr,
             btc_url,
@@ -87,85 +102,41 @@ class BridgeDepositReclaimDRTSeenTest(flexitest.Test):
             btc_password,
         )
         self.logger.debug(f"Refund BTC balance (before DRT): {btc_refund_balance}")
-        assert btc_refund_balance == 0, "BTC balance is not zero"
-        btc_recovery_balance_post = get_balance_recovery(
+        assert btc_refund_balance == 0, "Refund BTC balance is not zero"
+        btc_recovery_balance = get_balance_recovery(
             recovery_addr,
             bridge_pk,
             btc_url,
             btc_user,
             btc_password,
         )
-        self.logger.debug(f"DRT BTC balance (before DRT): {btc_recovery_balance_post}")
-        assert btc_recovery_balance_post == 0, "BTC balance is not zero"
+        self.logger.debug(f"DRT BTC balance (before DRT): {btc_recovery_balance}")
+        assert btc_recovery_balance == 0, "Recovery BTC balance is not zero"
 
         # Generate Plenty of BTC to address for the DRT
         self.logger.debug(f"Generating 102 blocks to address: {addr}")
         btcrpc.proxy.generatetoaddress(102, addr)
         self.logger.debug(f"Generated 102 blocks to address: {addr}")
-        time.sleep(0.5)
+        wait_until(lambda: get_balance(addr, btc_url, btc_user, btc_password) > 0)
 
         # Generate Plenty of BTC to recovery address for the take back path
         self.logger.debug(f"Generating 102 blocks to recovery address: {recovery_addr}")
         btcrpc.proxy.generatetoaddress(102, recovery_addr)
         self.logger.debug(f"Generated 110 blocks to recovery address: {recovery_addr}")
-        time.sleep(0.5)
-
-        # Grab the balances again
-        btc_addr_balance = get_balance(
-            addr,
-            btc_url,
-            btc_user,
-            btc_password,
+        wait_until(
+            lambda: get_balance_recovery(recovery_addr, bridge_pk, btc_url, btc_user, btc_password)
+            > 0
         )
-        self.logger.debug(f"Address BTC balance (after generating blocks): {btc_addr_balance}")
-        btc_recovery_balance_post = get_balance_recovery(
-            recovery_addr,
-            bridge_pk,
-            btc_url,
-            btc_user,
-            btc_password,
+        balance_recovery = get_balance_recovery(
+            recovery_addr, bridge_pk, btc_url, btc_user, btc_password
         )
-        self.logger.debug(f"DRT BTC balance (after generating blocks): {btc_recovery_balance_post}")
+        self.logger.debug(f"Recovery BTC balance: {balance_recovery}")
+        assert balance_recovery > 0, "Recovery BTC balance is not positive"
 
         # DRT same block
-        txid_drt = self.make_drt(ctx, el_address, bridge_pk, maturity=0)
+        txid_drt = self.make_drt(ctx, el_address, bridge_pk)
         self.logger.debug(f"Deposit Request Transaction: {txid_drt}")
         time.sleep(1)
-
-        # Kill the operator so the bridge does not process the DRT transaction
-        # NOTE: The operator is aware of the DRT transaction before stopping
-        bridge_operator.stop()
-        self.logger.debug("Bridge operators stopped")
-
-        # Grab the balances again
-        btc_addr_balance = get_balance(
-            addr,
-            btc_url,
-            btc_user,
-            btc_password,
-        )
-        self.logger.debug(
-            f"Address BTC balance (after DRT and stopping bridge): {btc_addr_balance}"
-        )
-        btc_recovery_balance_post = get_balance_recovery(
-            recovery_addr,
-            bridge_pk,
-            btc_url,
-            btc_user,
-            btc_password,
-        )
-        self.logger.debug(
-            f"DRT BTC balance (after DRT and stopping bridge): {btc_recovery_balance_post}"
-        )
-        btc_refund_balance = get_balance(
-            refund_addr,
-            btc_url,
-            btc_user,
-            btc_password,
-        )
-        self.logger.debug(
-            f"Refund BTC balance (after DRT and stopping bridge): {btc_refund_balance}"
-        )
 
         # Now we need to generate a bunch of blocks
         # since they will be able to spend the DRT output.
@@ -190,17 +161,7 @@ class BridgeDepositReclaimDRTSeenTest(flexitest.Test):
             btc_password,
         )
         self.logger.debug(f"Refund BTC balance (before takeback): {refund_btc_balance}")
-        assert refund_btc_balance == 0, "BTC balance is not zero"
-
-        # Check BTC balance of the recovery address
-        btc_recovery_balance_pre = get_balance_recovery(
-            recovery_addr,
-            bridge_pk,
-            btc_url,
-            btc_user,
-            btc_password,
-        )
-        self.logger.debug(f"DRT BTC balance (before takeback): {btc_recovery_balance_pre}")
+        assert refund_btc_balance == 0, "Refund BTC balance is not zero"
 
         # Spend the take back path
         take_back_tx = bytes(
@@ -212,18 +173,7 @@ class BridgeDepositReclaimDRTSeenTest(flexitest.Test):
         txid = btcrpc.proxy.sendrawtransaction(take_back_tx)
         self.logger.debug(f"sent take back tx with txid = {txid} for address {el_address}")
         btcrpc.proxy.generatetoaddress(2, UNSPENDABLE_ADDRESS)
-        time.sleep(1)
-
-        # Make sure that the BTC recovery address has 0 BTC
-        btc_recovery_balance_post = get_balance_recovery(
-            recovery_addr,
-            bridge_pk,
-            btc_url,
-            btc_user,
-            btc_password,
-        )
-        self.logger.debug(f"DRT BTC balance (after takeback): {btc_recovery_balance_post}")
-        assert btc_recovery_balance_post == 0, "BTC balance is not zero"
+        wait_until(lambda: get_balance(refund_addr, btc_url, btc_user, btc_password) > 0)
 
         # Make sure that the BTC refund address has the expected balance
         refund_btc_balance_post = get_balance(
@@ -233,42 +183,30 @@ class BridgeDepositReclaimDRTSeenTest(flexitest.Test):
             btc_password,
         )
         self.logger.debug(f"Refund BTC balance (after takeback): {refund_btc_balance_post}")
-        expected_balance_lower_bound = btc_recovery_balance_pre - 100_000_000
-        self.logger.debug(f"Expected balance lower bound: {expected_balance_lower_bound}")
+
         assert (
-            refund_btc_balance_post >= expected_balance_lower_bound
-        ), "BTC balance is not as expected"
+            refund_btc_balance_post == balance_recovery - TAKE_BACK_FEE
+        ), "Refund BTC balance is not expected"
 
-        # Now let's see if the EVM side has no funds
-        # Make sure that the el_address has zero balance
-        balance = int(rethrpc.eth_getBalance(f"0x{el_address}"), 16)
-        self.logger.debug(f"EVM balance (after takeback): {balance}")
-        self.logger.debug(f"Expected balance lower bound: {STRATA_DEPOSIT_LOWER_BOUND}")
-        assert balance >= STRATA_DEPOSIT_LOWER_BOUND, "EVM balance is not as expected"
-
-        # Restart the bridge operator
-        bridge_operator.start()
+        # Get the balance of the EL address after the deposits
+        balance_post = int(rethrpc.eth_getBalance(el_address), 16)
+        self.logger.debug(f"Strata Balance after deposits: {balance_post}")
+        assert balance_post == 0, "Strata balance is not zero"
 
         return True
 
-    def make_drt(self, ctx: flexitest.RunContext, el_address, musig_bridge_pk, maturity=0):
+    def make_drt(self, ctx: flexitest.RunContext, el_address, musig_bridge_pk):
         """
         Deposit Request Transaction
         """
         # Get relevant data
         btc = ctx.get_service("bitcoin")
         seq = ctx.get_service("sequencer")
-
         btcrpc: BitcoindClient = btc.create_rpc()
         btc_url = btcrpc.base_url
         btc_user = btc.props["rpc_user"]
         btc_password = btc.props["rpc_password"]
-
         seq_addr = seq.get_prop("address")
-
-        self.logger.debug(f"BTC URL: {btc_url}")
-        self.logger.debug(f"BTC user: {btc_user}")
-        self.logger.debug(f"BTC password: {btc_password}")
 
         # Create the deposit request transaction
         tx = bytes(
@@ -281,12 +219,12 @@ class BridgeDepositReclaimDRTSeenTest(flexitest.Test):
         # Send the transaction to the Bitcoin network
         txid = btcrpc.proxy.sendrawtransaction(tx)
         self.logger.debug(f"sent deposit request with txid = {txid} for address {el_address}")
-        # this transaction is not in the bitcoind wallet, so we cannot use gettransaction
         time.sleep(1)
 
         # time to mature DRT
-        if maturity > 0:
-            btcrpc.proxy.generatetoaddress(maturity, seq_addr)
-            time.sleep(3)
+        btcrpc.proxy.generatetoaddress(6, seq_addr)
+        time.sleep(3)
 
-        return txid
+        # time to mature DT
+        btcrpc.proxy.generatetoaddress(6, seq_addr)
+        time.sleep(3)

--- a/functional-tests/fn_bridge_deposit_reclaim_drt_seen.py
+++ b/functional-tests/fn_bridge_deposit_reclaim_drt_seen.py
@@ -1,0 +1,292 @@
+import time
+
+import flexitest
+from bitcoinlib.services.bitcoind import BitcoindClient
+from strata_utils import (
+    deposit_request_transaction,
+    get_address,
+    get_balance,
+    get_balance_recovery,
+    get_recovery_address,
+    take_back_transaction,
+)
+
+from constants import (
+    DEFAULT_ROLLUP_PARAMS,
+    DEFAULT_TAKEBACK_TIMEOUT,
+    SATS_TO_WEI,
+    UNSPENDABLE_ADDRESS,
+)
+from entry import BasicEnvConfig
+from utils import get_bridge_pubkey, get_logger
+
+# Local constants
+ROLLUP_DEPOSIT_AMOUNT = DEFAULT_ROLLUP_PARAMS["deposit_amount"]
+STRATA_DEPOSIT_LOWER_BOUND = ROLLUP_DEPOSIT_AMOUNT * SATS_TO_WEI
+
+
+@flexitest.register
+class BridgeDepositReclaimDRTSeenTest(flexitest.Test):
+    """
+    A test class for reclaim path scenarios of bridge deposits.
+
+    It tests the functionality of broadcasting a deposit request transaction (DRT) for the bridge
+    and verifying that the reclaim path works as expected.
+
+    In the test we stop one of the bridge operators to prevent the DRT from being processed.
+    However, we let the operator be aware of the DRT before stopping it.
+    """
+
+    def __init__(self, ctx: flexitest.InitContext):
+        ctx.set_env(BasicEnvConfig(pre_generate_blocks=101))
+        self.logger = get_logger("BridgeDepositReclaimTest")
+
+    def main(self, ctx: flexitest.RunContext):
+        btc = ctx.get_service("bitcoin")
+        reth = ctx.get_service("reth")
+        seq = ctx.get_service("sequencer")
+        # We just need to stop one bridge operator
+        bridge_operator = ctx.get_service("bridge.0")
+        btcrpc: BitcoindClient = btc.create_rpc()
+        btc_url = btcrpc.base_url
+        btc_user = btc.props["rpc_user"]
+        btc_password = btc.props["rpc_password"]
+
+        rethrpc = reth.create_rpc()
+
+        seqrpc = seq.create_rpc()
+
+        self.logger.debug(f"BTC URL: {btc_url}")
+        self.logger.debug(f"BTC user: {btc_user}")
+        self.logger.debug(f"BTC password: {btc_password}")
+
+        bridge_pk = get_bridge_pubkey(seqrpc)
+        el_address = "deadf001900dca3ebeefdeadf001900dca3ebeef"
+        addr = get_address(0)
+        refund_addr = get_address(1)
+        recovery_addr = get_recovery_address(0, bridge_pk)
+
+        # First let's see if the EVM side has no funds
+        # Make sure that the el_address has zero balance
+        balance = int(rethrpc.eth_getBalance(f"0x{el_address}"), 16)
+        assert balance == 0, "EVM balance is not zero"
+
+        # Also make sure that the all addresses have zero balance
+        btc_addr_balance = get_balance(
+            addr,
+            btc_url,
+            btc_user,
+            btc_password,
+        )
+        self.logger.debug(f"Address BTC balance (before DRT): {btc_addr_balance}")
+        assert btc_addr_balance == 0, "BTC balance is not zero"
+        btc_refund_balance = get_balance(
+            refund_addr,
+            btc_url,
+            btc_user,
+            btc_password,
+        )
+        self.logger.debug(f"Refund BTC balance (before DRT): {btc_refund_balance}")
+        assert btc_refund_balance == 0, "BTC balance is not zero"
+        btc_recovery_balance_post = get_balance_recovery(
+            recovery_addr,
+            bridge_pk,
+            btc_url,
+            btc_user,
+            btc_password,
+        )
+        self.logger.debug(f"DRT BTC balance (before DRT): {btc_recovery_balance_post}")
+        assert btc_recovery_balance_post == 0, "BTC balance is not zero"
+
+        # Generate Plenty of BTC to address for the DRT
+        self.logger.debug(f"Generating 102 blocks to address: {addr}")
+        btcrpc.proxy.generatetoaddress(102, addr)
+        self.logger.debug(f"Generated 102 blocks to address: {addr}")
+        time.sleep(0.5)
+
+        # Generate Plenty of BTC to recovery address for the take back path
+        self.logger.debug(f"Generating 102 blocks to recovery address: {recovery_addr}")
+        btcrpc.proxy.generatetoaddress(102, recovery_addr)
+        self.logger.debug(f"Generated 110 blocks to recovery address: {recovery_addr}")
+        time.sleep(0.5)
+
+        # Grab the balances again
+        btc_addr_balance = get_balance(
+            addr,
+            btc_url,
+            btc_user,
+            btc_password,
+        )
+        self.logger.debug(f"Address BTC balance (after generating blocks): {btc_addr_balance}")
+        btc_recovery_balance_post = get_balance_recovery(
+            recovery_addr,
+            bridge_pk,
+            btc_url,
+            btc_user,
+            btc_password,
+        )
+        self.logger.debug(f"DRT BTC balance (after generating blocks): {btc_recovery_balance_post}")
+
+        # DRT same block
+        txid_drt = self.make_drt(ctx, el_address, bridge_pk, maturity=0)
+        self.logger.debug(f"Deposit Request Transaction: {txid_drt}")
+        time.sleep(1)
+
+        # Kill the operator so the bridge does not process the DRT transaction
+        # NOTE: The operator is aware of the DRT transaction before stopping
+        bridge_operator.stop()
+        self.logger.debug("Bridge operators stopped")
+
+        # Grab the balances again
+        btc_addr_balance = get_balance(
+            addr,
+            btc_url,
+            btc_user,
+            btc_password,
+        )
+        self.logger.debug(
+            f"Address BTC balance (after DRT and stopping bridge): {btc_addr_balance}"
+        )
+        btc_recovery_balance_post = get_balance_recovery(
+            recovery_addr,
+            bridge_pk,
+            btc_url,
+            btc_user,
+            btc_password,
+        )
+        self.logger.debug(
+            f"DRT BTC balance (after DRT and stopping bridge): {btc_recovery_balance_post}"
+        )
+        btc_refund_balance = get_balance(
+            refund_addr,
+            btc_url,
+            btc_user,
+            btc_password,
+        )
+        self.logger.debug(
+            f"Refund BTC balance (after DRT and stopping bridge): {btc_refund_balance}"
+        )
+
+        # Now we need to generate a bunch of blocks
+        # since they will be able to spend the DRT output.
+        # We need to wait for the reclaim path 1008 blocks to mature
+        # so that we can use the take back path to spend the DRT output.
+        # Breaking by chunks
+        chunks = 8
+        blocks_to_generate = DEFAULT_TAKEBACK_TIMEOUT // chunks
+        self.logger.debug(f"Generating {DEFAULT_TAKEBACK_TIMEOUT} blocks in {chunks} chunks")
+        for i in range(chunks):
+            self.logger.debug(f"Generating {blocks_to_generate} blocks in chunk {i+1}/{chunks}")
+            btcrpc.proxy.generatetoaddress(blocks_to_generate, UNSPENDABLE_ADDRESS)
+
+        # wait up a little bit
+        time.sleep(1)
+
+        # Make sure that the BTC refund address has the expected balance
+        refund_btc_balance = get_balance(
+            refund_addr,
+            btc_url,
+            btc_user,
+            btc_password,
+        )
+        self.logger.debug(f"Refund BTC balance (before takeback): {refund_btc_balance}")
+        assert refund_btc_balance == 0, "BTC balance is not zero"
+
+        # Check BTC balance of the recovery address
+        btc_recovery_balance_pre = get_balance_recovery(
+            recovery_addr,
+            bridge_pk,
+            btc_url,
+            btc_user,
+            btc_password,
+        )
+        self.logger.debug(f"DRT BTC balance (before takeback): {btc_recovery_balance_pre}")
+
+        # Spend the take back path
+        take_back_tx = bytes(
+            take_back_transaction(refund_addr, bridge_pk, btc_url, btc_user, btc_password)
+        ).hex()
+        self.logger.debug("Take back tx generated")
+
+        # Send the transaction to the Bitcoin network
+        txid = btcrpc.proxy.sendrawtransaction(take_back_tx)
+        self.logger.debug(f"sent take back tx with txid = {txid} for address {el_address}")
+        btcrpc.proxy.generatetoaddress(2, UNSPENDABLE_ADDRESS)
+        time.sleep(1)
+
+        # Make sure that the BTC recovery address has 0 BTC
+        btc_recovery_balance_post = get_balance_recovery(
+            recovery_addr,
+            bridge_pk,
+            btc_url,
+            btc_user,
+            btc_password,
+        )
+        self.logger.debug(f"DRT BTC balance (after takeback): {btc_recovery_balance_post}")
+        assert btc_recovery_balance_post == 0, "BTC balance is not zero"
+
+        # Make sure that the BTC refund address has the expected balance
+        refund_btc_balance_post = get_balance(
+            refund_addr,
+            btc_url,
+            btc_user,
+            btc_password,
+        )
+        self.logger.debug(f"Refund BTC balance (after takeback): {refund_btc_balance_post}")
+        expected_balance_lower_bound = btc_recovery_balance_pre - 100_000_000
+        self.logger.debug(f"Expected balance lower bound: {expected_balance_lower_bound}")
+        assert (
+            refund_btc_balance_post >= expected_balance_lower_bound
+        ), "BTC balance is not as expected"
+
+        # Now let's see if the EVM side has no funds
+        # Make sure that the el_address has zero balance
+        balance = int(rethrpc.eth_getBalance(f"0x{el_address}"), 16)
+        self.logger.debug(f"EVM balance (after takeback): {balance}")
+        self.logger.debug(f"Expected balance lower bound: {STRATA_DEPOSIT_LOWER_BOUND}")
+        assert balance >= STRATA_DEPOSIT_LOWER_BOUND, "EVM balance is not as expected"
+
+        # Restart the bridge operator
+        bridge_operator.start()
+
+        return True
+
+    def make_drt(self, ctx: flexitest.RunContext, el_address, musig_bridge_pk, maturity=0):
+        """
+        Deposit Request Transaction
+        """
+        # Get relevant data
+        btc = ctx.get_service("bitcoin")
+        seq = ctx.get_service("sequencer")
+
+        btcrpc: BitcoindClient = btc.create_rpc()
+        btc_url = btcrpc.base_url
+        btc_user = btc.props["rpc_user"]
+        btc_password = btc.props["rpc_password"]
+
+        seq_addr = seq.get_prop("address")
+
+        self.logger.debug(f"BTC URL: {btc_url}")
+        self.logger.debug(f"BTC user: {btc_user}")
+        self.logger.debug(f"BTC password: {btc_password}")
+
+        # Create the deposit request transaction
+        tx = bytes(
+            deposit_request_transaction(
+                el_address, musig_bridge_pk, btc_url, btc_user, btc_password
+            )
+        ).hex()
+        self.logger.debug(f"Deposit request tx: {tx}")
+
+        # Send the transaction to the Bitcoin network
+        txid = btcrpc.proxy.sendrawtransaction(tx)
+        self.logger.debug(f"sent deposit request with txid = {txid} for address {el_address}")
+        # this transaction is not in the bitcoind wallet, so we cannot use gettransaction
+        time.sleep(1)
+
+        # time to mature DRT
+        if maturity > 0:
+            btcrpc.proxy.generatetoaddress(maturity, seq_addr)
+            time.sleep(3)
+
+        return txid

--- a/functional-tests/fn_bridge_deposit_reclaim_drt_seen.py
+++ b/functional-tests/fn_bridge_deposit_reclaim_drt_seen.py
@@ -4,10 +4,8 @@ import flexitest
 from bitcoinlib.services.bitcoind import BitcoindClient
 from strata_utils import (
     deposit_request_transaction,
-    get_address,
     get_balance,
     get_balance_recovery,
-    get_recovery_address,
     take_back_transaction,
 )
 
@@ -16,8 +14,7 @@ from constants import (
     DEFAULT_TAKEBACK_TIMEOUT,
     UNSPENDABLE_ADDRESS,
 )
-from entry import BasicEnvConfig
-from utils import get_bridge_pubkey, get_logger, wait_until
+from utils import get_bridge_pubkey, get_logger
 
 # Local constants
 # D BTC
@@ -37,17 +34,7 @@ class BridgeDepositReclaimDrtSeenTest(flexitest.Test):
     """
 
     def __init__(self, ctx: flexitest.InitContext):
-        ctx.set_env(
-            BasicEnvConfig(
-                pre_generate_blocks=101,
-                auto_generate_blocks=False,
-                # Set a high message interval to make sure the DRT is not processed.
-                # This is 10 minutes.
-                # NOTE: Alternatively, we could take one bridge operator down
-                #       to prevent the DRT from being processed.
-                message_interval=int(10 * 60 * 1_000),
-            )
-        )
+        ctx.set_env("operator_lag")
         self.logger = get_logger("BridgeDepositReclaimDrtSeenTest")
 
     def main(self, ctx: flexitest.RunContext):
@@ -68,70 +55,23 @@ class BridgeDepositReclaimDrtSeenTest(flexitest.Test):
         self.logger.debug(f"BTC password: {btc_password}")
 
         bridge_pk = get_bridge_pubkey(seqrpc)
-        self.logger.debug(f"Bridge pubkey: {bridge_pk}")
-        el_address = "deadf001900dca3ebeefdeadf001900dca3ebeef"
-        self.logger.debug(f"EL address: {el_address}")
-        addr = get_address(0)
-        self.logger.debug(f"Address: {addr}")
-        refund_addr = get_address(1)
-        self.logger.debug(f"Refund address: {refund_addr}")
-        recovery_addr = get_recovery_address(0, bridge_pk)
-        self.logger.debug(f"Recovery Address: {recovery_addr}")
-
-        seq_addr = seq.get_prop("address")
-        self.logger.debug(f"Sequencer Address: {seq_addr}")
+        el_address = ctx.env.gen_el_address()
+        refund_addr = ctx.env.gen_ext_btc_address()
+        recovery_addr = ctx.env.gen_rec_btc_address()
 
         # First let's see if the EVM side has no funds
         # Make sure that the el_address has zero balance
         balance = int(rethrpc.eth_getBalance(f"0x{el_address}"), 16)
         assert balance == 0, "EVM balance is not zero"
 
-        # Also make sure that the all addresses have zero balance
-        btc_addr_balance = get_balance(
-            addr,
-            btc_url,
-            btc_user,
-            btc_password,
-        )
-        self.logger.debug(f"Address BTC balance (before DRT): {btc_addr_balance}")
-        assert btc_addr_balance == 0, "Address BTC balance is not zero"
-        btc_refund_balance = get_balance(
+        # Make sure that the BTC refund address has the expected balance
+        initial_refund_btc_balance = get_balance(
             refund_addr,
             btc_url,
             btc_user,
             btc_password,
         )
-        self.logger.debug(f"Refund BTC balance (before DRT): {btc_refund_balance}")
-        assert btc_refund_balance == 0, "Refund BTC balance is not zero"
-        btc_recovery_balance = get_balance_recovery(
-            recovery_addr,
-            bridge_pk,
-            btc_url,
-            btc_user,
-            btc_password,
-        )
-        self.logger.debug(f"DRT BTC balance (before DRT): {btc_recovery_balance}")
-        assert btc_recovery_balance == 0, "Recovery BTC balance is not zero"
-
-        # Generate Plenty of BTC to address for the DRT
-        self.logger.debug(f"Generating 102 blocks to address: {addr}")
-        btcrpc.proxy.generatetoaddress(102, addr)
-        self.logger.debug(f"Generated 102 blocks to address: {addr}")
-        wait_until(lambda: get_balance(addr, btc_url, btc_user, btc_password) > 0)
-
-        # Generate Plenty of BTC to recovery address for the take back path
-        self.logger.debug(f"Generating 102 blocks to recovery address: {recovery_addr}")
-        btcrpc.proxy.generatetoaddress(102, recovery_addr)
-        self.logger.debug(f"Generated 110 blocks to recovery address: {recovery_addr}")
-        wait_until(
-            lambda: get_balance_recovery(recovery_addr, bridge_pk, btc_url, btc_user, btc_password)
-            > 0
-        )
-        balance_recovery = get_balance_recovery(
-            recovery_addr, bridge_pk, btc_url, btc_user, btc_password
-        )
-        self.logger.debug(f"Recovery BTC balance: {balance_recovery}")
-        assert balance_recovery > 0, "Recovery BTC balance is not positive"
+        self.logger.debug(f"Initial refund BTC balance: {initial_refund_btc_balance}")
 
         # DRT same block
         txid_drt = self.make_drt(ctx, el_address, bridge_pk)
@@ -151,7 +91,7 @@ class BridgeDepositReclaimDrtSeenTest(flexitest.Test):
             btcrpc.proxy.generatetoaddress(blocks_to_generate, UNSPENDABLE_ADDRESS)
 
         # wait up a little bit
-        time.sleep(1)
+        time.sleep(0.25)
 
         # Make sure that the BTC refund address has the expected balance
         refund_btc_balance = get_balance(
@@ -161,7 +101,7 @@ class BridgeDepositReclaimDrtSeenTest(flexitest.Test):
             btc_password,
         )
         self.logger.debug(f"Refund BTC balance (before takeback): {refund_btc_balance}")
-        assert refund_btc_balance == 0, "Refund BTC balance is not zero"
+        assert refund_btc_balance == initial_refund_btc_balance, "BTC balance has changed"
 
         # Spend the take back path
         take_back_tx = bytes(
@@ -173,20 +113,29 @@ class BridgeDepositReclaimDrtSeenTest(flexitest.Test):
         txid = btcrpc.proxy.sendrawtransaction(take_back_tx)
         self.logger.debug(f"sent take back tx with txid = {txid} for address {el_address}")
         btcrpc.proxy.generatetoaddress(2, UNSPENDABLE_ADDRESS)
-        wait_until(lambda: get_balance(refund_addr, btc_url, btc_user, btc_password) > 0)
+        time.sleep(1)
+
+        # Make sure that the BTC recovery address has 0 BTC
+        btc_balance = get_balance_recovery(
+            recovery_addr,
+            bridge_pk,
+            btc_url,
+            btc_user,
+            btc_password,
+        )
+        self.logger.debug(f"DRT BTC balance (after takeback): {btc_balance}")
+        assert btc_balance == 0, "BTC balance is not zero"
 
         # Make sure that the BTC refund address has the expected balance
-        refund_btc_balance_post = get_balance(
+        refund_btc_balance = get_balance(
             refund_addr,
             btc_url,
             btc_user,
             btc_password,
         )
-        self.logger.debug(f"Refund BTC balance (after takeback): {refund_btc_balance_post}")
-
-        assert (
-            refund_btc_balance_post == balance_recovery - TAKE_BACK_FEE
-        ), "Refund BTC balance is not expected"
+        self.logger.debug(f"User BTC balance (after takeback): {refund_btc_balance}")
+        expected_balance = 5 * DEPOSIT_AMOUNT - TAKE_BACK_FEE
+        assert refund_btc_balance >= expected_balance, "BTC balance is not as expected"
 
         # Get the balance of the EL address after the deposits
         balance_post = int(rethrpc.eth_getBalance(el_address), 16)
@@ -201,12 +150,10 @@ class BridgeDepositReclaimDrtSeenTest(flexitest.Test):
         """
         # Get relevant data
         btc = ctx.get_service("bitcoin")
-        seq = ctx.get_service("sequencer")
         btcrpc: BitcoindClient = btc.create_rpc()
         btc_url = btcrpc.base_url
         btc_user = btc.props["rpc_user"]
         btc_password = btc.props["rpc_password"]
-        seq_addr = seq.get_prop("address")
 
         # Create the deposit request transaction
         tx = bytes(
@@ -219,12 +166,6 @@ class BridgeDepositReclaimDrtSeenTest(flexitest.Test):
         # Send the transaction to the Bitcoin network
         txid = btcrpc.proxy.sendrawtransaction(tx)
         self.logger.debug(f"sent deposit request with txid = {txid} for address {el_address}")
-        time.sleep(1)
+        time.sleep(1)  # I don't know how to get rid of this sleep
 
-        # time to mature DRT
-        btcrpc.proxy.generatetoaddress(6, seq_addr)
-        time.sleep(3)
-
-        # time to mature DT
-        btcrpc.proxy.generatetoaddress(6, seq_addr)
-        time.sleep(3)
+        return txid

--- a/functional-tests/fn_btcio_broadcast.py
+++ b/functional-tests/fn_btcio_broadcast.py
@@ -7,7 +7,7 @@ from bitcoinlib.services.bitcoind import BitcoindClient
 @flexitest.register
 class BroadcastTest(flexitest.Test):
     def __init__(self, ctx: flexitest.InitContext):
-        ctx.set_env("premined_blocks")  # premined because we want to create a tx
+        ctx.set_env("basic")
 
     def main(self, ctx: flexitest.RunContext):
         btc = ctx.get_service("bitcoin")

--- a/functional-tests/fn_btcio_inscriber.py
+++ b/functional-tests/fn_btcio_inscriber.py
@@ -10,7 +10,7 @@ from utils import generate_n_blocks, wait_until
 @flexitest.register
 class L1WriterTest(flexitest.Test):
     def __init__(self, ctx: flexitest.InitContext):
-        ctx.set_env("premined_blocks")
+        ctx.set_env("basic")
 
     def main(self, ctx: flexitest.RunContext):
         btc = ctx.get_service("bitcoin")

--- a/functional-tests/fn_sync_genesis_with_btcblocks.py
+++ b/functional-tests/fn_sync_genesis_with_btcblocks.py
@@ -9,8 +9,7 @@ MAX_GENESIS_TRIES = 10
 @flexitest.register
 class SyncGenesisTest(flexitest.Test):
     def __init__(self, ctx: flexitest.InitContext):
-        # generate 100 bitcoin blocks before starting sequencer
-        ctx.set_env("premined_blocks")
+        ctx.set_env("basic")
 
     def main(self, ctx: flexitest.RunContext):
         seq = ctx.get_service("sequencer")


### PR DESCRIPTION
## Description

Test case same as bridge deposit reclaim but now the operators have a high `message_interval` and cannot coordinate to spend the DRT into a DT.

### Type of Change

-   [ ] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature/Enhancement (non-breaking change which adds functionality or enhances an existing one)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] Documentation update
-   [ ] Refactor
-   [x] New or updated tests

## Checklist

-   [x] I have performed a self-review of my code.
-   [x] I have commented my code where necessary.
-   [x] I have updated the documentation if needed.
-   [x] My changes do not introduce new warnings.
-   [x] I have added tests that prove my changes are effective or that my feature works.
-   [x] New and existing tests pass with my changes.

## Related Issues

STR-624
