### PR TITLE
(rocksdb-store): Use seek_key_codec for checkpoint db

### DIFF
--- a/crates/rocksdb-store/src/checkpoint/schemas.rs
+++ b/crates/rocksdb-store/src/checkpoint/schemas.rs
@@ -1,8 +1,8 @@
 use strata_db::types::CheckpointEntry;
 
-use crate::{define_table_with_default_codec, define_table_without_codec, impl_borsh_value_codec};
+use crate::{define_table_with_seek_key_codec, define_table_without_codec, impl_borsh_value_codec};
 
-define_table_with_default_codec!(
+define_table_with_seek_key_codec!(
     /// A table to store idx -> BatchCheckpoint mapping
     (BatchCheckpointSchema) u64 => CheckpointEntry
 );


### PR DESCRIPTION
## Description

This fixes a potential issue in checkpoint database where the last_idx did not grow beyond 256.

### Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature/Enhancement (non-breaking change which adds functionality or enhances an existing one)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactor
- [ ] New or updated tests
- [ ] Dependency Update

## Notes to Reviewers

<!--
Anything in particular you want to note that will help reviewers fulfill their role
in reviewing this PR?
-->

## Checklist

<!--
Ensure all the following are checked:
-->

- [x] I have performed a self-review of my code.
- [ ] I have commented my code where necessary.
- [ ] I have updated the documentation if needed.
- [ ] My changes do not introduce new warnings.
- [x] I have added tests that prove my changes are effective or that my feature works.
- [x] New and existing tests pass with my changes.

## Related Issues

<!--
Link any related issues (e.g., `closes #123`, `fixes #456`).
-->
