### PR TITLE
doc: add new type "dependencies" to PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -7,15 +7,23 @@ Provide a brief summary of the changes and the motivation behind them.
 ### Type of Change
 
 <!--
-Select the type of change your PR introduces (put an `x` in all that apply):-
+Select the type of change your PR introduces (put an `x` in all that apply):
 -->
 
--   [ ] Bug fix (non-breaking change which fixes an issue)
--   [ ] New feature/Enhancement (non-breaking change which adds functionality or enhances an existing one)
--   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
--   [ ] Documentation update
--   [ ] Refactor
--   [ ] New or updated tests
+- [ ] Bug fix (non-breaking change which fixes an issue)
+- [ ] New feature/Enhancement (non-breaking change which adds functionality or enhances an existing one)
+- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
+- [ ] Documentation update
+- [ ] Refactor
+- [ ] New or updated tests
+- [ ] Dependency Update
+
+## Notes to Reviewer's
+
+<!--
+Anything in particular you want to note that will help reviewer's fulfill their role
+in reviewing this PR?
+-->
 
 ## Checklist
 
@@ -23,12 +31,12 @@ Select the type of change your PR introduces (put an `x` in all that apply):-
 Ensure all the following are checked:
 -->
 
--   [ ] I have performed a self-review of my code.
--   [ ] I have commented my code where necessary.
--   [ ] I have updated the documentation if needed.
--   [ ] My changes do not introduce new warnings.
--   [ ] I have added tests that prove my changes are effective or that my feature works.
--   [ ] New and existing tests pass with my changes.
+- [ ] I have performed a self-review of my code.
+- [ ] I have commented my code where necessary.
+- [ ] I have updated the documentation if needed.
+- [ ] My changes do not introduce new warnings.
+- [ ] I have added tests that prove my changes are effective or that my feature works.
+- [ ] New and existing tests pass with my changes.
 
 ## Related Issues
 


### PR DESCRIPTION
## Description

I was a little annoyed that I had to add new variant for dependencies manually in the template every time that I had to open a PR.
So I decided to change the PR template.
Since I was editing it I did some tweaks as well.

### Type of Change

<!--
Select the type of change your PR introduces (put an `x` in all that apply):-
-->

-   [ ] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature/Enhancement (non-breaking change which adds functionality or enhances an existing one)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [x] Documentation update
-   [ ] Refactor
-   [ ] New or updated tests

## Checklist

<!--
Ensure all the following are checked:
-->

-   [ ] I have performed a self-review of my code.
-   [ ] I have commented my code where necessary.
-   [ ] I have updated the documentation if needed.
-   [ ] My changes do not introduce new warnings.
-   [ ] I have added tests that prove my changes are effective or that my feature works.
-   [ ] New and existing tests pass with my changes.
