### PR TITLE
Str 797 l1 block manager

### DIFF
--- a/bin/datatool/Cargo.toml
+++ b/bin/datatool/Cargo.toml
@@ -27,5 +27,5 @@ zeroize.workspace = true
 
 [features]
 default = []
-sp1 = ["strata-sp1-guest-builder"]
 risc0 = ["strata-risc0-guest-builder", "bytemuck"]
+sp1 = ["strata-sp1-guest-builder"]

--- a/bin/strata-client/src/main.rs
+++ b/bin/strata-client/src/main.rs
@@ -18,7 +18,7 @@ use strata_consensus_logic::{
     sync_manager::{self, SyncManager},
 };
 use strata_db::{
-    traits::{ChainstateDatabase, Database},
+    traits::{BroadcastDatabase, ChainstateDatabase, Database},
     DbError,
 };
 use strata_eectl::engine::ExecEngineCtl;
@@ -479,7 +479,9 @@ fn start_broadcaster_tasks(
     params: Arc<Params>,
 ) -> Arc<L1BroadcastHandle> {
     // Set up L1 broadcaster.
-    let broadcast_ctx = strata_storage::ops::l1tx_broadcast::Context::new(broadcast_database);
+    let broadcast_ctx = strata_storage::ops::l1tx_broadcast::Context::new(
+        broadcast_database.l1_broadcast_db().clone(),
+    );
     let broadcast_ops = Arc::new(broadcast_ctx.into_ops(pool));
     // start broadcast task
     let broadcast_handle =

--- a/bin/strata-client/src/rpc_server.rs
+++ b/bin/strata-client/src/rpc_server.rs
@@ -391,7 +391,7 @@ impl<D: Database + Send + Sync + 'static> StrataApiServer for StrataRpcImpl<D> {
         let blocks = futures::future::join_all(
             block_ids
                 .iter()
-                .map(|blkid| self.l2_block_manager.get_block_async(blkid)),
+                .map(|blkid| self.l2_block_manager.get_block_data_async(blkid)),
         )
         .await;
 
@@ -408,7 +408,7 @@ impl<D: Database + Send + Sync + 'static> StrataApiServer for StrataRpcImpl<D> {
     async fn get_raw_bundle_by_id(&self, block_id: L2BlockId) -> RpcResult<Option<HexBytes>> {
         let block = self
             .l2_block_manager
-            .get_block_async(&block_id)
+            .get_block_data_async(&block_id)
             .await
             .map_err(|e| Error::Other(e.to_string()))?
             .map(|block| {

--- a/bin/strata-client/src/rpc_server.rs
+++ b/bin/strata-client/src/rpc_server.rs
@@ -774,7 +774,7 @@ impl<D: Database + Sync + Send + 'static> StrataDebugApiServer for StrataDebugRp
     async fn get_block_by_id(&self, block_id: L2BlockId) -> RpcResult<Option<L2Block>> {
         let l2_block_manager = &self.l2_block_manager;
         let l2_block = l2_block_manager
-            .get_block_async(&block_id)
+            .get_block_data_async(&block_id)
             .await
             .map_err(Error::Db)?
             .map(|b| b.block().clone());

--- a/crates/bridge-sig-manager/src/manager.rs
+++ b/crates/bridge-sig-manager/src/manager.rs
@@ -23,6 +23,7 @@ use strata_primitives::{
         Musig2PartialSig, Musig2PubNonce, OperatorIdx, OperatorPartialSig, PublickeyTable,
         TxSigningData,
     },
+    buf::Buf32,
     l1::TaprootSpendPath,
 };
 use strata_storage::ops::bridge::BridgeTxStateOps;
@@ -77,7 +78,12 @@ impl SignatureManager {
         // fixed.
         //
         // A collision between `Txid`'s is practically impossible.
-        if self.db_ops.get_tx_state_async(txid).await?.is_some() {
+        if self
+            .db_ops
+            .get_tx_state_async(Buf32::from(txid))
+            .await?
+            .is_some()
+        {
             info!(%txid, "not replacing tx_state that is already present in the tx_db");
             return Ok(txid);
         }
@@ -99,7 +105,9 @@ impl SignatureManager {
 
         tx_state.add_nonce(&self.index, pub_nonce.into())?;
 
-        self.db_ops.put_tx_state_async(txid, tx_state).await?;
+        self.db_ops
+            .put_tx_state_async(Buf32::from(txid), tx_state)
+            .await?;
 
         Ok(txid)
     }
@@ -113,7 +121,7 @@ impl SignatureManager {
     /// ([`BridgeSigError::TransactionNotFound`]). Or, if there is an error in the persistence layer
     /// itself ([`BridgeSigError::Storage`]).
     pub async fn get_tx_state(&self, txid: &Txid) -> BridgeSigResult<BridgeTxState> {
-        let entry = self.db_ops.get_tx_state_async(*txid).await?;
+        let entry = self.db_ops.get_tx_state_async(Buf32::from(txid)).await?;
 
         entry.ok_or(BridgeSigError::TransactionNotFound)
     }
@@ -177,7 +185,9 @@ impl SignatureManager {
         let mut tx_state = self.get_tx_state(txid).await?;
 
         let is_complete = tx_state.add_nonce(&operator_index, pub_nonce.clone())?;
-        self.db_ops.put_tx_state_async(*txid, tx_state).await?;
+        self.db_ops
+            .put_tx_state_async(Buf32::from(txid), tx_state)
+            .await?;
 
         Ok(is_complete)
     }
@@ -244,7 +254,9 @@ impl SignatureManager {
 
         let is_fully_signed = tx_state.add_signature(own_signature_info)?;
 
-        self.db_ops.put_tx_state_async(*txid, tx_state).await?;
+        self.db_ops
+            .put_tx_state_async(Buf32::from(txid), tx_state)
+            .await?;
 
         Ok(is_fully_signed)
     }
@@ -301,7 +313,7 @@ impl SignatureManager {
 
         tx_state.add_signature(signature_info)?;
         self.db_ops
-            .put_tx_state_async(*txid, tx_state.clone())
+            .put_tx_state_async(Buf32::from(txid), tx_state.clone())
             .await?;
 
         Ok(tx_state.is_fully_signed())
@@ -621,7 +633,7 @@ mod tests {
 
         let state = sig_manager
             .db_ops
-            .get_tx_state_async(txid)
+            .get_tx_state_async(Buf32::from(txid))
             .await
             .expect("should be able to access stored state")
             .expect("state should be present");
@@ -644,7 +656,7 @@ mod tests {
 
         let updated_state = sig_manager
             .db_ops
-            .get_tx_state_async(txid)
+            .get_tx_state_async(Buf32::from(txid))
             .await
             .expect("should be able to access state")
             .expect("state should be defined");
@@ -733,7 +745,7 @@ mod tests {
         // Verify that the signature was added
         let stored_tx_state = signature_manager
             .db_ops
-            .get_tx_state_async(txid)
+            .get_tx_state_async(Buf32::from(txid))
             .await
             .expect("read state from db")
             .expect("state should be present");

--- a/crates/bridge-sig-manager/src/manager.rs
+++ b/crates/bridge-sig-manager/src/manager.rs
@@ -492,7 +492,10 @@ mod tests {
 
         let txid = result.unwrap();
 
-        let stored_tx_state = signature_manager.db_ops.get_tx_state_async(txid).await;
+        let stored_tx_state = signature_manager
+            .db_ops
+            .get_tx_state_async(Buf32::from(txid))
+            .await;
         assert!(stored_tx_state.is_ok(), "should retrieve saved state");
 
         let stored_tx_state = stored_tx_state.unwrap();
@@ -586,7 +589,7 @@ mod tests {
         assert!(
             sig_manager
                 .db_ops
-                .get_tx_state_async(txid)
+                .get_tx_state_async(txid.into())
                 .await
                 .expect("storage should be accessible")
                 .expect("state should be present")
@@ -633,7 +636,7 @@ mod tests {
 
         let state = sig_manager
             .db_ops
-            .get_tx_state_async(Buf32::from(txid))
+            .get_tx_state_async(txid.into())
             .await
             .expect("should be able to access stored state")
             .expect("state should be present");
@@ -837,7 +840,7 @@ mod tests {
 
         let tx_state = signature_manager
             .db_ops
-            .get_tx_state_async(txid)
+            .get_tx_state_async(txid.into())
             .await
             .expect("storage should be accessible")
             .expect("state should be present");
@@ -909,7 +912,7 @@ mod tests {
         // Verify that the signature was added
         let stored_tx_state = signature_manager
             .db_ops
-            .get_tx_state_async(txid)
+            .get_tx_state_async(txid.into())
             .await
             .expect("should be able to load state")
             .expect("state should be present");
@@ -1000,7 +1003,7 @@ mod tests {
 
         let tx_state = signature_manager
             .db_ops
-            .get_tx_state_async(txid)
+            .get_tx_state_async(txid.into())
             .await
             .expect("should be able to access storage")
             .expect("state should be available in the storage");
@@ -1066,7 +1069,7 @@ mod tests {
             // Verify that the signature has been added
             let stored_state = signature_manager
                 .db_ops
-                .get_tx_state_async(txid)
+                .get_tx_state_async(txid.into())
                 .await
                 .expect("should be able to access storage")
                 .expect("should have tx state in the storage");

--- a/crates/btcio/src/broadcaster/handle.rs
+++ b/crates/btcio/src/broadcaster/handle.rs
@@ -38,6 +38,8 @@ impl L1BroadcastHandle {
     /// This function is infallible. If the entry already exists it will update with the new
     /// `txentry`.
     pub async fn put_tx_entry(&self, txid: Buf32, txentry: L1TxEntry) -> DbResult<Option<u64>> {
+        trace!(%txid, "insert_new_tx_entry");
+        assert!(txentry.try_to_tx().is_ok(), "invalid tx entry {txentry:?}");
         let Some(idx) = self.ops.put_tx_entry_async(txid, txentry.clone()).await? else {
             return Ok(None);
         };

--- a/crates/btcio/src/broadcaster/handle.rs
+++ b/crates/btcio/src/broadcaster/handle.rs
@@ -24,7 +24,11 @@ impl L1BroadcastHandle {
     }
 
     pub async fn get_tx_status(&self, txid: Buf32) -> DbResult<Option<L1TxStatus>> {
-        self.ops.get_tx_status_async(txid).await
+        Ok(self
+            .ops
+            .get_tx_entry_by_id_async(txid)
+            .await?
+            .map(|e| e.status))
     }
 
     /// Insert an entry to the database

--- a/crates/btcio/src/broadcaster/state.rs
+++ b/crates/btcio/src/broadcaster/state.rs
@@ -88,7 +88,10 @@ async fn filter_unfinalized_from_db(
 #[cfg(test)]
 mod test {
     use bitcoin::{consensus, Transaction};
-    use strata_db::{traits::BroadcastDatabase, types::L1TxStatus};
+    use strata_db::{
+        traits::{BroadcastDatabase, L1BroadcastDatabase},
+        types::L1TxStatus,
+    };
     use strata_rocksdb::{
         broadcaster::db::{BroadcastDb, L1BroadcastDb},
         test_utils::get_rocksdb_tmp_instance,
@@ -107,7 +110,7 @@ mod test {
     fn get_ops() -> Arc<BroadcastDbOps> {
         let pool = threadpool::Builder::new().num_threads(2).build();
         let db = get_db();
-        let ops = Context::new(db).into_ops(pool);
+        let ops = Context::new(db.l1_broadcast_db().clone()).into_ops(pool);
         Arc::new(ops)
     }
 

--- a/crates/btcio/src/broadcaster/state.rs
+++ b/crates/btcio/src/broadcaster/state.rs
@@ -88,10 +88,7 @@ async fn filter_unfinalized_from_db(
 #[cfg(test)]
 mod test {
     use bitcoin::{consensus, Transaction};
-    use strata_db::{
-        traits::{BroadcastDatabase, L1BroadcastDatabase},
-        types::L1TxStatus,
-    };
+    use strata_db::{traits::BroadcastDatabase, types::L1TxStatus};
     use strata_rocksdb::{
         broadcaster::db::{BroadcastDb, L1BroadcastDb},
         test_utils::get_rocksdb_tmp_instance,

--- a/crates/btcio/src/broadcaster/task.rs
+++ b/crates/btcio/src/broadcaster/task.rs
@@ -202,7 +202,7 @@ mod test {
     fn get_ops() -> Arc<BroadcastDbOps> {
         let pool = threadpool::Builder::new().num_threads(2).build();
         let db = get_db();
-        let ops = Context::new(db).into_ops(pool);
+        let ops = Context::new(db.l1_broadcast_db().clone()).into_ops(pool);
         Arc::new(ops)
     }
 

--- a/crates/btcio/src/writer/test_utils.rs
+++ b/crates/btcio/src/writer/test_utils.rs
@@ -42,7 +42,7 @@ pub fn get_broadcast_db() -> Arc<impl BroadcastDatabase> {
 pub fn get_broadcast_handle() -> Arc<L1BroadcastHandle> {
     let pool = threadpool::Builder::new().num_threads(2).build();
     let db = get_broadcast_db();
-    let ops = BContext::new(db).into_ops(pool);
+    let ops = BContext::new(db.l1_broadcast_db().clone()).into_ops(pool);
     let (sender, _) = tokio::sync::mpsc::channel::<(u64, L1TxEntry)>(64);
     let handle = L1BroadcastHandle::new(sender, Arc::new(ops));
     Arc::new(handle)

--- a/crates/consensus-logic/src/csm/worker.rs
+++ b/crates/consensus-logic/src/csm/worker.rs
@@ -282,7 +282,7 @@ fn apply_action<D: Database>(
             warn!(?blkid, "marking block invalid!");
             state
                 .l2_block_manager
-                .put_block_status_blocking(&blkid, BlockStatus::Invalid)?;
+                .set_block_status_blocking(&blkid, BlockStatus::Invalid)?;
         }
 
         SyncAction::FinalizeBlock(blkid) => {

--- a/crates/consensus-logic/src/duty/worker.rs
+++ b/crates/consensus-logic/src/duty/worker.rs
@@ -149,7 +149,7 @@ fn update_tracker(
     // TODO include the block slot in the consensus state
     let tip_blkid = *ss.chain_tip_blkid();
     let block = l2_block_manager
-        .get_block_blocking(&tip_blkid)?
+        .get_block_data_blocking(&tip_blkid)?
         .ok_or(Error::MissingL2Block(tip_blkid))?;
     let block_idx = block.header().blockidx();
     let ts = time::Instant::now(); // FIXME XXX use .timestamp()!!!
@@ -200,7 +200,7 @@ fn get_finalized_blocks(
 
         // else loop till we reach to the last finalized block or go all the way
         // as long as we get some block data
-        match l2_blkman.get_block_blocking(&finalized)? {
+        match l2_blkman.get_block_data_blocking(&finalized)? {
             Some(block) => new_finalized = Some(*block.header().parent()),
             None => break,
         }

--- a/crates/consensus-logic/src/fork_choice_manager.rs
+++ b/crates/consensus-logic/src/fork_choice_manager.rs
@@ -79,7 +79,7 @@ impl<D: Database> ForkChoiceManager<D> {
 
     fn set_block_status(&self, id: &L2BlockId, status: BlockStatus) -> Result<(), DbError> {
         self.l2_block_manager
-            .put_block_status_blocking(id, status)?;
+            .set_block_status_blocking(id, status)?;
         Ok(())
     }
 
@@ -88,7 +88,7 @@ impl<D: Database> ForkChoiceManager<D> {
     }
 
     fn get_block_data(&self, id: &L2BlockId) -> Result<Option<L2BlockBundle>, DbError> {
-        self.l2_block_manager.get_block_blocking(id)
+        self.l2_block_manager.get_block_data_blocking(id)
     }
 
     fn get_block_index(&self, blkid: &L2BlockId) -> anyhow::Result<u64> {
@@ -120,7 +120,7 @@ pub fn init_forkchoice_manager<D: Database>(
 
     let finalized_blockid = *sync_state.finalized_blkid();
     let finalized_block = l2_block_manager
-        .get_block_blocking(&finalized_blockid)?
+        .get_block_data_blocking(&finalized_blockid)?
         .ok_or(Error::MissingL2Block(finalized_blockid))?;
     let finalized_height = finalized_block.header().blockidx();
 
@@ -162,7 +162,7 @@ fn determine_start_tip(
 
     let mut best = iter.next().expect("fcm: no chain tips");
     let mut best_height = l2_block_manager
-        .get_block_blocking(best)?
+        .get_block_data_blocking(best)?
         .ok_or(Error::MissingL2Block(*best))?
         .header()
         .blockidx();
@@ -170,7 +170,7 @@ fn determine_start_tip(
     // Iterate through the remaining elements and choose.
     for blkid in iter {
         let blkid_height = l2_block_manager
-            .get_block_blocking(blkid)?
+            .get_block_data_blocking(blkid)?
             .ok_or(Error::MissingL2Block(*best))?
             .header()
             .blockidx();
@@ -487,7 +487,7 @@ fn pick_best_block<'t>(
 ) -> Result<&'t L2BlockId, Error> {
     let mut best_tip = cur_tip;
     let mut best_block = l2_block_manager
-        .get_block_blocking(best_tip)?
+        .get_block_data_blocking(best_tip)?
         .ok_or(Error::MissingL2Block(*best_tip))?;
 
     // The implementation of this will only switch to a new tip if it's a higher
@@ -499,7 +499,7 @@ fn pick_best_block<'t>(
         }
 
         let other_block = l2_block_manager
-            .get_block_blocking(other_tip)?
+            .get_block_data_blocking(other_tip)?
             .ok_or(Error::MissingL2Block(*other_tip))?;
 
         let best_header = best_block.header();

--- a/crates/consensus-logic/src/unfinalized_tracker.rs
+++ b/crates/consensus-logic/src/unfinalized_tracker.rs
@@ -277,7 +277,7 @@ impl UnfinalizedBlockTracker {
             }
 
             for block_id in block_ids {
-                if let Some(block) = l2_block_manager.get_block_blocking(&block_id)? {
+                if let Some(block) = l2_block_manager.get_block_data_blocking(&block_id)? {
                     let header = block.header();
                     let _ = self.attach_block(block_id, header);
                 }

--- a/crates/db/src/traits.rs
+++ b/crates/db/src/traits.rs
@@ -66,6 +66,7 @@ pub trait L1Database {
     /// Gets the block manifest for a block index.
     fn get_block_manifest(&self, idx: u64) -> DbResult<Option<L1BlockManifest>>;
 
+    // TODO: This should not exist in database level and should be handled by downstream manager.
     /// Returns a half-open interval of block hashes, if we have all of them
     /// present.  Otherwise, returns error.
     fn get_blockid_range(&self, start_idx: u64, end_idx: u64) -> DbResult<Vec<Buf32>>;

--- a/crates/db/src/traits.rs
+++ b/crates/db/src/traits.rs
@@ -303,8 +303,9 @@ pub trait ProofDatabase {
     fn del_proof_deps(&self, proof_context: ProofContext) -> DbResult<bool>;
 }
 
+// TODO remove this trait, just like the high level `Database` trait
 pub trait BroadcastDatabase {
-    type L1BroadcastDB: L1BroadcastDatabase;
+    type L1BroadcastDB: L1BroadcastDatabase + Sync + Send;
 
     /// Return a reference to the L1 broadcast db implementation
     fn l1_broadcast_db(&self) -> &Arc<Self::L1BroadcastDB>;

--- a/crates/evmexec/src/engine.rs
+++ b/crates/evmexec/src/engine.rs
@@ -283,7 +283,7 @@ impl<T: EngineRpc> RpcExecEngineCtl<T> {
 impl<T: EngineRpc> RpcExecEngineCtl<T> {
     fn get_l2block(&self, l2_block_id: &L2BlockId) -> EngineResult<L2BlockBundle> {
         self.l2_block_manager
-            .get_block_blocking(l2_block_id)
+            .get_block_data_blocking(l2_block_id)
             .map_err(|err| EngineError::Other(err.to_string()))?
             .ok_or(EngineError::DbMissingBlock(*l2_block_id))
     }

--- a/crates/primitives/src/buf.rs
+++ b/crates/primitives/src/buf.rs
@@ -90,6 +90,12 @@ impl From<Txid> for Buf32 {
     }
 }
 
+impl From<&Txid> for Buf32 {
+    fn from(value: &Txid) -> Self {
+        Self::from(*value)
+    }
+}
+
 impl From<Buf32> for Txid {
     fn from(value: Buf32) -> Self {
         let mut bytes: [u8; 32] = [0; 32];

--- a/crates/rocksdb-store/src/l1/db.rs
+++ b/crates/rocksdb-store/src/l1/db.rs
@@ -159,6 +159,7 @@ impl L1Database for L1Db {
         Ok(self.db.get::<MmrSchema>(&idx)?)
     }
 
+    // TODO: This should not exist in database level and should be handled by downstream manager
     fn get_blockid_range(&self, start_idx: u64, end_idx: u64) -> DbResult<Vec<Buf32>> {
         let mut options = ReadOptions::default();
         options.set_iterate_lower_bound(

--- a/crates/storage/src/exec.rs
+++ b/crates/storage/src/exec.rs
@@ -112,12 +112,19 @@ macro_rules! inst_ops_simple {
         }
 
         $(
-            fn $iname < $tparam : $tpconstr > (context: &Context<$tparam>, $($aname : $aty),* ) -> DbResult<$ret> {
-                context.db.as_ref(). $iname ( $($aname),* )
-            }
+            inst_ops_ctx_shim!($iname<$tparam: $tpconstr>($($aname: $aty),*) -> $ret);
         )*
     }
 }
 
+macro_rules! inst_ops_ctx_shim {
+    ($iname:ident<$tparam: ident : $tpconstr:tt>($($aname:ident: $aty:ty),*) -> $ret:ty) => {
+        fn $iname < $tparam : $tpconstr > (context: &Context<$tparam>, $($aname : $aty),* ) -> DbResult<$ret> {
+            context.db.as_ref(). $iname ( $($aname),* )
+        }
+    }
+}
+
 pub(crate) use inst_ops;
+pub(crate) use inst_ops_ctx_shim;
 pub(crate) use inst_ops_simple;

--- a/crates/storage/src/exec.rs
+++ b/crates/storage/src/exec.rs
@@ -135,4 +135,83 @@ macro_rules! inst_ops {
     }
 }
 
+/// Same as `inst_ops` but automatically generates the functions. The function name must exist
+/// inside the database instance
+macro_rules! inst_ops_auto {
+    {
+        ($db_method: ident, $base:ident, $ctx:ident $(<$($tparam:ident: $tpconstr:tt),+>)?) {
+            $($iname:ident($($aname:ident: $aty:ty),*) => $ret:ty;)*
+        }
+    } => {
+        pub struct $base {
+            pool: threadpool::ThreadPool,
+            inner: Arc<dyn ShimTrait>,
+        }
+
+        paste::paste! {
+            impl $base {
+                pub fn new $(<$($tparam: $tpconstr + Sync + Send + 'static),+>)? (pool: threadpool::ThreadPool, ctx: Arc<$ctx $(<$($tparam),+>)?>) -> Self {
+                    Self {
+                        pool,
+                        inner: Arc::new(Inner { ctx }),
+                    }
+                }
+
+                $(
+                    pub async fn [<$iname _async>] (&self, $($aname: $aty),*) -> DbResult<$ret> {
+                        let resp_rx = self.inner. [<$iname _chan>] (&self.pool, $($aname),*);
+                        match resp_rx.await {
+                            Ok(v) => v,
+                            Err(_e) => Err(DbError::WorkerFailedStrangely),
+                        }
+                    }
+
+                    pub fn [<$iname _blocking>] (&self, $($aname: $aty),*) -> DbResult<$ret> {
+                        self.inner. [<$iname _blocking>] ($($aname),*)
+                    }
+
+                    pub fn [<$iname _chan>] (&self, $($aname: $aty),*) -> DbRecv<$ret> {
+                        self.inner. [<$iname _chan>] (&self.pool, $($aname),*)
+                    }
+                )*
+            }
+
+            #[async_trait::async_trait]
+            trait ShimTrait: Sync + Send + 'static {
+                $(
+                    fn [<$iname _blocking>] (&self, $($aname: $aty),*) -> DbResult<$ret>;
+                    fn [<$iname _chan>] (&self, pool: &threadpool::ThreadPool, $($aname: $aty),*) -> DbRecv<$ret>;
+                )*
+            }
+
+            pub struct Inner $(<$($tparam: $tpconstr + Sync + Send + 'static),+>)? {
+                ctx: Arc<$ctx $(<$($tparam),+>)?>,
+            }
+
+            impl $(<$($tparam: $tpconstr + Sync + Send + 'static),+>)? ShimTrait for Inner $(<$($tparam),+>)? {
+                $(
+                    fn [<$iname _blocking>] (&self, $($aname: $aty),*) -> DbResult<$ret> {
+                        self.ctx.db.$db_method().$iname($($aname),*)
+                    }
+
+                    fn [<$iname _chan>] (&self, pool: &threadpool::ThreadPool, $($aname: $aty),*) -> DbRecv<$ret> {
+                        let (resp_tx, resp_rx) = tokio::sync::oneshot::channel();
+                        let ctx = self.ctx.clone();
+
+                        pool.execute(move || {
+                            let res = ctx.db.$db_method().$iname($($aname),*);
+                            if resp_tx.send(res).is_err() {
+                                warn!("failed to send response");
+                            }
+                        });
+
+                        resp_rx
+                    }
+                )*
+            }
+        }
+    }
+}
+
 pub(crate) use inst_ops;
+pub(crate) use inst_ops_auto;

--- a/crates/storage/src/exec.rs
+++ b/crates/storage/src/exec.rs
@@ -99,7 +99,7 @@ macro_rules! inst_ops_common {
             }
 
             #[async_trait::async_trait]
-            pub trait ShimTrait: Sync + Send + 'static {
+            pub(crate) trait ShimTrait: Sync + Send + 'static {
                 $(
                     fn [<$iname _blocking>] (&self, $($aname: $aty),*) -> DbResult<$ret>;
                     fn [<$iname _chan>] (&self, pool: &threadpool::ThreadPool, $($aname: $aty),*) -> DbRecv<$ret>;
@@ -152,8 +152,8 @@ macro_rules! inst_ops {
     }
 }
 
-/// Same as `inst_ops` but automatically generates the functions. The function name must exist
-/// inside the database instance
+/// Same as `inst_ops` but calls the methods on context db. The function name must exist
+/// in the database instance
 macro_rules! inst_ops_auto {
     {
         ($db_method: ident, $base:ident, $ctx:ident $(<$($tparam:ident: $tpconstr:tt),+>)?) {

--- a/crates/storage/src/lib.rs
+++ b/crates/storage/src/lib.rs
@@ -5,7 +5,7 @@ pub mod ops;
 
 use std::sync::Arc;
 
-pub use managers::{checkpoint::CheckpointDbManager, l2::L2BlockManager};
+pub use managers::{checkpoint::CheckpointDbManager, l1::L1BlockManager, l2::L2BlockManager};
 pub use ops::l1tx_broadcast::BroadcastDbOps;
 use strata_db::traits::Database;
 

--- a/crates/storage/src/managers/l1.rs
+++ b/crates/storage/src/managers/l1.rs
@@ -1,7 +1,6 @@
 use std::sync::Arc;
 
 use strata_db::{traits::Database, DbResult};
-use strata_mmr::CompactMmr;
 use strata_primitives::{
     buf::Buf32,
     l1::{L1BlockManifest, L1TxRef},
@@ -41,18 +40,6 @@ impl L1BlockManager {
     ) -> DbResult<()> {
         self.ops.put_block_data_async(idx, mf, txs).await?;
         self.block_cache.purge(&idx);
-        Ok(())
-    }
-
-    pub fn put_mmr_checkpoint(&self, idx: u64, mmr: CompactMmr) -> DbResult<()> {
-        self.ops.put_mmr_checkpoint_blocking(idx, mmr)?;
-        // TODO: mmr cache
-        Ok(())
-    }
-
-    pub async fn put_mmr_checkpoint_async(&self, idx: u64, mmr: CompactMmr) -> DbResult<()> {
-        self.ops.put_mmr_checkpoint_async(idx, mmr).await?;
-        // TODO: mmr cache
         Ok(())
     }
 
@@ -115,14 +102,6 @@ impl L1BlockManager {
     pub async fn get_tx_async(&self, tx_ref: L1TxRef) -> DbResult<Option<L1Tx>> {
         // TODO: possibly a cache
         self.ops.get_tx_async(tx_ref).await
-    }
-
-    pub fn get_last_mmr_to(&self, idx: u64) -> DbResult<Option<CompactMmr>> {
-        self.ops.get_last_mmr_to_blocking(idx)
-    }
-
-    pub async fn get_last_mmr_to_async(&self, idx: u64) -> DbResult<Option<CompactMmr>> {
-        self.ops.get_last_mmr_to_async(idx).await
     }
 
     pub fn get_txs_from(&self, start_idx: u64) -> DbResult<(Vec<L1Tx>, u64)> {

--- a/crates/storage/src/managers/l1.rs
+++ b/crates/storage/src/managers/l1.rs
@@ -1,0 +1,135 @@
+use std::sync::Arc;
+
+use strata_db::{traits::Database, DbResult};
+use strata_mmr::CompactMmr;
+use strata_primitives::{
+    buf::Buf32,
+    l1::{L1BlockManifest, L1TxRef},
+};
+use strata_state::l1::L1Tx;
+use threadpool::ThreadPool;
+
+use crate::{
+    cache::{self, CacheTable},
+    ops,
+};
+
+/// Caching manager of L1 blocks in the block database.
+pub struct L1BlockManager {
+    ops: ops::l1::L1DataOps,
+    block_cache: CacheTable<u64, Option<L1BlockManifest>>,
+}
+
+impl L1BlockManager {
+    pub fn new<D: Database + Sync + Send + 'static>(pool: ThreadPool, db: Arc<D>) -> Self {
+        let ops = ops::l1::Context::new(db).into_ops(pool);
+        let block_cache = cache::CacheTable::new(64.try_into().unwrap());
+        Self { ops, block_cache }
+    }
+
+    pub fn put_block_data(&self, idx: u64, mf: L1BlockManifest, txs: Vec<L1Tx>) -> DbResult<()> {
+        self.ops.put_block_data_blocking(idx, mf, txs)?;
+        self.block_cache.purge(&idx);
+        Ok(())
+    }
+
+    pub async fn put_block_data_async(
+        &self,
+        idx: u64,
+        mf: L1BlockManifest,
+        txs: Vec<L1Tx>,
+    ) -> DbResult<()> {
+        self.ops.put_block_data_async(idx, mf, txs).await?;
+        self.block_cache.purge(&idx);
+        Ok(())
+    }
+
+    pub fn put_mmr_checkpoint(&self, idx: u64, mmr: CompactMmr) -> DbResult<()> {
+        self.ops.put_mmr_checkpoint_blocking(idx, mmr)?;
+        // TODO: mmr cache
+        Ok(())
+    }
+
+    pub async fn put_mmr_checkpoint_async(&self, idx: u64, mmr: CompactMmr) -> DbResult<()> {
+        self.ops.put_mmr_checkpoint_async(idx, mmr).await?;
+        // TODO: mmr cache
+        Ok(())
+    }
+
+    pub fn revert_to_height(&self, idx: u64) -> DbResult<()> {
+        // TODO: purge all idx from cache
+        self.ops.revert_to_height_blocking(idx)
+    }
+
+    pub async fn revert_to_height_async(&self, idx: u64) -> DbResult<()> {
+        // TODO: purge all idx from cache
+        self.ops.revert_to_height_async(idx).await
+    }
+
+    pub fn get_chain_tip(&self) -> DbResult<Option<u64>> {
+        self.ops.get_chain_tip_blocking()
+    }
+
+    pub async fn get_chain_tip_async(&self) -> DbResult<Option<u64>> {
+        self.ops.get_chain_tip_async().await
+    }
+
+    pub fn get_block_manifest(&self, idx: u64) -> DbResult<Option<L1BlockManifest>> {
+        self.block_cache
+            .get_or_fetch_blocking(&idx, || self.ops.get_block_manifest_blocking(idx))
+    }
+
+    pub async fn get_block_manifest_async(&self, idx: u64) -> DbResult<Option<L1BlockManifest>> {
+        self.block_cache
+            .get_or_fetch(&idx, || self.ops.get_block_manifest_chan(idx))
+            .await
+    }
+
+    pub fn get_blockid_range(&self, start_idx: u64, end_idx: u64) -> DbResult<Vec<Buf32>> {
+        self.ops.get_blockid_range_blocking(start_idx, end_idx)
+    }
+
+    pub async fn get_blockid_range_async(
+        &self,
+        start_idx: u64,
+        end_idx: u64,
+    ) -> DbResult<Vec<Buf32>> {
+        self.ops.get_blockid_range_async(start_idx, end_idx).await
+    }
+
+    pub fn get_block_txs(&self, idx: u64) -> DbResult<Option<Vec<L1TxRef>>> {
+        // TODO: possibly a cache
+        self.ops.get_block_txs_blocking(idx)
+    }
+
+    pub async fn get_block_txs_async(&self, idx: u64) -> DbResult<Option<Vec<L1TxRef>>> {
+        // TODO: possibly a cache
+        self.ops.get_block_txs_async(idx).await
+    }
+
+    pub fn get_tx(&self, tx_ref: L1TxRef) -> DbResult<Option<L1Tx>> {
+        // TODO: possibly a cache
+        self.ops.get_tx_blocking(tx_ref)
+    }
+
+    pub async fn get_tx_async(&self, tx_ref: L1TxRef) -> DbResult<Option<L1Tx>> {
+        // TODO: possibly a cache
+        self.ops.get_tx_async(tx_ref).await
+    }
+
+    pub fn get_last_mmr_to(&self, idx: u64) -> DbResult<Option<CompactMmr>> {
+        self.ops.get_last_mmr_to_blocking(idx)
+    }
+
+    pub async fn get_last_mmr_to_async(&self, idx: u64) -> DbResult<Option<CompactMmr>> {
+        self.ops.get_last_mmr_to_async(idx).await
+    }
+
+    pub fn get_txs_from(&self, start_idx: u64) -> DbResult<(Vec<L1Tx>, u64)> {
+        self.ops.get_txs_from_blocking(start_idx)
+    }
+
+    pub async fn get_txs_from_async(&self, start_idx: u64) -> DbResult<(Vec<L1Tx>, u64)> {
+        self.ops.get_txs_from_async(start_idx).await
+    }
+}

--- a/crates/storage/src/managers/l1.rs
+++ b/crates/storage/src/managers/l1.rs
@@ -22,7 +22,7 @@ pub struct L1BlockManager {
 
 impl L1BlockManager {
     pub fn new<D: Database + Sync + Send + 'static>(pool: ThreadPool, db: Arc<D>) -> Self {
-        let ops = ops::l1::Context::new(db).into_ops(pool);
+        let ops = ops::l1::Context::new(db.l1_db().clone()).into_ops(pool);
         let manifest_cache = cache::CacheTable::new(64.try_into().unwrap());
         let txs_cache = cache::CacheTable::new(64.try_into().unwrap());
         Self {

--- a/crates/storage/src/managers/l1.rs
+++ b/crates/storage/src/managers/l1.rs
@@ -13,22 +13,29 @@ use crate::{
     ops,
 };
 
-/// Caching manager of L1 blocks in the block database.
+/// Caching manager of L1 block data
 pub struct L1BlockManager {
     ops: ops::l1::L1DataOps,
-    block_cache: CacheTable<u64, Option<L1BlockManifest>>,
+    manifest_cache: CacheTable<u64, Option<L1BlockManifest>>,
+    txs_cache: CacheTable<u64, Option<Vec<L1TxRef>>>,
 }
 
 impl L1BlockManager {
     pub fn new<D: Database + Sync + Send + 'static>(pool: ThreadPool, db: Arc<D>) -> Self {
         let ops = ops::l1::Context::new(db).into_ops(pool);
-        let block_cache = cache::CacheTable::new(64.try_into().unwrap());
-        Self { ops, block_cache }
+        let manifest_cache = cache::CacheTable::new(64.try_into().unwrap());
+        let txs_cache = cache::CacheTable::new(64.try_into().unwrap());
+        Self {
+            ops,
+            manifest_cache,
+            txs_cache,
+        }
     }
 
     pub fn put_block_data(&self, idx: u64, mf: L1BlockManifest, txs: Vec<L1Tx>) -> DbResult<()> {
         self.ops.put_block_data_blocking(idx, mf, txs)?;
-        self.block_cache.purge(&idx);
+        self.manifest_cache.purge(&idx);
+        self.txs_cache.purge(&idx);
         Ok(())
     }
 
@@ -39,18 +46,34 @@ impl L1BlockManager {
         txs: Vec<L1Tx>,
     ) -> DbResult<()> {
         self.ops.put_block_data_async(idx, mf, txs).await?;
-        self.block_cache.purge(&idx);
+        self.manifest_cache.purge(&idx);
+        self.txs_cache.purge(&idx);
         Ok(())
     }
 
     pub fn revert_to_height(&self, idx: u64) -> DbResult<()> {
-        // TODO: purge all idx from cache
-        self.ops.revert_to_height_blocking(idx)
+        let res = self.ops.revert_to_height_blocking(idx);
+
+        // Purge from cache
+        if let Some(tip) = self.ops.get_chain_tip_blocking()? {
+            for i in idx..=tip {
+                self.manifest_cache.purge(&i);
+            }
+        }
+
+        res
     }
 
     pub async fn revert_to_height_async(&self, idx: u64) -> DbResult<()> {
-        // TODO: purge all idx from cache
-        self.ops.revert_to_height_async(idx).await
+        let res = self.ops.revert_to_height_async(idx).await;
+
+        // Purge from cache
+        if let Some(tip) = self.ops.get_chain_tip_blocking()? {
+            for i in idx..=tip {
+                self.manifest_cache.purge(&i);
+            }
+        }
+        res
     }
 
     pub fn get_chain_tip(&self) -> DbResult<Option<u64>> {
@@ -62,12 +85,12 @@ impl L1BlockManager {
     }
 
     pub fn get_block_manifest(&self, idx: u64) -> DbResult<Option<L1BlockManifest>> {
-        self.block_cache
+        self.manifest_cache
             .get_or_fetch_blocking(&idx, || self.ops.get_block_manifest_blocking(idx))
     }
 
     pub async fn get_block_manifest_async(&self, idx: u64) -> DbResult<Option<L1BlockManifest>> {
-        self.block_cache
+        self.manifest_cache
             .get_or_fetch(&idx, || self.ops.get_block_manifest_chan(idx))
             .await
     }
@@ -85,22 +108,23 @@ impl L1BlockManager {
     }
 
     pub fn get_block_txs(&self, idx: u64) -> DbResult<Option<Vec<L1TxRef>>> {
-        // TODO: possibly a cache
-        self.ops.get_block_txs_blocking(idx)
+        self.txs_cache
+            .get_or_fetch_blocking(&idx, || self.ops.get_block_txs_blocking(idx))
     }
 
     pub async fn get_block_txs_async(&self, idx: u64) -> DbResult<Option<Vec<L1TxRef>>> {
-        // TODO: possibly a cache
-        self.ops.get_block_txs_async(idx).await
+        self.txs_cache
+            .get_or_fetch(&idx, || self.ops.get_block_txs_chan(idx))
+            .await
     }
 
     pub fn get_tx(&self, tx_ref: L1TxRef) -> DbResult<Option<L1Tx>> {
-        // TODO: possibly a cache
+        // TODO: Might need to use a cache here, but let's keep it for when we use it
         self.ops.get_tx_blocking(tx_ref)
     }
 
     pub async fn get_tx_async(&self, tx_ref: L1TxRef) -> DbResult<Option<L1Tx>> {
-        // TODO: possibly a cache
+        // TODO: Might need to use a cache here, but let's keep it for when we use it
         self.ops.get_tx_async(tx_ref).await
     }
 

--- a/crates/storage/src/managers/l2.rs
+++ b/crates/storage/src/managers/l2.rs
@@ -17,7 +17,7 @@ pub struct L2BlockManager {
 
 impl L2BlockManager {
     pub fn new<D: Database + Sync + Send + 'static>(pool: ThreadPool, db: Arc<D>) -> Self {
-        let ops = ops::l2::Context::new(db).into_ops(pool);
+        let ops = ops::l2::Context::new(db.l2_db().clone()).into_ops(pool);
         let block_cache = cache::CacheTable::new(64.try_into().unwrap());
         Self { ops, block_cache }
     }

--- a/crates/storage/src/managers/l2.rs
+++ b/crates/storage/src/managers/l2.rs
@@ -23,32 +23,32 @@ impl L2BlockManager {
     }
 
     /// Puts a block in the database, purging cache entry.
-    pub async fn put_block_async(&self, bundle: L2BlockBundle) -> DbResult<()> {
+    pub async fn put_block_data_async(&self, bundle: L2BlockBundle) -> DbResult<()> {
         let id = bundle.block().header().get_blockid();
-        self.ops.put_block_async(bundle).await?;
+        self.ops.put_block_data_async(bundle).await?;
         self.block_cache.purge(&id);
         Ok(())
     }
 
     /// Puts in a block in the database, purging cache entry.
-    pub fn put_block_blocking(&self, bundle: L2BlockBundle) -> DbResult<()> {
+    pub fn put_block_data_blocking(&self, bundle: L2BlockBundle) -> DbResult<()> {
         let id = bundle.block().header().get_blockid();
-        self.ops.put_block_blocking(bundle)?;
+        self.ops.put_block_data_blocking(bundle)?;
         self.block_cache.purge(&id);
         Ok(())
     }
 
     /// Gets a block either in the cache or from the underlying database.
-    pub async fn get_block_async(&self, id: &L2BlockId) -> DbResult<Option<L2BlockBundle>> {
+    pub async fn get_block_data_async(&self, id: &L2BlockId) -> DbResult<Option<L2BlockBundle>> {
         self.block_cache
-            .get_or_fetch(id, || self.ops.get_block_chan(*id))
+            .get_or_fetch(id, || self.ops.get_block_data_chan(*id))
             .await
     }
 
     /// Gets a block either in the cache or from the underlying database.
-    pub fn get_block_blocking(&self, id: &L2BlockId) -> DbResult<Option<L2BlockBundle>> {
+    pub fn get_block_data_blocking(&self, id: &L2BlockId) -> DbResult<Option<L2BlockBundle>> {
         self.block_cache
-            .get_or_fetch_blocking(id, || self.ops.get_block_blocking(*id))
+            .get_or_fetch_blocking(id, || self.ops.get_block_data_blocking(*id))
     }
 
     /// Gets the block at a height.  Async.
@@ -72,16 +72,16 @@ impl L2BlockManager {
     }
 
     /// Sets the block's verification status.  Async.
-    pub async fn put_block_status_async(
+    pub async fn set_block_status_async(
         &self,
         id: &L2BlockId,
         status: BlockStatus,
     ) -> DbResult<()> {
-        self.ops.put_block_status_async(*id, status).await
+        self.ops.set_block_status_async(*id, status).await
     }
 
     /// Sets the block's verification status.  Blocking.
-    pub fn put_block_status_blocking(&self, id: &L2BlockId, status: BlockStatus) -> DbResult<()> {
-        self.ops.put_block_status_blocking(*id, status)
+    pub fn set_block_status_blocking(&self, id: &L2BlockId, status: BlockStatus) -> DbResult<()> {
+        self.ops.set_block_status_blocking(*id, status)
     }
 }

--- a/crates/storage/src/managers/mod.rs
+++ b/crates/storage/src/managers/mod.rs
@@ -1,2 +1,3 @@
 pub mod checkpoint;
+pub mod l1;
 pub mod l2;

--- a/crates/storage/src/ops/bridge.rs
+++ b/crates/storage/src/ops/bridge.rs
@@ -1,6 +1,5 @@
 use std::sync::Arc;
 
-use bitcoin::Txid;
 use strata_db::{entities::bridge_tx_state::BridgeTxState, traits::BridgeTxDatabase, DbResult};
 use strata_primitives::buf::Buf32;
 

--- a/crates/storage/src/ops/bridge.rs
+++ b/crates/storage/src/ops/bridge.rs
@@ -2,50 +2,14 @@ use std::sync::Arc;
 
 use bitcoin::Txid;
 use strata_db::{entities::bridge_tx_state::BridgeTxState, traits::BridgeTxDatabase, DbResult};
+use strata_primitives::buf::Buf32;
 
 use crate::exec::*;
 
-/// Database context for a database operation interface.
-pub struct Context<D: BridgeTxDatabase + Sync + Send + 'static> {
-    db: Arc<D>,
-}
-
-impl<D: BridgeTxDatabase + Sync + Send + 'static> Context<D> {
-    pub fn new(db: Arc<D>) -> Self {
-        Self { db }
+inst_ops_simple! {
+    (<D: BridgeTxDatabase> => BridgeTxStateOps) {
+        get_tx_state(txid: Buf32) => Option<BridgeTxState>;
+        put_tx_state(txid: Buf32, tx_state: BridgeTxState) => ();
+        delete_tx_state(txid: Buf32) => Option<BridgeTxState>;
     }
-
-    pub fn into_ops(self, pool: threadpool::ThreadPool) -> BridgeTxStateOps {
-        BridgeTxStateOps::new(pool, Arc::new(self))
-    }
-}
-
-inst_ops! {
-    (BridgeTxStateOps, Context<D: BridgeTxDatabase>) {
-        get_tx_state(txid: Txid) => Option<BridgeTxState>;
-        put_tx_state(txid: Txid, tx_state: BridgeTxState) => ();
-        delete_tx_state(txid: Txid) => Option<BridgeTxState>;
-    }
-}
-
-fn get_tx_state<D: BridgeTxDatabase + Sync + Send + 'static>(
-    context: &Context<D>,
-    txid: Txid,
-) -> DbResult<Option<BridgeTxState>> {
-    context.db.get_tx_state(txid.into())
-}
-
-fn put_tx_state<D: BridgeTxDatabase + Sync + Send + 'static>(
-    context: &Context<D>,
-    txid: Txid,
-    tx_state: BridgeTxState,
-) -> DbResult<()> {
-    context.db.put_tx_state(txid.into(), tx_state)
-}
-
-fn delete_tx_state<D: BridgeTxDatabase + Sync + Send + 'static>(
-    context: &Context<D>,
-    txid: Txid,
-) -> DbResult<Option<BridgeTxState>> {
-    context.db.delete_tx_state(txid.into())
 }

--- a/crates/storage/src/ops/bridge_duty_index.rs
+++ b/crates/storage/src/ops/bridge_duty_index.rs
@@ -17,24 +17,15 @@ impl<D: BridgeDutyIndexDatabase + Sync + Send + 'static> Context<D> {
     pub fn into_ops(self, pool: threadpool::ThreadPool) -> BridgeDutyIndexOps {
         BridgeDutyIndexOps::new(pool, Arc::new(self))
     }
+
+    pub fn db(&self) -> &D {
+        self.db.as_ref()
+    }
 }
 
-inst_ops! {
+inst_ops_auto! {
     (BridgeDutyIndexOps, Context<D: BridgeDutyIndexDatabase>) {
         get_index() => Option<u64>;
         set_index(index: u64) => ();
     }
-}
-
-fn get_index<D: BridgeDutyIndexDatabase + Sync + Send + 'static>(
-    context: &Context<D>,
-) -> DbResult<Option<u64>> {
-    context.db.get_index()
-}
-
-fn set_index<D: BridgeDutyIndexDatabase + Sync + Send + 'static>(
-    context: &Context<D>,
-    index: u64,
-) -> DbResult<()> {
-    context.db.set_index(index)
 }

--- a/crates/storage/src/ops/bridge_duty_index.rs
+++ b/crates/storage/src/ops/bridge_duty_index.rs
@@ -4,8 +4,8 @@ use strata_db::{traits::BridgeDutyIndexDatabase, DbResult};
 
 use crate::exec::*;
 
-inst_ops_auto! {
-    (BridgeDutyIndexOps, Context<D: BridgeDutyIndexDatabase>) {
+inst_ops_simple! {
+    (<D: BridgeDutyIndexDatabase> => BridgeDutyIndexOps) {
         get_index() => Option<u64>;
         set_index(index: u64) => ();
     }

--- a/crates/storage/src/ops/bridge_duty_index.rs
+++ b/crates/storage/src/ops/bridge_duty_index.rs
@@ -4,25 +4,6 @@ use strata_db::{traits::BridgeDutyIndexDatabase, DbResult};
 
 use crate::exec::*;
 
-/// Database context for a database operation interface.
-pub struct Context<D: BridgeDutyIndexDatabase + Sync + Send + 'static> {
-    db: Arc<D>,
-}
-
-impl<D: BridgeDutyIndexDatabase + Sync + Send + 'static> Context<D> {
-    pub fn new(db: Arc<D>) -> Self {
-        Self { db }
-    }
-
-    pub fn into_ops(self, pool: threadpool::ThreadPool) -> BridgeDutyIndexOps {
-        BridgeDutyIndexOps::new(pool, Arc::new(self))
-    }
-
-    pub fn db(&self) -> &D {
-        self.db.as_ref()
-    }
-}
-
 inst_ops_auto! {
     (BridgeDutyIndexOps, Context<D: BridgeDutyIndexDatabase>) {
         get_index() => Option<u64>;

--- a/crates/storage/src/ops/inscription.rs
+++ b/crates/storage/src/ops/inscription.rs
@@ -13,7 +13,7 @@ use threadpool::ThreadPool;
 use crate::exec::*;
 
 /// Database context for an database operation interface.
-pub struct Context<D: SequencerDatabase> {
+pub struct Context<D> {
     db: Arc<D>,
 }
 

--- a/crates/storage/src/ops/l1.rs
+++ b/crates/storage/src/ops/l1.rs
@@ -1,0 +1,43 @@
+//! L1 data operation interface.
+
+use std::sync::Arc;
+
+use strata_db::traits::*;
+use strata_mmr::CompactMmr;
+use strata_primitives::{
+    buf::Buf32,
+    l1::{L1BlockManifest, L1TxRef},
+};
+use strata_state::l1::L1Tx;
+
+use crate::exec::*;
+
+/// Database context for an database operation interface.
+pub struct Context<D: Database> {
+    db: Arc<D>,
+}
+
+impl<D: Database + Sync + Send + 'static> Context<D> {
+    pub fn new(db: Arc<D>) -> Self {
+        Self { db }
+    }
+
+    pub fn into_ops(self, pool: threadpool::ThreadPool) -> L1DataOps {
+        L1DataOps::new(pool, Arc::new(self))
+    }
+}
+
+inst_ops_auto! {
+    (l1_db, L1DataOps, Context<D: Database>) {
+        put_block_data(idx: u64, mf: L1BlockManifest, txs: Vec<L1Tx>) => ();
+        put_mmr_checkpoint(idx: u64, mmr: CompactMmr) => ();
+        revert_to_height(idx: u64) => ();
+        get_chain_tip() => Option<u64>;
+        get_block_manifest(idx: u64) => Option<L1BlockManifest>;
+        get_blockid_range(start_idx: u64, end_idx: u64) => Vec<Buf32>;
+        get_block_txs(idx: u64) => Option<Vec<L1TxRef>>;
+        get_tx(tx_ref: L1TxRef) => Option<L1Tx>;
+        get_last_mmr_to(idx: u64) => Option<CompactMmr>;
+        get_txs_from(start_idx: u64) => (Vec<L1Tx>, u64);
+    }
+}

--- a/crates/storage/src/ops/l1.rs
+++ b/crates/storage/src/ops/l1.rs
@@ -24,10 +24,14 @@ impl<D: Database + Sync + Send + 'static> Context<D> {
     pub fn into_ops(self, pool: threadpool::ThreadPool) -> L1DataOps {
         L1DataOps::new(pool, Arc::new(self))
     }
+
+    pub fn db(&self) -> &impl L1Database {
+        self.db.l1_db().as_ref()
+    }
 }
 
 inst_ops_auto! {
-    (l1_db, L1DataOps, Context<D: Database>) {
+    (L1DataOps, Context<D: Database>) {
         put_block_data(idx: u64, mf: L1BlockManifest, txs: Vec<L1Tx>) => ();
         revert_to_height(idx: u64) => ();
         get_chain_tip() => Option<u64>;

--- a/crates/storage/src/ops/l1.rs
+++ b/crates/storage/src/ops/l1.rs
@@ -11,8 +11,8 @@ use strata_state::l1::L1Tx;
 
 use crate::exec::*;
 
-inst_ops_auto! {
-    (L1DataOps, Context<D: L1Database>) {
+inst_ops_simple! {
+    (<D: L1Database> => L1DataOps) {
         put_block_data(idx: u64, mf: L1BlockManifest, txs: Vec<L1Tx>) => ();
         revert_to_height(idx: u64) => ();
         get_chain_tip() => Option<u64>;

--- a/crates/storage/src/ops/l1.rs
+++ b/crates/storage/src/ops/l1.rs
@@ -3,7 +3,6 @@
 use std::sync::Arc;
 
 use strata_db::traits::*;
-use strata_mmr::CompactMmr;
 use strata_primitives::{
     buf::Buf32,
     l1::{L1BlockManifest, L1TxRef},
@@ -30,14 +29,12 @@ impl<D: Database + Sync + Send + 'static> Context<D> {
 inst_ops_auto! {
     (l1_db, L1DataOps, Context<D: Database>) {
         put_block_data(idx: u64, mf: L1BlockManifest, txs: Vec<L1Tx>) => ();
-        put_mmr_checkpoint(idx: u64, mmr: CompactMmr) => ();
         revert_to_height(idx: u64) => ();
         get_chain_tip() => Option<u64>;
         get_block_manifest(idx: u64) => Option<L1BlockManifest>;
         get_blockid_range(start_idx: u64, end_idx: u64) => Vec<Buf32>;
         get_block_txs(idx: u64) => Option<Vec<L1TxRef>>;
         get_tx(tx_ref: L1TxRef) => Option<L1Tx>;
-        get_last_mmr_to(idx: u64) => Option<CompactMmr>;
         get_txs_from(start_idx: u64) => (Vec<L1Tx>, u64);
     }
 }

--- a/crates/storage/src/ops/l1.rs
+++ b/crates/storage/src/ops/l1.rs
@@ -11,27 +11,8 @@ use strata_state::l1::L1Tx;
 
 use crate::exec::*;
 
-/// Database context for an database operation interface.
-pub struct Context<D: Database> {
-    db: Arc<D>,
-}
-
-impl<D: Database + Sync + Send + 'static> Context<D> {
-    pub fn new(db: Arc<D>) -> Self {
-        Self { db }
-    }
-
-    pub fn into_ops(self, pool: threadpool::ThreadPool) -> L1DataOps {
-        L1DataOps::new(pool, Arc::new(self))
-    }
-
-    pub fn db(&self) -> &impl L1Database {
-        self.db.l1_db().as_ref()
-    }
-}
-
 inst_ops_auto! {
-    (L1DataOps, Context<D: Database>) {
+    (L1DataOps, Context<D: L1Database>) {
         put_block_data(idx: u64, mf: L1BlockManifest, txs: Vec<L1Tx>) => ();
         revert_to_height(idx: u64) => ();
         get_chain_tip() => Option<u64>;

--- a/crates/storage/src/ops/l1tx_broadcast.rs
+++ b/crates/storage/src/ops/l1tx_broadcast.rs
@@ -5,8 +5,8 @@ use strata_primitives::buf::Buf32;
 
 use crate::exec::*;
 
-inst_ops_auto! {
-    (BroadcastDbOps, Context<D: L1BroadcastDatabase>) {
+inst_ops_simple! {
+    (<D: L1BroadcastDatabase> => BroadcastDbOps) {
         get_tx_entry(idx: u64) => Option<L1TxEntry>;
         get_tx_entry_by_id(id: Buf32) => Option<L1TxEntry>;
         get_txid(idx: u64) => Option<Buf32>;

--- a/crates/storage/src/ops/l1tx_broadcast.rs
+++ b/crates/storage/src/ops/l1tx_broadcast.rs
@@ -1,10 +1,6 @@
 use std::sync::Arc;
 
-use strata_db::{
-    traits::*,
-    types::{L1TxEntry, L1TxStatus},
-    DbResult,
-};
+use strata_db::{traits::*, types::L1TxEntry, DbResult};
 use strata_primitives::buf::Buf32;
 
 use crate::exec::*;
@@ -24,81 +20,14 @@ impl<D: BroadcastDatabase + Sync + Send + 'static> Context<D> {
     }
 }
 
-inst_ops! {
-    (BroadcastDbOps, Context<D: BroadcastDatabase>) {
+inst_ops_auto! {
+    (l1_broadcast_db, BroadcastDbOps, Context<D: BroadcastDatabase>) {
         get_tx_entry(idx: u64) => Option<L1TxEntry>;
         get_tx_entry_by_id(id: Buf32) => Option<L1TxEntry>;
-        get_tx_status(id: Buf32) => Option<L1TxStatus>;
         get_txid(idx: u64) => Option<Buf32>;
         get_next_tx_idx() => u64;
         put_tx_entry(id: Buf32, entry: L1TxEntry) => Option<u64>;
         put_tx_entry_by_idx(idx: u64, entry: L1TxEntry) => ();
         get_last_tx_entry() => Option<L1TxEntry>;
     }
-}
-
-fn get_last_tx_entry<D: BroadcastDatabase + Sync + Send + 'static>(
-    context: &Context<D>,
-) -> DbResult<Option<L1TxEntry>> {
-    let bcast_db = context.db.l1_broadcast_db();
-    bcast_db.get_last_tx_entry()
-}
-
-fn get_tx_entry<D: BroadcastDatabase + Sync + Send + 'static>(
-    context: &Context<D>,
-    idx: u64,
-) -> DbResult<Option<L1TxEntry>> {
-    let bcast_db = context.db.l1_broadcast_db();
-    bcast_db.get_tx_entry(idx)
-}
-
-fn get_tx_entry_by_id<D: BroadcastDatabase + Sync + Send + 'static>(
-    context: &Context<D>,
-    id: Buf32,
-) -> DbResult<Option<L1TxEntry>> {
-    let bcast_db = context.db.l1_broadcast_db();
-    bcast_db.get_tx_entry_by_id(id)
-}
-
-fn get_txid<D: BroadcastDatabase + Sync + Send + 'static>(
-    context: &Context<D>,
-    idx: u64,
-) -> DbResult<Option<Buf32>> {
-    let bcast_db = context.db.l1_broadcast_db();
-    bcast_db.get_txid(idx)
-}
-
-fn get_tx_status<D: BroadcastDatabase + Sync + Send + 'static>(
-    context: &Context<D>,
-    id: Buf32,
-) -> DbResult<Option<L1TxStatus>> {
-    let bcast_db = context.db.l1_broadcast_db();
-    Ok(bcast_db.get_tx_entry_by_id(id)?.map(|entry| entry.status))
-}
-
-fn get_next_tx_idx<D: BroadcastDatabase + Sync + Send + 'static>(
-    context: &Context<D>,
-) -> DbResult<u64> {
-    let bcast_db = context.db.l1_broadcast_db();
-    bcast_db.get_next_tx_idx()
-}
-
-fn put_tx_entry<D: BroadcastDatabase + Sync + Send + 'static>(
-    context: &Context<D>,
-    txid: Buf32,
-    entry: L1TxEntry,
-) -> DbResult<Option<u64>> {
-    trace!(%txid, "insert_new_tx_entry");
-    assert!(entry.try_to_tx().is_ok(), "invalid tx entry {entry:?}");
-    let bcast_db = context.db.l1_broadcast_db();
-    bcast_db.put_tx_entry(txid, entry)
-}
-
-fn put_tx_entry_by_idx<D: BroadcastDatabase + Sync + Send + 'static>(
-    context: &Context<D>,
-    idx: u64,
-    entry: L1TxEntry,
-) -> DbResult<()> {
-    let bcast_db = context.db.l1_broadcast_db();
-    bcast_db.put_tx_entry_by_idx(idx, entry)
 }

--- a/crates/storage/src/ops/l1tx_broadcast.rs
+++ b/crates/storage/src/ops/l1tx_broadcast.rs
@@ -18,10 +18,14 @@ impl<D: BroadcastDatabase + Sync + Send + 'static> Context<D> {
     pub fn into_ops(self, pool: threadpool::ThreadPool) -> BroadcastDbOps {
         BroadcastDbOps::new(pool, Arc::new(self))
     }
+
+    pub fn db(&self) -> &impl L1BroadcastDatabase {
+        self.db.l1_broadcast_db().as_ref()
+    }
 }
 
 inst_ops_auto! {
-    (l1_broadcast_db, BroadcastDbOps, Context<D: BroadcastDatabase>) {
+    (BroadcastDbOps, Context<D: BroadcastDatabase>) {
         get_tx_entry(idx: u64) => Option<L1TxEntry>;
         get_tx_entry_by_id(id: Buf32) => Option<L1TxEntry>;
         get_txid(idx: u64) => Option<Buf32>;

--- a/crates/storage/src/ops/l1tx_broadcast.rs
+++ b/crates/storage/src/ops/l1tx_broadcast.rs
@@ -5,27 +5,8 @@ use strata_primitives::buf::Buf32;
 
 use crate::exec::*;
 
-/// Database context for an database operation interface.
-pub struct Context<D: BroadcastDatabase + Sync + Send + 'static> {
-    db: Arc<D>,
-}
-
-impl<D: BroadcastDatabase + Sync + Send + 'static> Context<D> {
-    pub fn new(db: Arc<D>) -> Self {
-        Self { db }
-    }
-
-    pub fn into_ops(self, pool: threadpool::ThreadPool) -> BroadcastDbOps {
-        BroadcastDbOps::new(pool, Arc::new(self))
-    }
-
-    pub fn db(&self) -> &impl L1BroadcastDatabase {
-        self.db.l1_broadcast_db().as_ref()
-    }
-}
-
 inst_ops_auto! {
-    (BroadcastDbOps, Context<D: BroadcastDatabase>) {
+    (BroadcastDbOps, Context<D: L1BroadcastDatabase>) {
         get_tx_entry(idx: u64) => Option<L1TxEntry>;
         get_tx_entry_by_id(id: Buf32) => Option<L1TxEntry>;
         get_txid(idx: u64) => Option<Buf32>;

--- a/crates/storage/src/ops/l2.rs
+++ b/crates/storage/src/ops/l2.rs
@@ -20,10 +20,14 @@ impl<D: Database + Sync + Send + 'static> Context<D> {
     pub fn into_ops(self, pool: threadpool::ThreadPool) -> L2DataOps {
         L2DataOps::new(pool, Arc::new(self))
     }
+
+    pub fn db(&self) -> &impl L2BlockDatabase {
+        self.db.l2_db().as_ref()
+    }
 }
 
 inst_ops_auto! {
-    (l2_db, L2DataOps, Context<D: Database>) {
+    (L2DataOps, Context<D: Database>) {
         get_block_data(id: L2BlockId) => Option<L2BlockBundle>;
         get_blocks_at_height(h: u64) => Vec<L2BlockId>;
         get_block_status(id: L2BlockId) => Option<BlockStatus>;

--- a/crates/storage/src/ops/l2.rs
+++ b/crates/storage/src/ops/l2.rs
@@ -22,44 +22,12 @@ impl<D: Database + Sync + Send + 'static> Context<D> {
     }
 }
 
-inst_ops! {
-    (L2DataOps, Context<D: Database>) {
-        get_block(id: L2BlockId) => Option<L2BlockBundle>;
+inst_ops_auto! {
+    (l2_db, L2DataOps, Context<D: Database>) {
+        get_block_data(id: L2BlockId) => Option<L2BlockBundle>;
         get_blocks_at_height(h: u64) => Vec<L2BlockId>;
         get_block_status(id: L2BlockId) => Option<BlockStatus>;
-        put_block(block: L2BlockBundle) => ();
-        put_block_status(id: L2BlockId, status: BlockStatus) => ();
+        put_block_data(block: L2BlockBundle) => ();
+        set_block_status(id: L2BlockId, status: BlockStatus) => ();
     }
-}
-
-fn get_block<D: Database>(context: &Context<D>, id: L2BlockId) -> DbResult<Option<L2BlockBundle>> {
-    let l2_db = context.db.l2_db();
-    l2_db.get_block_data(id)
-}
-
-fn get_blocks_at_height<D: Database>(context: &Context<D>, h: u64) -> DbResult<Vec<L2BlockId>> {
-    let l2_db = context.db.l2_db();
-    l2_db.get_blocks_at_height(h)
-}
-
-fn get_block_status<D: Database>(
-    context: &Context<D>,
-    id: L2BlockId,
-) -> DbResult<Option<BlockStatus>> {
-    let l2_db = context.db.l2_db();
-    l2_db.get_block_status(id)
-}
-
-fn put_block<D: Database>(context: &Context<D>, block: L2BlockBundle) -> DbResult<()> {
-    let l2_db = context.db.l2_db();
-    l2_db.put_block_data(block)
-}
-
-fn put_block_status<D: Database>(
-    context: &Context<D>,
-    id: L2BlockId,
-    status: BlockStatus,
-) -> DbResult<()> {
-    let l2_db = context.db.l2_db();
-    l2_db.set_block_status(id, status)
 }

--- a/crates/storage/src/ops/l2.rs
+++ b/crates/storage/src/ops/l2.rs
@@ -7,27 +7,8 @@ use strata_state::{block::L2BlockBundle, id::L2BlockId};
 
 use crate::exec::*;
 
-/// Database context for an database operation interface.
-pub struct Context<D: Database> {
-    db: Arc<D>,
-}
-
-impl<D: Database + Sync + Send + 'static> Context<D> {
-    pub fn new(db: Arc<D>) -> Self {
-        Self { db }
-    }
-
-    pub fn into_ops(self, pool: threadpool::ThreadPool) -> L2DataOps {
-        L2DataOps::new(pool, Arc::new(self))
-    }
-
-    pub fn db(&self) -> &impl L2BlockDatabase {
-        self.db.l2_db().as_ref()
-    }
-}
-
 inst_ops_auto! {
-    (L2DataOps, Context<D: Database>) {
+    (L2DataOps, Context<D: L2BlockDatabase>) {
         get_block_data(id: L2BlockId) => Option<L2BlockBundle>;
         get_blocks_at_height(h: u64) => Vec<L2BlockId>;
         get_block_status(id: L2BlockId) => Option<BlockStatus>;

--- a/crates/storage/src/ops/l2.rs
+++ b/crates/storage/src/ops/l2.rs
@@ -7,8 +7,8 @@ use strata_state::{block::L2BlockBundle, id::L2BlockId};
 
 use crate::exec::*;
 
-inst_ops_auto! {
-    (L2DataOps, Context<D: L2BlockDatabase>) {
+inst_ops_simple! {
+    (<D: L2BlockDatabase> => L2DataOps) {
         get_block_data(id: L2BlockId) => Option<L2BlockBundle>;
         get_blocks_at_height(h: u64) => Vec<L2BlockId>;
         get_block_status(id: L2BlockId) => Option<BlockStatus>;

--- a/crates/storage/src/ops/mod.rs
+++ b/crates/storage/src/ops/mod.rs
@@ -4,5 +4,6 @@ pub mod bridge_duty_index;
 pub mod bridge_relay;
 pub mod checkpoint;
 pub mod inscription;
+pub mod l1;
 pub mod l1tx_broadcast;
 pub mod l2;

--- a/crates/sync/src/state.rs
+++ b/crates/sync/src/state.rs
@@ -62,7 +62,7 @@ pub fn initialize_from_db(
     l2_block_manager: &L2BlockManager,
 ) -> Result<L2SyncState, L2SyncError> {
     let finalized_blockid = sync.finalized_blkid();
-    let finalized_block = l2_block_manager.get_block_blocking(finalized_blockid)?;
+    let finalized_block = l2_block_manager.get_block_data_blocking(finalized_blockid)?;
     let Some(finalized_block) = finalized_block else {
         return Err(L2SyncError::MissingBlock(*finalized_blockid));
     };

--- a/crates/sync/src/worker.rs
+++ b/crates/sync/src/worker.rs
@@ -79,7 +79,7 @@ pub async fn sync_worker<T: SyncClient>(
                 };
 
                 let finalized_blockid = sync.finalized_blkid();
-                let Ok(Some(finalized_block)) = context.l2_block_manager.get_block_async(finalized_blockid).await else {
+                let Ok(Some(finalized_block)) = context.l2_block_manager.get_block_data_async(finalized_blockid).await else {
                     error!(finalized_blockid = ?finalized_blockid, "missing finalized block");
                     continue;
                 };
@@ -192,7 +192,7 @@ async fn handle_new_block<T: SyncClient>(
         state.attach_block(block.header())?;
         context
             .l2_block_manager
-            .put_block_async(block.clone())
+            .put_block_data_async(block.clone())
             .await?;
         let block_idx = block.header().blockidx();
         debug!(%block_idx, "l2 sync: sending chain tip msg");


### PR DESCRIPTION
## Description

This PR does the following: 
1. Adds `L1DataManager` which basically hides the `Database` implementation internally.
2. Adds a new `inst_ops_simple` macro that removes some boilerplate that was required in order to define `*DbOps`. Basically, now we need pass in the corresponding db method name to the macro and the functions defined should already exist in the database interface.
3. Refactors `L2DataOps` to use this new macro.

### Type of Change

<!--
Select the type of change your PR introduces (put an `x` in all that apply):
-->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature/Enhancement (non-breaking change which adds functionality or enhances an existing one)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Refactor
- [ ] New or updated tests
- [ ] Dependency Update

## Notes to Reviewers

<!--
Anything in particular you want to note that will help reviewers fulfill their role
in reviewing this PR?
-->

## Checklist

<!--
Ensure all the following are checked:
-->

- [x] I have performed a self-review of my code.
- [ ] I have commented my code where necessary.
- [ ] I have updated the documentation if needed.
- [x] My changes do not introduce new warnings.
- [ ] I have added tests that prove my changes are effective or that my feature works.
- [ ] New and existing tests pass with my changes.

## Related Issues

<!--
Link any related issues (e.g., `closes #123`, `fixes #456`).
-->
