### PR TITLE
ProverManager: Avoid Cloning VM for Each Proof Request

### DIFF
--- a/crates/zkvm/zkvm/src/host.rs
+++ b/crates/zkvm/zkvm/src/host.rs
@@ -1,7 +1,7 @@
 use crate::{Proof, ProverOptions, VerificationKey, ZkVmInputBuilder};
 
 /// A trait implemented by the prover ("host") of a zkVM program.
-pub trait ZkVmHost: Send + Sync + Clone {
+pub trait ZkVmHost: Send + Sync + Clone + 'static {
     type Input<'a>: ZkVmInputBuilder<'a>;
 
     /// Initializes the ZkVm with the provided ELF program and prover configuration.


### PR DESCRIPTION
## Description
In the current implementation, the ZkVm host is cloned for each proof request. This results in significant  memory overhead, especially in the SP1 host, where the proving key is stored. 

<!--
Provide a brief summary of the changes and the motivation behind them.
-->

### Type of Change

<!--
Select the type of change your PR introduces (put an `x` in all that apply):-
-->

-   [x] Bug fix (non-breaking change which fixes an issue)
-   [x] New feature/Enhancement (non-breaking change which adds functionality or enhances an existing one)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] Documentation update
-   [x] Refactor
-   [ ] New or updated tests

## Checklist

<!--
Ensure all the following are checked:
-->

-   [ ] I have performed a self-review of my code.
-   [ ] I have commented my code where necessary.
-   [ ] I have updated the documentation if needed.
-   [ ] My changes do not introduce new warnings.
-   [ ] I have added tests that prove my changes are effective or that my feature works.
-   [ ] New and existing tests pass with my changes.

## Related Issues

<!--
Link any related issues (e.g., `closes #123`, `fixes #456`).
-->
