### PR TITLE
STR-741: Add `zizmor` and harden CI jobs against malicious attackers

### DIFF
--- a/.github/workflows/cron-zizmor.yml
+++ b/.github/workflows/cron-zizmor.yml
@@ -1,0 +1,31 @@
+name: Automated GitHub Actions Security Analysis with zizmor 🌈
+
+on:
+  schedule:
+    - cron: "0 0 * * *" # Run every day at midnight
+
+jobs:
+  zizmor:
+    name: zizmor latest via PyPI
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+
+      - name: Install the latest version of uv
+        uses: astral-sh/setup-uv@v4
+
+      - name: Run zizmor 🌈
+        run: uvx zizmor --format sarif . > results.sarif
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Upload SARIF file
+        uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: results.sarif
+          category: zizmor

--- a/.github/workflows/dependencies.yml
+++ b/.github/workflows/dependencies.yml
@@ -45,15 +45,20 @@ jobs:
       - name: craft commit message and PR body
         id: msg
         run: |
-          export cargo_update_log="$(cat cargo_update.log)"
+          cargo_update_log="$(cat cargo_update.log)"
+          export cargo_update_log
 
-          echo "commit_message<<EOF" >> $GITHUB_OUTPUT
-          printf "$TITLE\n\n$cargo_update_log\n" >> $GITHUB_OUTPUT
-          echo "EOF" >> $GITHUB_OUTPUT
+          {
+            echo "commit_message<<EOF"
+            printf "$TITLE\n\n$cargo_update_log\n"
+            echo "EOF"
+          } >> "$GITHUB_OUTPUT"
 
-          echo "body<<EOF" >> $GITHUB_OUTPUT
-          echo "$BODY" | envsubst >> $GITHUB_OUTPUT
-          echo "EOF" >> $GITHUB_OUTPUT
+          {
+            echo "body<<EOF"
+            echo "$BODY" | envsubst
+            echo "EOF"
+          } >> "$GITHUB_OUTPUT"
 
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v7

--- a/.github/workflows/dependencies.yml
+++ b/.github/workflows/dependencies.yml
@@ -32,6 +32,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
       - uses: dtolnay/rust-toolchain@nightly
         with:
           toolchain: nightly-2024-07-27

--- a/.github/workflows/dependencies.yml
+++ b/.github/workflows/dependencies.yml
@@ -50,7 +50,10 @@ jobs:
 
           {
             echo "commit_message<<EOF"
-            printf "$TITLE\n\n$cargo_update_log\n"
+            echo "$TITLE"
+            echo ""
+            echo "$cargo_update_log"
+            echo ""
             echo "EOF"
           } >> "$GITHUB_OUTPUT"
 

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -16,6 +16,8 @@ jobs:
     timeout-minutes: 60
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
       - uses: dtolnay/rust-toolchain@nightly
         with:
           toolchain: nightly-2024-07-27

--- a/.github/workflows/functional.yml
+++ b/.github/workflows/functional.yml
@@ -74,7 +74,7 @@ jobs:
           curl -fsSLO --proto "=https" --tlsv1.2 "https://bitcoincore.org/bin/bitcoin-core-$BITCOIND_VERSION/bitcoin-$BITCOIND_VERSION-$BITCOIND_ARCH.tar.gz"
           sha256sum -c <<< "$SHASUM bitcoin-$BITCOIND_VERSION-$BITCOIND_ARCH.tar.gz"
           tar xzf "bitcoin-$BITCOIND_VERSION-$BITCOIND_ARCH.tar.gz"
-          sudo install -m 0755 -t /usr/local/bin bitcoin-$BITCOIND_VERSION/bin/*
+          sudo install -m 0755 -t /usr/local/bin bitcoin-"$BITCOIND_VERSION"/bin/*
           bitcoind --version
           rm -rf "bitcoin-$BITCOIND_VERSION" "bitcoin-$BITCOIND_VERSION-$BITCOIND_ARCH.tar.gz"
 
@@ -116,19 +116,19 @@ jobs:
         id: funcTestsRun1
         continue-on-error: true
         run: |
-          export "PATH=$(realpath target/debug/):$PATH"
+          NEWPATH="$(realpath target/debug/)"
+          export PATH="${NEWPATH}:${PATH}"
           which strata-client
-          cd functional-tests && \
-          poetry run python entry.py
+          cd functional-tests && poetry run python entry.py
 
       # Run again just to be sure as some tests are flaky
       - name: Run functional tests (2)
         if: steps.funcTestsRun1.outcome == 'failure'
         run: |
-          export PATH="$(realpath target/debug/):$PATH"
+          NEWPATH="$(realpath target/debug/)"
+          export PATH="${NEWPATH}:${PATH}"
           which strata-client
-          cd functional-tests && \
-          poetry run python entry.py
+          cd functional-tests && poetry run python entry.py
 
   functional-tests-success:
     name: Check that all checks pass

--- a/.github/workflows/functional.yml
+++ b/.github/workflows/functional.yml
@@ -17,6 +17,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - name: Set up Python
         uses: actions/setup-python@v5
@@ -57,6 +59,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - name: Cleanup Space
         uses: ./.github/actions/cleanup

--- a/.github/workflows/functional.yml
+++ b/.github/workflows/functional.yml
@@ -71,12 +71,12 @@ jobs:
           BITCOIND_ARCH: "x86_64-linux-gnu"
           SHASUM: "7fe294b02b25b51acb8e8e0a0eb5af6bbafa7cd0c5b0e5fcbb61263104a82fbc"
         run: |
-          curl -fsSLO --proto "=https" --tlsv1.2 "https://bitcoincore.org/bin/bitcoin-core-${{ env.BITCOIND_VERSION }}/bitcoin-${{ env.BITCOIND_VERSION }}-${{ env.BITCOIND_ARCH }}.tar.gz"
-          sha256sum -c <<< "$SHASUM bitcoin-${{ env.BITCOIND_VERSION }}-${{ env.BITCOIND_ARCH }}.tar.gz"
-          tar xzf "bitcoin-${{ env.BITCOIND_VERSION }}-${{ env.BITCOIND_ARCH }}.tar.gz"
-          sudo install -m 0755 -t /usr/local/bin bitcoin-${{ env.BITCOIND_VERSION }}/bin/*
+          curl -fsSLO --proto "=https" --tlsv1.2 "https://bitcoincore.org/bin/bitcoin-core-$BITCOIND_VERSION/bitcoin-$BITCOIND_VERSION-$BITCOIND_ARCH.tar.gz"
+          sha256sum -c <<< "$SHASUM bitcoin-$BITCOIND_VERSION-$BITCOIND_ARCH.tar.gz"
+          tar xzf "bitcoin-$BITCOIND_VERSION-$BITCOIND_ARCH.tar.gz"
+          sudo install -m 0755 -t /usr/local/bin bitcoin-$BITCOIND_VERSION/bin/*
           bitcoind --version
-          rm -rf "bitcoin-${{ env.BITCOIND_VERSION }}" "bitcoin-${{ env.BITCOIND_VERSION }}-${{ env.BITCOIND_ARCH }}.tar.gz"
+          rm -rf "bitcoin-$BITCOIND_VERSION" "bitcoin-$BITCOIND_VERSION-$BITCOIND_ARCH.tar.gz"
 
       - name: Set up Python
         uses: actions/setup-python@v5

--- a/.github/workflows/functional.yml
+++ b/.github/workflows/functional.yml
@@ -116,7 +116,7 @@ jobs:
         id: funcTestsRun1
         continue-on-error: true
         run: |
-          export PATH=$(realpath target/debug/):$PATH
+          export "PATH=$(realpath target/debug/):$PATH"
           which strata-client
           cd functional-tests && \
           poetry run python entry.py
@@ -125,7 +125,7 @@ jobs:
       - name: Run functional tests (2)
         if: steps.funcTestsRun1.outcome == 'failure'
         run: |
-          export PATH=$(realpath target/debug/):$PATH
+          export PATH="$(realpath target/debug/):$PATH"
           which strata-client
           cd functional-tests && \
           poetry run python entry.py

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -20,6 +20,8 @@ jobs:
     timeout-minutes: 60 # better fail-safe than the default 360 in github actions
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - name: Cleanup space
         uses: ./.github/actions/cleanup

--- a/.github/workflows/lint-actions.yml
+++ b/.github/workflows/lint-actions.yml
@@ -15,6 +15,6 @@ jobs:
       - uses: actions/checkout@v4
         with:
           persist-credentials: false
-      - uses: reviewdog/action-actionlint@v1
+      - uses: reviewdog/action-actionlint@v1.60
         with:
           fail_level: "any"

--- a/.github/workflows/lint-actions.yml
+++ b/.github/workflows/lint-actions.yml
@@ -15,12 +15,4 @@ jobs:
       - uses: actions/checkout@v4
         with:
           persist-credentials: false
-      - name: Download actionlint
-        id: get_actionlint
-        run: bash <(curl https://raw.githubusercontent.com/rhysd/actionlint/main/scripts/download-actionlint.bash)
-        shell: bash
-      - name: Check workflow files
-        env:
-          ACTIONLINT_VERSION: ${{ steps.get_actionlint.outputs.version }}
-        run: SHELLCHECK_OPTS="-S error" $ACTIONLINT_VERSION -color
-        shell: bash
+      - uses: reviewdog/action-actionlint@v1

--- a/.github/workflows/lint-actions.yml
+++ b/.github/workflows/lint-actions.yml
@@ -20,5 +20,7 @@ jobs:
         run: bash <(curl https://raw.githubusercontent.com/rhysd/actionlint/main/scripts/download-actionlint.bash)
         shell: bash
       - name: Check workflow files
-        run: SHELLCHECK_OPTS="-S error" ${{ steps.get_actionlint.outputs.executable }} -color
+        env:
+          ACTIONLINT_VERSION: ${{ steps.get_actionlint.outputs.version }}
+        run: SHELLCHECK_OPTS="-S error" $ACTIONLINT_VERSION -color
         shell: bash

--- a/.github/workflows/lint-actions.yml
+++ b/.github/workflows/lint-actions.yml
@@ -13,6 +13,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
       - name: Download actionlint
         id: get_actionlint
         run: bash <(curl https://raw.githubusercontent.com/rhysd/actionlint/main/scripts/download-actionlint.bash)

--- a/.github/workflows/lint-actions.yml
+++ b/.github/workflows/lint-actions.yml
@@ -16,3 +16,5 @@ jobs:
         with:
           persist-credentials: false
       - uses: reviewdog/action-actionlint@v1
+        with:
+          fail_level: "any"

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -16,6 +16,8 @@ jobs:
     timeout-minutes: 60
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
       - uses: dtolnay/rust-toolchain@clippy
       - uses: Swatinem/rust-cache@v2
         with:
@@ -30,6 +32,8 @@ jobs:
     timeout-minutes: 90 # cold run takes a lot of time as each crate is compiled separately
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - name: Cleanup space
         uses: ./.github/actions/cleanup
@@ -58,6 +62,8 @@ jobs:
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
       - uses: dtolnay/rust-toolchain@nightly
         with:
           components: rustfmt
@@ -70,6 +76,8 @@ jobs:
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
       - uses: codespell-project/actions-codespell@v2
 
   taplo:
@@ -78,6 +86,8 @@ jobs:
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
       - name: Install taplo
         run: |
           curl -fsSL https://github.com/tamasfe/taplo/releases/latest/download/taplo-full-linux-x86_64.gz \

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -47,8 +47,8 @@ jobs:
           cache-on-failure: true
       - name: Configure sccache
         run: |
-          echo "RUSTC_WRAPPER=sccache" >> $GITHUB_ENV
-          echo  "SCCACHE_GHA_ENABLED=true" >> $GITHUB_ENV
+          echo "RUSTC_WRAPPER=sccache" >> "$GITHUB_ENV"
+          echo  "SCCACHE_GHA_ENABLED=true" >> "$GITHUB_ENV"
       - name: Run sccache-cache
         uses: mozilla-actions/sccache-action@v0.0.6
         with:

--- a/.github/workflows/mutants.yml
+++ b/.github/workflows/mutants.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Relative diff
         run: |
           git branch -av
-          git diff origin/$DEFAULT_BRANCH | tee git.diff
+          git diff "origin/$DEFAULT_BRANCH" | tee git.diff
       - uses: Swatinem/rust-cache@v2
       - uses: taiki-e/install-action@v2
         name: Install `cargo-mutants`

--- a/.github/workflows/mutants.yml
+++ b/.github/workflows/mutants.yml
@@ -26,6 +26,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          persist-credentials: false
       - name: Relative diff
         run: |
           git branch -av

--- a/.github/workflows/prover.yml
+++ b/.github/workflows/prover.yml
@@ -41,6 +41,8 @@ jobs:
 
       - name: Checkout code
         uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - name: Build prover guest code
         run: cargo build --profile prover-ci -F "prover"

--- a/.github/workflows/security.yml.disabled
+++ b/.github/workflows/security.yml.disabled
@@ -16,13 +16,15 @@ jobs:
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
       - uses: dtolnay/rust-toolchain@clippy
       - uses: Swatinem/rust-cache@v2
         with:
           cache-on-failure: true
 
        # HACK: v0.21.0 fails during dependency resolution. Remove when this is resolved
-       # https://github.com/rustsec/rustsec/issues/1249#issuecomment-2423257490 
+       # https://github.com/rustsec/rustsec/issues/1249#issuecomment-2423257490
       - name: Install cargo-audit v0.20.0
         run: cargo install cargo-audit --version 0.20.0 --force
 

--- a/.github/workflows/unit.yml
+++ b/.github/workflows/unit.yml
@@ -22,6 +22,8 @@ jobs:
     timeout-minutes: 60 # better fail-safe than the default 360 in github actions
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - name: Cleanup space
         uses: ./.github/actions/cleanup
@@ -65,6 +67,8 @@ jobs:
     timeout-minutes: 60
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - name: Cleanup space
         uses: ./.github/actions/cleanup

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -1,0 +1,36 @@
+name: GitHub Actions Security Analysis with zizmor 🌈
+
+on:
+  push:
+    branches: ["main"]
+  pull_request:
+    branches: ["**"]
+
+jobs:
+  zizmor:
+    name: zizmor latest via PyPI
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+      # required for workflows in private repositories
+      contents: read
+      actions: read
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+
+      - name: Install the latest version of uv
+        uses: astral-sh/setup-uv@v4
+
+      - name: Run zizmor 🌈
+        run: uvx zizmor --format sarif . > results.sarif
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Upload SARIF file
+        uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: results.sarif
+          category: zizmor

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -1,8 +1,6 @@
 name: GitHub Actions Security Analysis with zizmor 🌈
 
 on:
-  push:
-    branches: ["main"]
   pull_request:
     branches: ["**"]
 
@@ -10,11 +8,6 @@ jobs:
   zizmor:
     name: zizmor latest via PyPI
     runs-on: ubuntu-latest
-    permissions:
-      security-events: write
-      # required for workflows in private repositories
-      contents: read
-      actions: read
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -25,12 +18,4 @@ jobs:
         uses: astral-sh/setup-uv@v4
 
       - name: Run zizmor 🌈
-        run: uvx zizmor --format sarif . > results.sarif
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Upload SARIF file
-        uses: github/codeql-action/upload-sarif@v3
-        with:
-          sarif_file: results.sarif
-          category: zizmor
+        run: uvx zizmor ./.github/workflows

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -18,4 +18,4 @@ jobs:
         uses: astral-sh/setup-uv@v4
 
       - name: Run zizmor 🌈
-        run: uvx zizmor ./.github/workflows
+        run: uvx zizmor .


### PR DESCRIPTION
## Description

Hardens CI jobs against malicious attackers and adds a new CI job to check these in the future.

### Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature/Enhancement (non-breaking change which adds functionality or enhances an existing one)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactor
- [x] New or updated tests
- [ ] Dependency Update
- [x] Security fix

## Notes to Reviewers

Here's information on a recent [attack](https://blog.yossarian.net/2024/12/06/zizmor-ultralytics-injection) on a GitHub repository via CI template injection.
The linked post recommends the use of [`zizmor`](https://github.com/woodruffw/zizmor) to check for common CI attack vectors.

This makes two fixes:

1. Don't have the credentials being persistent in GitHub Actions artifacts with `persist-credentials: true` in all `actions/checkout` steps. See https://woodruffw.github.io/zizmor/audits/#artipacked
2. Avoid template injections by setting the untrusted input value of the expression to an intermediate environment variable. See https://woodruffw.github.io/zizmor/audits/#template-injection and https://securitylab.github.com/resources/github-actions-untrusted-input/

## Checklist

- [x] I have performed a self-review of my code.
- [x] I have commented my code where necessary.
- [x] I have updated the documentation if needed.
- [x] My changes do not introduce new warnings.
- [x] I have added tests that prove my changes are effective or that my feature works.
- [x] New and existing tests pass with my changes.

## Related Issues

STR-741.
