### PR TITLE
Use consistent rust edition

### DIFF
--- a/crates/config/Cargo.toml
+++ b/crates/config/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-edition = "2024"
+edition = "2021"
 name = "strata-config"
 version = "0.1.0"
 


### PR DESCRIPTION
## Description

<!--
Provide a brief summary of the changes and the motivation behind them.
-->
The `strata-config` crate uses the 2024 edition of rust while the rest of the crates use the 2021 edition. This is not a problem for this repo since the 2024 edition was [stabilized](https://doc.rust-lang.org/nightly/cargo/reference/unstable.html#edition-2024) in rust-1.85 which is the version of Rust this repo uses. However, there is a [regression](https://github.com/rust-lang/rust/issues/134044) in this rustc version related to const generics that is causing compilation issues in the strata-bridge repo. This PR, therefore, changes the edition to 2021.

### Type of Change

<!--
Select the type of change your PR introduces (put an `x` in all that apply):
-->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature/Enhancement (non-breaking change which adds functionality or enhances an existing one)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactor
- [ ] New or updated tests
- [ ] Dependency Update


## Checklist

<!--
Ensure all the following are checked:
-->

- [x] I have performed a self-review of my code.
- [ ] I have commented my code where necessary.
- [ ] I have updated the documentation if needed.
- [x] My changes do not introduce new warnings.
- [ ] I have added tests that prove my changes are effective or that my feature works.
- [ ] New and existing tests pass with my changes.