### PR TITLE
STR-676: sets a CI autoupdate cron job

### DIFF
--- a/.github/workflows/cron-nightly-rust.yml
+++ b/.github/workflows/cron-nightly-rust.yml
@@ -1,0 +1,57 @@
+name: Update nightly Rust
+on:
+  schedule:
+    - cron: "29 17 1 * *" # At 17:29 on day-of-month 1.
+  workflow_dispatch: # allows manual triggering
+env:
+  CARGO_TERM_COLOR: always
+jobs:
+  format:
+    name: Update nightly Rustc
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+      - uses: dtolnay/rust-toolchain@nightly
+      - name: Update rust-toolchain.toml to use latest nightly
+        run: |
+          set -x
+
+          # Get the latest nightly date.
+          # If the latest nightly date is not the same as the current nightly date,
+          # rustup will default to the latest nightly up to TODAY.
+          #
+          # Example: If the latest nightly is 2023-07-01, and the TODAY is 2023-07-02,
+          # then rustup will default to nightly-2023-07-01.
+          TODAY="$(date +%Y-%m-%d)"
+
+          # Update the nightly version in the rust-toolchain.toml file.
+          echo "Updating rust-toolchain.toml to use nightly-$TODAY"
+          sed -i "s/^channel = \"nightly-.*\"/channel = \"nightly-$TODAY\"/" rust-toolchain.toml
+
+          # Update the nightly date in the environment.
+          echo "nightly_date=${TODAY}" >> "$GITHUB_ENV"
+
+          # Maybe there is no new nightly.
+          # In this case don't make an empty PR.
+          if ! git diff --exit-code > /dev/null; then
+              echo "Updated nightly. Opening PR."
+              echo "changes_made=true" >> "$GITHUB_ENV"
+          else
+              echo "Attempted to update nightly but the latest-nightly date did not change. Not opening any PR."
+              echo "changes_made=false" >> "$GITHUB_ENV"
+          fi
+      - name: Create Pull Request
+        if: env.changes_made == 'true'
+        uses: peter-evans/create-pull-request@v7
+        env:
+          NIGHTLY_DATE: ${{ env.nightly_date }}
+        with:
+          author: Update Nightly Rustc Bot <no-reply@alpenlabs.io>
+          committer: Update Nightly Rustc Bot <no-reply@alpenlabs.io>
+          title: Automated update to rustc (to nightly-$NIGHTLY_DATE)
+          body: |
+            Automated update to Rust nightly by [create-pull-request](https://github.com/peter-evans/create-pull-request) GitHub action
+          commit-message: Automated update to Rust nightly-$NIGHTLY_DATE
+          branch: create-pull-request/automated-nightly-update

--- a/.github/workflows/cron-nightly-rust.yml
+++ b/.github/workflows/cron-nightly-rust.yml
@@ -16,7 +16,7 @@ jobs:
       - uses: dtolnay/rust-toolchain@nightly
       - name: Update rust-toolchain.toml to use latest nightly
         run: |
-          set -x
+          set -xe
 
           # Get the latest nightly date.
           # If the latest nightly date is not the same as the current nightly date,


### PR DESCRIPTION
## Description

Spinoff of #537.

Adds a CI cron job to do an automated PR monthly.

### Type of Change

<!--
Select the type of change your PR introduces (put an `x` in all that apply):
-->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature/Enhancement (non-breaking change which adds functionality or enhances an existing one)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactor
- [ ] New or updated tests
- [ ] Dependency Update
- [x] New CI action

## Notes to Reviewers

Depends on `https://github.com/organizations/alpenlabs/settings/actions` and check `Allow GitHub Actions to create and approve pull requests`.

If you look closely, you might find a Ramanujan number hidden in this PR.

## Checklist

<!--
Ensure all the following are checked:
-->

- [x] I have performed a self-review of my code.
- [x] I have commented my code where necessary.
- [x] I have updated the documentation if needed.
- [x] My changes do not introduce new warnings.
- [x] I have added tests that prove my changes are effective or that my feature works.
- [x] New and existing tests pass with my changes.

## Related Issues

STR-676
STR-630