### PR TITLE
Enable SP1 Mock Mode with Proof Composition Support via Feature Flag

### DIFF
--- a/crates/zkvm/adapters/risc0/Cargo.toml
+++ b/crates/zkvm/adapters/risc0/Cargo.toml
@@ -16,3 +16,4 @@ tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 [features]
 default = []
 prover = []
+mock = []

--- a/crates/zkvm/adapters/risc0/src/host.rs
+++ b/crates/zkvm/adapters/risc0/src/host.rs
@@ -32,6 +32,11 @@ impl ZkVmHost for Risc0Host {
         prover_input: <Self::Input<'a> as ZkVmInputBuilder<'a>>::Input,
         proof_type: ProofType,
     ) -> ZkVmResult<(Proof, VerificationKey)> {
+        #[cfg(feature = "mock")]
+        {
+            std::env::set_var("RISC0_DEV_MODE", "true");
+        }
+
         // Setup the prover
         let opts = match proof_type {
             ProofType::Core => ProverOpts::default(),

--- a/crates/zkvm/adapters/sp1/Cargo.toml
+++ b/crates/zkvm/adapters/sp1/Cargo.toml
@@ -23,3 +23,4 @@ tracing.workspace = true
 default = []
 prover = ["sp1-sdk"]
 zkvm = ["sp1-zkvm"]
+mock = []

--- a/crates/zkvm/adapters/sp1/src/env.rs
+++ b/crates/zkvm/adapters/sp1/src/env.rs
@@ -1,8 +1,12 @@
 use serde::{de::DeserializeOwned, Serialize};
+#[cfg(not(feature = "mock"))]
 use sha2::{Digest, Sha256};
-use sp1_zkvm::{io, lib::verify::verify_sp1_proof};
+use sp1_zkvm::io;
+#[cfg(not(feature = "mock"))]
+use sp1_zkvm::lib::verify::verify_sp1_proof;
 use strata_zkvm::{Proof, ZkVmEnv};
 
+#[cfg(not(feature = "mock"))]
 use crate::verify_groth16;
 
 pub struct Sp1ZkVmEnv;
@@ -24,11 +28,16 @@ impl ZkVmEnv for Sp1ZkVmEnv {
         io::commit_slice(output_raw);
     }
 
+    #[cfg(not(feature = "mock"))]
     fn verify_native_proof(&self, vk_digest: &[u32; 8], public_values: &[u8]) {
         let pv_digest = Sha256::digest(public_values);
         verify_sp1_proof(vk_digest, &pv_digest.into());
     }
 
+    #[cfg(feature = "mock")]
+    fn verify_native_proof(&self, _vk_digest: &[u32; 8], _public_values: &[u8]) {}
+
+    #[cfg(not(feature = "mock"))]
     fn verify_groth16_proof(
         &self,
         proof: &Proof,
@@ -36,6 +45,15 @@ impl ZkVmEnv for Sp1ZkVmEnv {
         public_params_raw: &[u8],
     ) {
         verify_groth16(proof, verification_key, public_params_raw).unwrap();
+    }
+
+    #[cfg(feature = "mock")]
+    fn verify_groth16_proof(
+        &self,
+        _proof: &Proof,
+        _verification_key: &[u8],
+        _public_params_raw: &[u8],
+    ) {
     }
 
     fn read_verified_serde<T: DeserializeOwned>(&self, vk_digest: &[u32; 8]) -> T {

--- a/crates/zkvm/adapters/sp1/src/host.rs
+++ b/crates/zkvm/adapters/sp1/src/host.rs
@@ -47,6 +47,11 @@ impl ZkVmHost for SP1Host {
         prover_input: <Self::Input<'a> as ZkVmInputBuilder<'a>>::Input,
         proof_type: ProofType,
     ) -> ZkVmResult<(Proof, VerificationKey)> {
+        #[cfg(feature = "mock")]
+        {
+            std::env::set_var("SP1_PROVER", "mock");
+        }
+
         sp1_sdk::utils::setup_logger();
         let client = ProverClient::new();
 

--- a/provers/sp1/Cargo.toml
+++ b/provers/sp1/Cargo.toml
@@ -17,4 +17,5 @@ sp1-sdk = "3.0.0"
 
 [features]
 default = ["prover"]
-prover = ["dep:strata-sp1-adapter"]
+prover = ["strata-sp1-adapter"]
+mock = []

--- a/provers/sp1/build.rs
+++ b/provers/sp1/build.rs
@@ -223,9 +223,21 @@ fn ensure_cache_validity(program: &str) -> Result<SP1VerifyingKey, String> {
 /// Generates the ELF contents and VK hash for a given program.
 #[cfg(not(debug_assertions))]
 fn generate_elf_contents_and_vk_hash(program: &str) -> ([u32; 8], String) {
+    let features = {
+        #[cfg(feature = "mock")]
+        {
+            vec!["mock".to_string()]
+        }
+        #[cfg(not(feature = "mock"))]
+        {
+            vec![]
+        }
+    };
+
     let build_args = BuildArgs {
         elf_name: format!("{}.elf", program),
         output_directory: "cache".to_owned(),
+        features,
         ..Default::default()
     };
 

--- a/provers/sp1/guest-btc-blockspace/Cargo.toml
+++ b/provers/sp1/guest-btc-blockspace/Cargo.toml
@@ -14,3 +14,6 @@ strata-sp1-adapter = { path = "../../../crates/zkvm/adapters/sp1", features = [
 [patch.crates-io]
 secp256k1 = { git = "https://github.com/sp1-patches/rust-secp256k1", branch = "patch-secp256k1-v0.29.1" }
 sha2-v0-10-8 = { git = "https://github.com/sp1-patches/RustCrypto-hashes", package = "sha2", branch = "patch-sha2-v0.10.8" }
+
+[features]
+mock = ["strata-sp1-adapter/mock"]

--- a/provers/sp1/guest-checkpoint/Cargo.toml
+++ b/provers/sp1/guest-checkpoint/Cargo.toml
@@ -14,3 +14,6 @@ strata-sp1-adapter = { path = "../../../crates/zkvm/adapters/sp1", features = [
 [patch.crates-io]
 secp256k1 = { git = "https://github.com/sp1-patches/rust-secp256k1", branch = "patch-secp256k1-v0.29.1" }
 sha2-v0-10-8 = { git = "https://github.com/sp1-patches/RustCrypto-hashes", package = "sha2", branch = "patch-sha2-v0.10.8" }
+
+[features]
+mock = ["strata-sp1-adapter/mock"]

--- a/provers/sp1/guest-cl-agg/Cargo.toml
+++ b/provers/sp1/guest-cl-agg/Cargo.toml
@@ -14,3 +14,6 @@ strata-sp1-adapter = { path = "../../../crates/zkvm/adapters/sp1", features = [
 [patch.crates-io]
 secp256k1 = { git = "https://github.com/sp1-patches/rust-secp256k1", branch = "patch-secp256k1-v0.29.1" }
 sha2-v0-10-8 = { git = "https://github.com/sp1-patches/RustCrypto-hashes", package = "sha2", branch = "patch-sha2-v0.10.8" }
+
+[features]
+mock = ["strata-sp1-adapter/mock"]

--- a/provers/sp1/guest-cl-stf/Cargo.toml
+++ b/provers/sp1/guest-cl-stf/Cargo.toml
@@ -14,3 +14,6 @@ strata-sp1-adapter = { path = "../../../crates/zkvm/adapters/sp1", features = [
 [patch.crates-io]
 secp256k1 = { git = "https://github.com/sp1-patches/rust-secp256k1", branch = "patch-secp256k1-v0.29.1" }
 sha2-v0-10-8 = { git = "https://github.com/sp1-patches/RustCrypto-hashes", package = "sha2", branch = "patch-sha2-v0.10.8" }
+
+[features]
+mock = ["strata-sp1-adapter/mock"]

--- a/provers/sp1/guest-evm-ee-stf/Cargo.toml
+++ b/provers/sp1/guest-evm-ee-stf/Cargo.toml
@@ -17,3 +17,6 @@ revm-primitives = { git = "https://github.com/sp1-patches/revm-new", branch = "j
 secp256k1 = { git = "https://github.com/sp1-patches/rust-secp256k1", branch = "patch-secp256k1-v0.29.1" }
 sha2-v0-10-8 = { git = "https://github.com/sp1-patches/RustCrypto-hashes", package = "sha2", branch = "patch-sha2-v0.10.8" }
 tiny-keccak = { git = "https://github.com/sp1-patches/tiny-keccak", branch = "patch-v2.0.2" }
+
+[features]
+mock = ["strata-sp1-adapter/mock"]

--- a/provers/sp1/guest-l1-batch/Cargo.toml
+++ b/provers/sp1/guest-l1-batch/Cargo.toml
@@ -15,3 +15,6 @@ strata-sp1-adapter = { path = "../../../crates/zkvm/adapters/sp1", features = [
 [patch.crates-io]
 secp256k1 = { git = "https://github.com/sp1-patches/rust-secp256k1", branch = "patch-secp256k1-v0.29.1" }
 sha2-v0-10-8 = { git = "https://github.com/sp1-patches/RustCrypto-hashes", package = "sha2", branch = "patch-sha2-v0.10.8" }
+
+[features]
+mock = ["strata-sp1-adapter/mock"]

--- a/provers/tests/Cargo.toml
+++ b/provers/tests/Cargo.toml
@@ -45,4 +45,8 @@ strata-risc0-guest-builder = { path = "../risc0", optional = true, features = [
 default = ["sp1"]
 sp1 = ["strata-sp1-adapter", "strata-sp1-guest-builder"]
 risc0 = ["strata-risc0-adapter", "strata-risc0-guest-builder"]
-mock = ["strata-sp1-guest-builder/mock", "strata-sp1-adapter/mock"]
+mock = [
+  "strata-sp1-guest-builder/mock",
+  "strata-sp1-adapter/mock",
+  "strata-risc0-adapter/mock",
+]

--- a/provers/tests/Cargo.toml
+++ b/provers/tests/Cargo.toml
@@ -42,6 +42,7 @@ strata-risc0-guest-builder = { path = "../risc0", optional = true, features = [
 ] }
 
 [features]
+default = ["sp1"]
 sp1 = ["strata-sp1-adapter", "strata-sp1-guest-builder"]
 risc0 = ["strata-risc0-adapter", "strata-risc0-guest-builder"]
-default = ["sp1"]
+mock = ["strata-sp1-guest-builder/mock", "strata-sp1-adapter/mock"]


### PR DESCRIPTION
## Description

<!--
Provide a brief summary of the changes and the motivation behind them.
-->
This update extends SP1's mock mode to support guest programs that include proof composition. Previously, SP1 mock mode was limited to programs without proof composition capabilities. A new feature flag has been introduced for both Risc0 and SP1, enabling the system to assume the proof composition component when running in mock mode. 

### Type of Change

<!--
Select the type of change your PR introduces (put an `x` in all that apply):-
-->

-   [ ] Bug fix (non-breaking change which fixes an issue)
-   [x] New feature/Enhancement (non-breaking change which adds functionality or enhances an existing one)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] Documentation update
-   [ ] Refactor
-   [ ] New or updated tests

## Checklist

<!--
Ensure all the following are checked:
-->

-   [x] I have performed a self-review of my code.
-   [ ] I have commented my code where necessary.
-   [ ] I have updated the documentation if needed.
-   [x] My changes do not introduce new warnings.
-   [ ] I have added tests that prove my changes are effective or that my feature works.
-   [ ] New and existing tests pass with my changes.

## Related Issues

<!--
Link any related issues (e.g., `closes #123`, `fixes #456`).
-->
