### PR TITLE
STR-670: Remove deprecated `bitcoind` crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5614,7 +5614,6 @@ name = "integration-tests"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "bitcoin",
  "bitcoincore-rpc",
  "corepc-node",
  "strata-bridge-sig-manager",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2156,24 +2156,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "bitcoind"
-version = "0.36.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ee5cf6a9903ff9cc808494c1232b0e9f6eef6600913d0d69fe1cb5c428f25b9"
-dependencies = [
- "anyhow",
- "bitcoin_hashes 0.14.0",
- "bitcoincore-rpc",
- "flate2",
- "log",
- "minreq",
- "tar",
- "tempfile",
- "which",
- "zip",
-]
-
-[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3013,6 +2995,51 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b49ba7ef1ad6107f8824dbe97de947cbaac53c44e7f9756a1fba0d37c1eec505"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "corepc-client"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b926446a90cd329b8ce85ea40d74e1961d0ad42ea0bc0708a82e5ca843fe631d"
+dependencies = [
+ "bitcoin",
+ "corepc-types",
+ "jsonrpc",
+ "log",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "corepc-node"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d73264e3fa9857a43c8c51dba528646c355773617924f0b9e821d078f11a6fb"
+dependencies = [
+ "anyhow",
+ "bitcoin_hashes 0.14.0",
+ "corepc-client",
+ "flate2",
+ "log",
+ "minreq",
+ "serde_json",
+ "tar",
+ "tempfile",
+ "which",
+ "zip",
+]
+
+[[package]]
+name = "corepc-types"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7efadd36b3035cb5dda5c8346d6314a16507b4d26269a553733d12b5bbf9b31"
+dependencies = [
+ "bitcoin",
+ "bitcoin-internals",
+ "serde",
+ "serde_json",
 ]
 
 [[package]]
@@ -5588,7 +5615,8 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "bitcoin",
- "bitcoind",
+ "bitcoincore-rpc",
+ "corepc-node",
  "strata-bridge-sig-manager",
  "strata-bridge-tx-builder",
  "strata-common",
@@ -12725,8 +12753,8 @@ dependencies = [
  "argh",
  "async-trait",
  "bitcoin",
- "bitcoind",
  "chrono",
+ "corepc-node",
  "directories",
  "jsonrpsee",
  "miniscript",
@@ -12835,9 +12863,9 @@ dependencies = [
  "async-trait",
  "base64 0.22.1",
  "bitcoin",
- "bitcoind",
  "borsh",
  "bytes",
+ "corepc-node",
  "hex",
  "mockall",
  "musig2",
@@ -13313,7 +13341,7 @@ dependencies = [
  "anyhow",
  "bdk_bitcoind_rpc",
  "bdk_wallet",
- "bitcoind",
+ "corepc-node",
  "musig2",
  "pyo3",
  "pyo3-build-config",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -181,7 +181,6 @@ async-trait = "0.1.80"
 base64 = "0.22.1"
 bincode = "1.3"
 bitcoin = { version = "=0.32.5", features = ["serde"] }
-bitcoind = { version = "0.36.0", features = ["26_0"] }
 borsh = { version = "1.5.0", features = ["derive"] }
 bytes = "1.6.0"
 chrono = "0.4.38"

--- a/bin/bridge-client/Cargo.toml
+++ b/bin/bridge-client/Cargo.toml
@@ -41,4 +41,4 @@ tokio.workspace = true
 tracing.workspace = true
 
 [dev-dependencies]
-bitcoind.workspace = true
+corepc-node = { version = "0.4.0", features = ["28_0"] }

--- a/bin/bridge-client/src/descriptor.rs
+++ b/bin/bridge-client/src/descriptor.rs
@@ -118,7 +118,7 @@ pub(crate) async fn check_or_load_descriptor_into_wallet(
 
 #[cfg(test)]
 mod tests {
-    use bitcoind::BitcoinD;
+    use corepc_node::BitcoinD;
     use strata_btcio::rpc::{
         traits::Signer,
         types::{ImportDescriptor, ImportDescriptorResult},

--- a/crates/btcio/Cargo.toml
+++ b/crates/btcio/Cargo.toml
@@ -33,12 +33,13 @@ tokio.workspace = true
 tracing.workspace = true
 
 [dev-dependencies]
-arbitrary.workspace = true
-bitcoind.workspace = true
-mockall.workspace = true
 strata-common.workspace = true
 strata-rocksdb = { workspace = true, features = ["test_utils"] }
 strata-test-utils.workspace = true
+
+arbitrary.workspace = true
+mockall.workspace = true
+corepc-node = { version = "0.4.0", features = ["28_0"] }
 
 [features]
 test_utils = []

--- a/crates/btcio/src/rpc/client.rs
+++ b/crates/btcio/src/rpc/client.rs
@@ -390,7 +390,7 @@ mod test {
     use std::env::set_var;
 
     use bitcoin::{consensus, hashes::Hash, NetworkKind};
-    use bitcoind::{bitcoincore_rpc::RpcApi, BitcoinD};
+    use corepc_node::BitcoinD;
     use strata_common::logging;
 
     use super::*;
@@ -411,14 +411,15 @@ mod test {
     ) -> anyhow::Result<Vec<BlockHash>> {
         let coinbase_address = match address {
             Some(address) => address,
-            None => bitcoind
-                .client
-                .get_new_address(None, None)?
-                .assume_checked(),
+            None => bitcoind.client.new_address()?,
         };
         let block_hashes = bitcoind
             .client
-            .generate_to_address(count as _, &coinbase_address)?;
+            .generate_to_address(count as _, &coinbase_address)?
+            .0
+            .iter()
+            .map(|hash| hash.parse::<BlockHash>())
+            .collect::<Result<Vec<_>, _>>()?;
         Ok(block_hashes)
     }
 

--- a/crates/util/python-utils/Cargo.toml
+++ b/crates/util/python-utils/Cargo.toml
@@ -13,30 +13,27 @@ name = "strata_utils"
 crate-type = ["cdylib"]
 
 [dependencies]
+shrex = { version = "0.1.0", path = "../shrex", features = ["serde"] }
 
 bdk_bitcoind_rpc = "0.16.0"
 # TODO: once bdk_wallet 1.0 is released, update this and don't change!
 bdk_wallet = "1.0.0-beta.5"
-# "abi3-py310" tells pyo3 (and maturin) to build using the stable ABI with minimum Python version 3.10
 musig2.workspace = true
+# "abi3-py310" tells pyo3 (and maturin) to build using the stable ABI with minimum Python version 3.10
 pyo3 = { version = "0.22.6", features = ["extension-module", "abi3-py310"] }
 reth-primitives.workspace = true
 # TODO: secp256k1 is not used directly in this crate, but through the chain of re-imports from bdk.
 # However, removing this from the dependency list makes it fail to build.
 secp256k1.workspace = true
 
-# Internal crates
-shrex = { version = "0.1.0", path = "../shrex", features = ["serde"] }
-
 [target.'cfg(target_os = "macos")'.build-dependencies]
 pyo3-build-config = "0.22.6"
 
 [dev-dependencies]
-anyhow.workspace = true
-bitcoind.workspace = true
-tokio.workspace = true
-tracing.workspace = true
-
-# Internal crates
 strata-btcio.workspace = true
 strata-common.workspace = true
+
+anyhow.workspace = true
+corepc-node = { version = "0.4.0", features = ["28_0"] }
+tokio.workspace = true
+tracing.workspace = true

--- a/crates/util/python-utils/src/drt.rs
+++ b/crates/util/python-utils/src/drt.rs
@@ -462,7 +462,7 @@ pub(crate) fn get_balance_recovery_inner(
 #[cfg(test)]
 mod tests {
     use bdk_wallet::{bitcoin::Amount, KeychainKind, LocalOutput};
-    use bitcoind::{bitcoincore_rpc::RpcApi, BitcoinD};
+    use corepc_node::BitcoinD;
     use strata_btcio::rpc::{traits::Broadcaster, BitcoinClient};
     use strata_common::logging;
     use tokio::time::{sleep, Duration};
@@ -491,10 +491,7 @@ mod tests {
     ) -> anyhow::Result<()> {
         let coinbase_address = match address {
             Some(address) => address,
-            None => bitcoind
-                .client
-                .get_new_address(None, None)?
-                .assume_checked(),
+            None => bitcoind.client.new_address()?,
         };
         let _ = bitcoind
             .client

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -20,9 +20,9 @@ strata-primitives.workspace = true
 strata-rocksdb.workspace = true
 strata-storage.workspace = true
 
-anyhow.workspace = true                                 # anyhow should be fine for tests
-bitcoin = { workspace = true, features = ["rand-std"] }
-bitcoind.workspace = true
+anyhow.workspace = true                                  # anyhow should be fine for tests
+bitcoincore-rpc = "0.19.0"
+corepc-node = { version = "0.4.0", features = ["28_0"] }
 threadpool.workspace = true
 tokio.workspace = true
 tracing.workspace = true

--- a/tests/common/bitcoind.rs
+++ b/tests/common/bitcoind.rs
@@ -1,0 +1,8 @@
+use corepc_node::BitcoinD;
+
+/// Get the authentication credentials for a given `bitcoind` instance.
+pub(crate) fn get_auth(bitcoind: &BitcoinD) -> (String, String) {
+    let params = &bitcoind.params;
+    let cookie_values = params.get_cookie_values().unwrap().unwrap();
+    (cookie_values.user, cookie_values.password)
+}

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -12,4 +12,5 @@
 //! is `dead code` even though it is actually being used by another test "crate".
 //! Apparently, `clippy` isn't smart enough for that kind of analysis.
 
+pub(crate) mod bitcoind;
 pub(crate) mod bridge;

--- a/tests/cooperative-bridge-out-flow.rs
+++ b/tests/cooperative-bridge-out-flow.rs
@@ -5,12 +5,12 @@
 
 use std::sync::Arc;
 
-use bitcoin::{
+use bitcoincore_rpc::bitcoin::{
     key::rand::{self, Rng},
     Address, Amount, Network, OutPoint, ScriptBuf, Transaction,
 };
-use bitcoind::BitcoinD;
 use common::bridge::{setup, BridgeDuty, User, MIN_MINER_REWARD_CONFS};
+use corepc_node::BitcoinD;
 use rand::rngs::OsRng;
 use strata_bridge_tx_builder::prelude::{
     create_taproot_addr, create_tx, create_tx_ins, create_tx_outs, get_aggregated_pubkey,
@@ -25,7 +25,7 @@ mod common;
 #[tokio::test]
 async fn withdrawal_flow() {
     let num_operators = 5;
-    let (bitcoind, federation) = setup(num_operators).await;
+    let (bitcoind, _client, federation) = setup(num_operators).await;
 
     let span = span!(Level::WARN, "starting cooperative withdrawal flow");
     let _guard = span.enter();


### PR DESCRIPTION
## Description

`bitcoind` has been deprecated (see the warning here: https://docs.rs/bitcoind/latest/bitcoind/ )

We should move to [`corepc`](https://github.com/rust-bitcoin/corepc) which also is up-to-date with bitcoin version 28.0, while `bitcoind` is stuck in version 26.0.

### Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature/Enhancement (non-breaking change which adds functionality or enhances an existing one)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Refactor
- [ ] New or updated tests
- [x] Dependency Update

## Notes to Reviewers

- I had to bring [`bitcoincore-rpc`](https://github.com/rust-bitcoin/rust-bitcoincore-rpc) for some compatibility without major rewrites in the integration tests, i.e. `tests/`.
- I purposely did not add them to the root-level `Cargo.toml` since they are `dev-dependencies` and I don't want to add them to the compile bloat whenever we do `cargo build` (or save a file with `rust-analyzer`).

## Checklist

- [x] I have performed a self-review of my code.
- [x] I have commented my code where necessary.
- [x] I have updated the documentation if needed.
- [x] My changes do not introduce new warnings.
- [x] I have added tests that prove my changes are effective or that my feature works.
- [x] New and existing tests pass with my changes.

## Related Issues

STR-670
