### PR TITLE
ci: fix automated `Cargo.lock` dependency update

### DIFF
--- a/.github/workflows/dependencies.yml
+++ b/.github/workflows/dependencies.yml
@@ -6,12 +6,11 @@ on:
   schedule:
     # Run at the first of every month
     - cron: "0 0 1 * *"
-  workflow_dispatch:
-    # Needed so we can run it manually
+  workflow_dispatch: # Needed so we can run it manually
 
 env:
-  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-  BRANCH: cargo-update
+  AUTHOR: Update Cargo.lock Bot <no-reply@alpenlabs.io>
+  BRANCH: create-pull-request/automated-cargo-update
   TITLE: "chore(deps): monthly `cargo update`"
   BODY: |
     Automation to keep dependencies in `Cargo.lock` current.
@@ -30,6 +29,9 @@ jobs:
   update:
     name: Update
     runs-on: ubuntu-latest
+    permissions:
+      contents: write # Needed to create commits
+      pull-requests: write # Needed to create a PR
     steps:
       - uses: actions/checkout@v4
         with:
@@ -68,6 +70,7 @@ jobs:
         with:
           add-paths: ./Cargo.lock
           commit-message: ${{ steps.msg.outputs.commit_message }}
+          author: ${{ env.AUTHOR }}
           title: ${{ env.TITLE }}
           body: ${{ steps.msg.outputs.body }}
           branch: ${{ env.BRANCH }}


### PR DESCRIPTION
## Description

Fixes the automated `Cargo.lock` dependency update.

### Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature/Enhancement (non-breaking change which adds functionality or enhances an existing one)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactor
- [ ] New or updated tests
- [ ] Dependency Update
- [x] CI

## Notes to Reviewers

I think this will work with the default `GITHUB_TOKEN`.

Since:

> Note that due to [token restrictions on public repository forks](https://docs.github.com/en/actions/configuring-and-managing-workflows/authenticating-with-the-github_token#permissions-for-the-github_token), workflows for this use case do not work for pull requests raised from forks. Private repositories can be configured to [enable workflows](https://docs.github.com/en/github/administering-a-repository/disabling-or-limiting-github-actions-for-a-repository#enabling-workflows-for-private-repository-forks) from forks to run without restriction.

Source: https://github.com/peter-evans/create-pull-request/blob/main/docs/examples.md#use-case-create-a-pull-request-to-modifyfix-pull-requests

## Checklist

- [x] I have performed a self-review of my code.
- [x] I have commented my code where necessary.
- [x] I have updated the documentation if needed.
- [x] My changes do not introduce new warnings.
- [x] I have added tests that prove my changes are effective or that my feature works.
- [x] New and existing tests pass with my changes.

## Related Issues

https://github.com/alpenlabs/strata/pull/536#issuecomment-2546199070
