### PR TITLE
Changes in ArbitraryGenerator

### DIFF
--- a/bin/strata-client/src/extractor.rs
+++ b/bin/strata-client/src/extractor.rs
@@ -337,7 +337,7 @@ mod tests {
         max_txs_per_block: usize,
         needle: (Vec<u8>, ProtocolOperation),
     ) -> usize {
-        let arb = ArbitraryGenerator::new();
+        let mut arb = ArbitraryGenerator::new();
         assert!(
             num_blocks.gt(&0) && max_txs_per_block.gt(&0),
             "num_blocks and max_tx_per_block must be at least 1"
@@ -397,7 +397,7 @@ mod tests {
 
     /// Create a known transaction that should be present in some block.
     fn get_needle() -> (Vec<u8>, ProtocolOperation, DepositInfo) {
-        let arb = ArbitraryGenerator::new();
+        let mut arb = ArbitraryGenerator::new();
         let network = Network::Regtest;
 
         let el_address: [u8; 20] = arb.generate();
@@ -469,20 +469,20 @@ mod tests {
     ///    So, you can assume that this flag represents whether the pair is valid (true) or invalid
     ///    (false).
     fn generate_mock_tx() -> (Vec<u8>, ProtocolOperation, bool) {
-        let arb = ArbitraryGenerator::new();
+        let mut arb = ArbitraryGenerator::new();
 
         let should_be_valid: bool = arb.generate();
 
         if should_be_valid.not() {
-            let (invalid_tx, invalid_protocol_op) = generate_invalid_tx(&arb);
+            let (invalid_tx, invalid_protocol_op) = generate_invalid_tx(&mut arb);
             return (invalid_tx, invalid_protocol_op, should_be_valid);
         }
 
-        let (valid_tx, valid_protocol_op) = generate_valid_tx(&arb);
+        let (valid_tx, valid_protocol_op) = generate_valid_tx(&mut arb);
         (valid_tx, valid_protocol_op, should_be_valid)
     }
 
-    fn generate_invalid_tx(arb: &ArbitraryGenerator) -> (Vec<u8>, ProtocolOperation) {
+    fn generate_invalid_tx(arb: &mut ArbitraryGenerator) -> (Vec<u8>, ProtocolOperation) {
         let random_protocol_op: ProtocolOperation = arb.generate();
 
         // true => tx invalid
@@ -509,7 +509,7 @@ mod tests {
         (tx_with_invalid_script_pubkey, random_protocol_op)
     }
 
-    fn generate_valid_tx(arb: &ArbitraryGenerator) -> (Vec<u8>, ProtocolOperation) {
+    fn generate_valid_tx(arb: &mut ArbitraryGenerator) -> (Vec<u8>, ProtocolOperation) {
         let (tx, spend_info, script_to_spend) = generate_mock_unsigned_tx();
 
         let random_hash = *spend_info
@@ -565,7 +565,7 @@ mod tests {
         let empty_deposits = empty_chain_state.deposits_table_mut();
         let mut deposits_table = DepositsTable::new_empty();
 
-        let arb = ArbitraryGenerator::new();
+        let mut arb = ArbitraryGenerator::new();
 
         let mut operators: Vec<OperatorIdx> = arb.generate();
         loop {

--- a/crates/bridge-relay/src/relayer.rs
+++ b/crates/bridge-relay/src/relayer.rs
@@ -245,7 +245,7 @@ mod tests {
         let processed_msgs = RecentMessageTracker::new();
 
         // Create valid BridgeMsgId instances for testing
-        let ag = ArbitraryGenerator::new();
+        let mut ag = ArbitraryGenerator::new();
         let cur_message_id: BridgeMsgId = ag.generate();
         let old_message_id: BridgeMsgId = ag.generate();
         assert_ne!(cur_message_id, old_message_id);

--- a/crates/consensus-logic/src/duty/block_assembly.rs
+++ b/crates/consensus-logic/src/duty/block_assembly.rs
@@ -444,7 +444,7 @@ mod tests {
 
     #[test]
     fn test_find_pivot_noop() {
-        let ag = ArbitraryGenerator::new_with_size(1 << 12);
+        let mut ag = ArbitraryGenerator::new_with_size(1 << 12);
 
         let blkids: [L1BlockId; 10] = ag.generate();
         eprintln!("{blkids:#?}");
@@ -467,7 +467,7 @@ mod tests {
 
     #[test]
     fn test_find_pivot_noop_offset() {
-        let ag = ArbitraryGenerator::new_with_size(1 << 12);
+        let mut ag = ArbitraryGenerator::new_with_size(1 << 12);
 
         let blkids: [L1BlockId; 10] = ag.generate();
         eprintln!("{blkids:#?}");
@@ -490,7 +490,7 @@ mod tests {
 
     #[test]
     fn test_find_pivot_simple_extend() {
-        let ag = ArbitraryGenerator::new_with_size(1 << 12);
+        let mut ag = ArbitraryGenerator::new_with_size(1 << 12);
 
         let blkids1: [L1BlockId; 10] = ag.generate();
         let mut blkids2 = Vec::from(blkids1);
@@ -522,7 +522,7 @@ mod tests {
 
     #[test]
     fn test_find_pivot_typical_reorg() {
-        let ag = ArbitraryGenerator::new_with_size(1 << 16);
+        let mut ag = ArbitraryGenerator::new_with_size(1 << 16);
 
         let mut blkids1: Vec<L1BlockId> = Vec::new();
         for _ in 0..10 {
@@ -559,7 +559,7 @@ mod tests {
 
     #[test]
     fn test_find_pivot_cur_shorter_reorg() {
-        let ag = ArbitraryGenerator::new_with_size(1 << 16);
+        let mut ag = ArbitraryGenerator::new_with_size(1 << 16);
 
         let mut blkids1: Vec<L1BlockId> = Vec::new();
         for _ in 0..10 {
@@ -600,7 +600,7 @@ mod tests {
 
     #[test]
     fn test_find_pivot_disjoint() {
-        let ag = ArbitraryGenerator::new_with_size(1 << 16);
+        let mut ag = ArbitraryGenerator::new_with_size(1 << 16);
 
         let mut blkids1: Vec<L1BlockId> = Vec::new();
         for _ in 0..10 {

--- a/crates/evmexec/src/engine.rs
+++ b/crates/evmexec/src/engine.rs
@@ -518,7 +518,7 @@ mod tests {
 
         let el_payload = random_el_payload();
 
-        let arb = strata_test_utils::ArbitraryGenerator::new();
+        let mut arb = strata_test_utils::ArbitraryGenerator::new();
         let l2block: L2Block = arb.generate();
         let accessory = L2BlockAccessory::new(borsh::to_vec(&el_payload).unwrap());
         let l2block_bundle = L2BlockBundle::new(l2block, accessory);

--- a/crates/primitives/src/l1.rs
+++ b/crates/primitives/src/l1.rs
@@ -1314,7 +1314,7 @@ mod tests {
 
     #[test]
     fn test_bitcoin_txid_serialize_deserialize() {
-        let generator = ArbitraryGenerator::new();
+        let mut generator = ArbitraryGenerator::new();
         let txid: BitcoinTxid = generator.generate();
 
         let serialized_txid =

--- a/crates/primitives/src/relay/util.rs
+++ b/crates/primitives/src/relay/util.rs
@@ -187,7 +187,7 @@ mod tests {
 
     #[test]
     fn test_message_signer_serde() {
-        let generator = ArbitraryGenerator::new();
+        let mut generator = ArbitraryGenerator::new();
         let txid: BitcoinTxid = generator.generate();
         let scope = Scope::V0PubNonce(txid);
         let payload: Musig2PubNonce = generator.generate();

--- a/crates/rocksdb-store/src/bridge/db.rs
+++ b/crates/rocksdb-store/src/bridge/db.rs
@@ -233,7 +233,7 @@ mod tests {
     fn test_bridge_duty_status_db() {
         let db = setup_duty_db();
 
-        let arb = ArbitraryGenerator::new();
+        let mut arb = ArbitraryGenerator::new();
 
         let duty_status: BridgeDutyStatus = arb.generate();
         let txid: BitcoinTxid = arb.generate();
@@ -315,7 +315,7 @@ mod tests {
     fn test_bridge_duty_index_db() {
         let db = setup_bridge_duty_index_db();
 
-        let arb = ArbitraryGenerator::new();
+        let mut arb = ArbitraryGenerator::new();
 
         let checkpoint: u64 = arb.generate();
 

--- a/crates/rocksdb-store/src/bridge_relay/db.rs
+++ b/crates/rocksdb-store/src/bridge_relay/db.rs
@@ -118,7 +118,7 @@ mod tests {
     }
 
     fn make_bridge_msg() -> (u128, BridgeMessage) {
-        let arb = ArbitraryGenerator::new();
+        let mut arb = ArbitraryGenerator::new();
 
         let msg: BridgeMessage = arb.generate();
 

--- a/crates/rocksdb-store/src/l1/db.rs
+++ b/crates/rocksdb-store/src/l1/db.rs
@@ -239,7 +239,7 @@ mod tests {
         db: &L1Db,
         num_txs: usize,
     ) -> (L1BlockManifest, Vec<L1Tx>, CompactMmr) {
-        let arb = ArbitraryGenerator::new();
+        let mut arb = ArbitraryGenerator::new();
 
         // TODO maybe tweak this to make it a bit more realistic?
         let mf: L1BlockManifest = arb.generate();

--- a/crates/rocksdb-store/src/l2/db.rs
+++ b/crates/rocksdb-store/src/l2/db.rs
@@ -117,7 +117,7 @@ mod tests {
     use crate::test_utils::get_rocksdb_tmp_instance;
 
     fn get_mock_data() -> L2BlockBundle {
-        let arb = ArbitraryGenerator::new();
+        let mut arb = ArbitraryGenerator::new();
         let l2_block: L2BlockBundle = arb.generate();
 
         l2_block

--- a/crates/test-utils/src/l2.rs
+++ b/crates/test-utils/src/l2.rs
@@ -20,7 +20,7 @@ use strata_state::{
 use crate::{bitcoin::get_btc_chain, ArbitraryGenerator};
 
 pub fn gen_block(parent: Option<&SignedL2BlockHeader>) -> L2BlockBundle {
-    let arb = ArbitraryGenerator::new();
+    let mut arb = ArbitraryGenerator::new();
     let header: L2BlockHeader = arb.generate();
     let body: L2BlockBody = arb.generate();
     let accessory: L2BlockAccessory = arb.generate();

--- a/crates/test-utils/src/lib.rs
+++ b/crates/test-utils/src/lib.rs
@@ -18,16 +18,39 @@ impl Default for ArbitraryGenerator {
     }
 }
 impl ArbitraryGenerator {
+    /// Creates a new `ArbitraryGenerator` with a default buffer size.
+    ///
+    /// # Returns
+    ///
+    /// A new instance of `ArbitraryGenerator`.
     pub fn new() -> Self {
         ArbitraryGenerator {
             buf: vec![0u8; ARB_GEN_LEN],
         }
     }
+
+    /// Creates a new `ArbitraryGenerator` with a specified buffer size.
+    ///
+    /// # Arguments
+    ///
+    /// * `s` - The size of the buffer to be used.
+    ///
+    /// # Returns
+    ///
+    /// A new instance of `ArbitraryGenerator` with the specified buffer size.
     pub fn new_with_size(s: usize) -> Self {
         ArbitraryGenerator { buf: vec![0u8; s] }
     }
 
-    /// Legacy interface: no arguments
+    /// Generates an arbitrary instance of type `T` using the default RNG, [`OsRng`].
+    ///
+    /// # Returns
+    ///
+    /// An arbitrary instance of type `T`.
+    ///
+    /// # Panics
+    ///
+    /// This function will panic if it fails to generate an arbitrary instance.
     pub fn generate<'a, T>(&'a mut self) -> T
     where
         T: Arbitrary<'a> + Clone,
@@ -35,7 +58,21 @@ impl ArbitraryGenerator {
         self.generate_with_rng::<T, OsRng>(None)
     }
 
-    /// Core function: accepts an optional RNG
+    /// Generates an arbitrary instance of type `T` using an optional RNG.
+    ///
+    /// # Arguments
+    ///
+    /// * `rng` - An optional RNG to be used for generating the arbitrary instance. If `None`, the
+    ///   default RNG, [`OsRng`], will be used. The provided RNG must implement the [`RngCore`] and
+    ///   [`CryptoRng`] traits.
+    ///
+    /// # Returns
+    ///
+    /// An arbitrary instance of type `T`.
+    ///
+    /// # Panics
+    ///
+    /// This function will panic if it fails to generate an arbitrary instance.
     pub fn generate_with_rng<'a, T, R>(&'a mut self, rng: Option<&mut R>) -> T
     where
         T: Arbitrary<'a> + Clone,

--- a/crates/test-utils/src/lib.rs
+++ b/crates/test-utils/src/lib.rs
@@ -6,8 +6,8 @@ pub mod bridge;
 pub mod evm_ee;
 pub mod l2;
 
-// Smaller buffer size as compared to 2^24
-const ARB_GEN_LEN: usize = 128;
+/// The default buffer size for the `ArbitraryGenerator`.
+const ARB_GEN_LEN: usize = 1024;
 
 pub struct ArbitraryGenerator {
     buf: Vec<u8>, // Persistent buffer
@@ -24,9 +24,7 @@ impl ArbitraryGenerator {
     ///
     /// A new instance of `ArbitraryGenerator`.
     pub fn new() -> Self {
-        ArbitraryGenerator {
-            buf: vec![0u8; ARB_GEN_LEN],
-        }
+        Self::new_with_size(ARB_GEN_LEN)
     }
 
     /// Creates a new `ArbitraryGenerator` with a specified buffer size.
@@ -39,7 +37,7 @@ impl ArbitraryGenerator {
     ///
     /// A new instance of `ArbitraryGenerator` with the specified buffer size.
     pub fn new_with_size(s: usize) -> Self {
-        ArbitraryGenerator { buf: vec![0u8; s] }
+        Self { buf: vec![0u8; s] }
     }
 
     /// Generates an arbitrary instance of type `T` using the default RNG, [`OsRng`].
@@ -47,43 +45,28 @@ impl ArbitraryGenerator {
     /// # Returns
     ///
     /// An arbitrary instance of type `T`.
-    ///
-    /// # Panics
-    ///
-    /// This function will panic if it fails to generate an arbitrary instance.
     pub fn generate<'a, T>(&'a mut self) -> T
     where
         T: Arbitrary<'a> + Clone,
     {
-        self.generate_with_rng::<T, OsRng>(None)
+        self.generate_with_rng::<T, OsRng>(&mut OsRng)
     }
 
-    /// Generates an arbitrary instance of type `T` using an optional RNG.
+    /// Generates an arbitrary instance of type `T`.
     ///
     /// # Arguments
     ///
-    /// * `rng` - An optional RNG to be used for generating the arbitrary instance. If `None`, the
-    ///   default RNG, [`OsRng`], will be used. The provided RNG must implement the [`RngCore`] and
-    ///   [`CryptoRng`] traits.
+    /// * `rng` - An RNG to be used for generating the arbitrary instance. Provided RNG must
+    ///   implement the [`RngCore`] and [`CryptoRng`] traits.
     ///
     /// # Returns
     ///
     /// An arbitrary instance of type `T`.
-    ///
-    /// # Panics
-    ///
-    /// This function will panic if it fails to generate an arbitrary instance.
-    pub fn generate_with_rng<'a, T, R>(&'a mut self, rng: Option<&mut R>) -> T
+    pub fn generate_with_rng<'a, T, R>(&'a mut self, rng: &mut R) -> T
     where
         T: Arbitrary<'a> + Clone,
         R: RngCore + CryptoRng,
     {
-        let mut thread_rng = OsRng; // Default secure RNG
-        let rng: &mut dyn RngCore = match rng {
-            Some(r) => r,
-            None => &mut thread_rng as &mut dyn RngCore,
-        };
-
         rng.fill_bytes(&mut self.buf);
         let mut u = Unstructured::new(&self.buf);
         T::arbitrary(&mut u).expect("Failed to generate arbitrary instance")

--- a/crates/test-utils/src/lib.rs
+++ b/crates/test-utils/src/lib.rs
@@ -1,46 +1,40 @@
-use std::sync::atomic::{AtomicUsize, Ordering};
-
 use arbitrary::{Arbitrary, Unstructured};
-use rand::{rngs::OsRng, RngCore};
+use rand::{thread_rng, RngCore};
 
 pub mod bitcoin;
 pub mod bridge;
 pub mod evm_ee;
 pub mod l2;
 
-const ARB_GEN_LEN: usize = 1 << 24; // 16 MiB
+// Smaller buffer size as compared to 2^24
+const ARB_GEN_LEN: usize = 128;
 
 pub struct ArbitraryGenerator {
-    buf: Vec<u8>,
-    off: AtomicUsize,
+    rng: rand::rngs::ThreadRng, // Thread-local RNG
+    buf: Vec<u8>,               // Persistent buffer
 }
-
 impl Default for ArbitraryGenerator {
     fn default() -> Self {
         Self::new()
     }
 }
-
 impl ArbitraryGenerator {
     pub fn new() -> Self {
-        Self::new_with_size(ARB_GEN_LEN)
+        ArbitraryGenerator {
+            rng: thread_rng(),
+            buf: vec![0u8; ARB_GEN_LEN],
+        }
+    }
+    pub fn new_with_size(s: usize) -> Self {
+        ArbitraryGenerator {
+            rng: thread_rng(),
+            buf: vec![0u8; s],
+        }
     }
 
-    pub fn new_with_size(n: usize) -> Self {
-        let mut buf = vec![0; n];
-        OsRng.fill_bytes(&mut buf); // 128 wasn't enough
-        let off = AtomicUsize::new(0);
-        ArbitraryGenerator { buf, off }
-    }
-
-    pub fn generate<'a, T: Arbitrary<'a> + Clone>(&'a self) -> T {
-        // Doing hacky atomics to make this actually be reusable, this is pretty bad.
-        let off = self.off.load(Ordering::Relaxed);
-        let mut u = Unstructured::new(&self.buf[off..]);
-        let prev_off = u.len();
-        let inst = T::arbitrary(&mut u).expect("failed to generate arbitrary instance");
-        let additional_off = prev_off - u.len();
-        self.off.store(off + additional_off, Ordering::Relaxed);
-        inst
+    pub fn generate<'a, T: Arbitrary<'a> + Clone>(&'a mut self) -> T {
+        self.rng.fill_bytes(&mut self.buf);
+        let mut u = Unstructured::new(&self.buf);
+        T::arbitrary(&mut u).expect("Failed to generate arbitrary instance")
     }
 }


### PR DESCRIPTION
## Description
- Used 128 bytes of default buffer size vs 2^24 bytes buffer size earlier.
- Used thread_rng to generate random number in each call as compared to using slices from pre-initialized huge buffer
- Updated unit tests accordingly to work with new changes.

### Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature/Enhancement (non-breaking change which adds functionality or enhances an existing one)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Refactor
- [ ] New or updated tests
- [ ] Dependency Update

## Notes to Reviewers


## Checklist

- [x] I have performed a self-review of my code.
- [x] I have commented my code where necessary.
- [x] I have updated the documentation if needed.
- [x] My changes do not introduce new warnings.
- [ ] I have added tests that prove my changes are effective or that my feature works.
- [x] New and existing tests pass with my changes.

## Related Issues
STR-551
