### PR TITLE
chore(make): disable sec for now

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -226,7 +226,7 @@ test: ## Runs all tests in the workspace including unit and docs tests.
 	make test-doc
 
 .PHONY: pr
-pr: lint sec rustdocs test-doc test-unit test-int test-functional ## Runs lints (without fixing), audit, docs, and tests (run this before creating a PR).
+pr: lint rustdocs test-doc test-unit test-int test-functional ## Runs lints (without fixing), audit, docs, and tests (run this before creating a PR).
 	@echo "\n\033[36m======== CHECKS_COMPLETE ========\033[0m\n"
 	@test -z "$$(git status --porcelain)" || echo "WARNNG: You have uncommitted changes"
 	@echo "All good to create a PR!"


### PR DESCRIPTION
## Description

Right now we have several issues with `cargo-audit` that will be fixed once #542 lands and we have a new release of `cargo-audit`.

Hence `make pr` should emulate our GH CI.

### Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature/Enhancement (non-breaking change which adds functionality or enhances an existing one)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Refactor
- [ ] New or updated tests
- [ ] Dependency Update

## Notes to Reviewers

I've updated STR-601 to remember to toggle this back as well once the `cargo-audit` stuff is fixed.

## Checklist


- [x] I have performed a self-review of my code.
- [x] I have commented my code where necessary.
- [x] I have updated the documentation if needed.
- [x] My changes do not introduce new warnings.
- [x] I have added tests that prove my changes are effective or that my feature works.
- [x] New and existing tests pass with my changes.

