### PR TITLE
CI: Ignore unpinned-uses to github cleanup actions

### DIFF
--- a/.github/workflows/functional.yml
+++ b/.github/workflows/functional.yml
@@ -63,7 +63,7 @@ jobs:
           persist-credentials: false
 
       - name: Cleanup Space
-        uses: ./.github/actions/cleanup@main
+        uses: ./.github/actions/cleanup # zizmor: ignore[unpinned-uses]
 
       - name: Install bitcoind
         env:

--- a/.github/workflows/functional.yml
+++ b/.github/workflows/functional.yml
@@ -63,7 +63,7 @@ jobs:
           persist-credentials: false
 
       - name: Cleanup Space
-        uses: ./.github/actions/cleanup
+        uses: ./.github/actions/cleanup@main
 
       - name: Install bitcoind
         env:

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -24,7 +24,7 @@ jobs:
           persist-credentials: false
 
       - name: Cleanup space
-        uses: ./.github/actions/cleanup@main
+        uses: ./.github/actions/cleanup # zizmor: ignore[unpinned-uses]
 
       - uses: dtolnay/rust-toolchain@nightly
       - name: Install latest nextest release

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -24,7 +24,7 @@ jobs:
           persist-credentials: false
 
       - name: Cleanup space
-        uses: ./.github/actions/cleanup
+        uses: ./.github/actions/cleanup@main
 
       - uses: dtolnay/rust-toolchain@nightly
       - name: Install latest nextest release

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -36,7 +36,7 @@ jobs:
           persist-credentials: false
 
       - name: Cleanup space
-        uses: ./.github/actions/cleanup@main
+        uses: ./.github/actions/cleanup # zizmor: ignore[unpinned-uses]
 
       - uses: dtolnay/rust-toolchain@nightly
         with:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -36,7 +36,7 @@ jobs:
           persist-credentials: false
 
       - name: Cleanup space
-        uses: ./.github/actions/cleanup
+        uses: ./.github/actions/cleanup@main
 
       - uses: dtolnay/rust-toolchain@nightly
         with:

--- a/.github/workflows/unit.yml
+++ b/.github/workflows/unit.yml
@@ -26,7 +26,7 @@ jobs:
           persist-credentials: false
 
       - name: Cleanup space
-        uses: ./.github/actions/cleanup@main
+        uses: ./.github/actions/cleanup # zizmor: ignore[unpinned-uses]
 
       - uses: dtolnay/rust-toolchain@nightly
         with:
@@ -71,7 +71,7 @@ jobs:
           persist-credentials: false
 
       - name: Cleanup space
-        uses: ./.github/actions/cleanup@main
+        uses: ./.github/actions/cleanup # zizmor: ignore[unpinned-uses]
 
       - uses: dtolnay/rust-toolchain@nightly
         with:

--- a/.github/workflows/unit.yml
+++ b/.github/workflows/unit.yml
@@ -26,7 +26,7 @@ jobs:
           persist-credentials: false
 
       - name: Cleanup space
-        uses: ./.github/actions/cleanup
+        uses: ./.github/actions/cleanup@main
 
       - uses: dtolnay/rust-toolchain@nightly
         with:
@@ -71,7 +71,7 @@ jobs:
           persist-credentials: false
 
       - name: Cleanup space
-        uses: ./.github/actions/cleanup
+        uses: ./.github/actions/cleanup@main
 
       - uses: dtolnay/rust-toolchain@nightly
         with:


### PR DESCRIPTION
## Description

zizmor CI checks are failing because the cleanup action does not have a version/tag/branch pinned to it. This PR tags the action with `@main`.

__EDIT__: That didn't work so as @Rajil1213  suggested, I've just commented the `cleanup` actions with `# zizmor: ignore[unpinned-uses]`.

### Type of Change

<!--
Select the type of change your PR introduces (put an `x` in all that apply):
-->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature/Enhancement (non-breaking change which adds functionality or enhances an existing one)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactor
- [ ] New or updated tests
- [ ] Dependency Update

## Notes to Reviewers

<!--
Anything in particular you want to note that will help reviewers fulfill their role
in reviewing this PR?
-->

## Checklist

<!--
Ensure all the following are checked:
-->

- [ ] I have performed a self-review of my code.
- [ ] I have commented my code where necessary.
- [ ] I have updated the documentation if needed.
- [ ] My changes do not introduce new warnings.
- [ ] I have added tests that prove my changes are effective or that my feature works.
- [ ] New and existing tests pass with my changes.

## Related Issues

<!--
Link any related issues (e.g., `closes #123`, `fixes #456`).
-->
