### PR TITLE
chore(deps): bump bitcoin to 0.32.5

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2072,9 +2072,9 @@ checksum = "349f9b6a179ed607305526ca489b34ad0a41aed5f7980fa90eb03160b69598fb"
 
 [[package]]
 name = "bitcoin"
-version = "0.32.3"
+version = "0.32.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0032b0e8ead7074cda7fc4f034409607e3f03a6f71d66ade8a307f79b4d99e73"
+checksum = "ce6bc65742dea50536e35ad42492b234c27904a27f0abdcbce605015cb4ea026"
 dependencies = [
  "base58ck",
  "base64 0.21.7",
@@ -6129,7 +6129,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e310b3a6b5907f99202fcdb4960ff45b93735d7c7d96b760fcff8db2dc0e103d"
 dependencies = [
  "cfg-if",
- "windows-targets 0.48.5",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -180,7 +180,7 @@ argh = "0.1"
 async-trait = "0.1.80"
 base64 = "0.22.1"
 bincode = "1.3"
-bitcoin = { version = "=0.32.3", features = ["serde"] }
+bitcoin = { version = "=0.32.5", features = ["serde"] }
 bitcoind = { version = "0.36.0", features = ["26_0"] }
 borsh = { version = "1.5.0", features = ["derive"] }
 bytes = "1.6.0"

--- a/bin/strata-client/src/extractor.rs
+++ b/bin/strata-client/src/extractor.rs
@@ -81,7 +81,7 @@ pub(super) async fn extract_deposit_requests<L1DB: L1Database>(
 
         let network_params = match network {
             Network::Bitcoin => Params::MAINNET,
-            Network::Testnet => Params::TESTNET,
+            Network::Testnet => Params::TESTNET4,
             Network::Signet => Params::SIGNET,
             Network::Regtest => Params::REGTEST,
             _ => unimplemented!("{} network not handled", network),


### PR DESCRIPTION
## Description

Updates `rust-bitcoin` to 0.32.5 on all Strata.

### Type of Change

<!--
Select the type of change your PR introduces (put an `x` in all that apply):
-->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature/Enhancement (non-breaking change which adds functionality or enhances an existing one)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactor
- [ ] New or updated tests
- [x] Dependency Update

## Notes to Reviewers

Notable changes from version 0.32.3 that this PR is bumping from:

- Add testnet 4 support [#3453](https://github.com/rust-bitcoin/rust-bitcoin/pull/3453)
- Add difficulty adjustment calculation [#3494](https://github.com/rust-bitcoin/rust-bitcoin/pull/3494) (we might be able to use it, I remember we found a bug in `rust-bitcoin`'s PoW calculation Cc @delbonis)
- Fix bug in witness stack getters [#3626](https://github.com/rust-bitcoin/rust-bitcoin/pull/3626) (Cc @prajwolrg whom I remember was doing some witness getter or am I going crazy?)
- Some additional inspectors on `Script` and `Witness` [#2646](https://github.com/rust-bitcoin/rust-bitcoin/pull/2646)
- address: Add `Address::into_unchecked` [#3655](https://github.com/rust-bitcoin/rust-bitcoin/pull/3655) (we don't need `assume_checked()` but to be honest I wan't to not use it anymore and neither use `into_checked`).

## Checklist

- [x] I have performed a self-review of my code.
- [x] I have commented my code where necessary.
- [x] I have updated the documentation if needed.
- [x] My changes do not introduce new warnings.
- [x] I have added tests that prove my changes are effective or that my feature works.
- [x] New and existing tests pass with my changes.
