### PR TITLE
STR-782: add a warning about partial MuSig2 verification

### DIFF
--- a/crates/bridge-sig-manager/src/operations.rs
+++ b/crates/bridge-sig-manager/src/operations.rs
@@ -113,6 +113,21 @@ pub fn sign_state_partial(
 }
 
 /// Verify that a partial MuSig2 signature is correct.
+///
+/// # Warning
+///
+/// It is possible for an adversary to forge a partial signature under certain conditions.
+/// You _must not_ rely on this verification to imply that a partial signature is unforgeable.
+///
+/// See the footnote in section 4.2 of <https://eprint.iacr.org/archive/2020/1261/20231020:081535> or
+/// <https://gist.github.com/AdamISZ/ca974ed67889cedc738c4a1f65ff620b> for details.
+///
+/// It is _only_ safe to assume that:
+///
+/// - failed verification of _any_ partial signature represents a fault, and the signing session
+///   should be aborted
+/// - successful verification of _all_ partial signatures for a signing session will result in a
+///   successful signing session
 pub fn verify_partial_sig(
     tx_state: &BridgeTxState,
     signature_info: &OperatorPartialSig,


### PR DESCRIPTION
## Description

This PR updates the documentation for partial MuSig2 signature verification to caution against assuming unforgeability of partial signatures.

<!--
Provide a brief summary of the changes and the motivation behind them.
-->

### Type of Change

<!--
Select the type of change your PR introduces (put an `x` in all that apply):
-->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature/Enhancement (non-breaking change which adds functionality or enhances an existing one)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Refactor
- [ ] New or updated tests
- [ ] Dependency Update

## Notes to Reviewers

<!--
Anything in particular you want to note that will help reviewers fulfill their role
in reviewing this PR?
-->

## Checklist

<!--
Ensure all the following are checked:
-->

- [x] I have performed a self-review of my code.
- [x] I have commented my code where necessary.
- [x] I have updated the documentation if needed.
- [x] My changes do not introduce new warnings.
- [ ] I have added tests that prove my changes are effective or that my feature works.
- [x] New and existing tests pass with my changes.

## Related Issues

<!--
Link any related issues (e.g., `closes #123`, `fixes #456`).
-->
