### PR TITLE
Reuse TxFilterConfig in L1-Scan Guest code

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12967,6 +12967,7 @@ dependencies = [
  "strata-proofimpl-btc-blockspace",
  "strata-state",
  "strata-test-utils",
+ "strata-tx-parser",
  "strata-zkvm",
 ]
 

--- a/crates/proof-impl/btc-blockspace/src/filter.rs
+++ b/crates/proof-impl/btc-blockspace/src/filter.rs
@@ -12,14 +12,12 @@ use strata_tx_parser::filter::{filter_protocol_op_tx_refs, TxFilterConfig};
 pub fn extract_relevant_info(
     block: &Block,
     rollup_params: &RollupParams,
+    filter_config: &TxFilterConfig,
 ) -> (Vec<DepositInfo>, Option<BatchCheckpoint>) {
-    let filter_config =
-        TxFilterConfig::derive_from(rollup_params).expect("derive tx-filter config");
-
     let mut deposits = Vec::new();
     let mut prev_checkpoint = None;
 
-    let relevant_txs = filter_protocol_op_tx_refs(block, &filter_config);
+    let relevant_txs = filter_protocol_op_tx_refs(block, filter_config);
 
     for tx in relevant_txs {
         match tx.proto_op() {

--- a/crates/proof-impl/btc-blockspace/src/logic.rs
+++ b/crates/proof-impl/btc-blockspace/src/logic.rs
@@ -4,6 +4,7 @@ use bitcoin::{consensus::deserialize, Block};
 use borsh::{BorshDeserialize, BorshSerialize};
 use strata_primitives::params::RollupParams;
 use strata_state::{batch::BatchCheckpoint, l1::L1TxProof, tx::DepositInfo};
+use strata_tx_parser::filter::TxFilterConfig;
 use strata_zkvm::ZkVmEnv;
 
 use crate::scan::process_blockscan;
@@ -29,7 +30,9 @@ pub fn process_blockspace_proof_outer(zkvm: &impl ZkVmEnv) {
     let serialized_block = zkvm.read_buf();
     let inclusion_proof: Option<L1TxProof> = zkvm.read_borsh();
     let block: Block = deserialize(&serialized_block).unwrap();
-    let output = process_blockscan(&block, &inclusion_proof, &rollup_params);
+    let filter_config =
+        TxFilterConfig::derive_from(&rollup_params).expect("derive tx-filter config");
+    let output = process_blockscan(&block, &inclusion_proof, &rollup_params, &filter_config);
     zkvm.commit_borsh(&output);
 }
 

--- a/crates/proof-impl/btc-blockspace/src/scan.rs
+++ b/crates/proof-impl/btc-blockspace/src/scan.rs
@@ -3,6 +3,7 @@
 use bitcoin::{consensus::serialize, Block};
 use strata_primitives::params::RollupParams;
 use strata_state::l1::L1TxProof;
+use strata_tx_parser::filter::TxFilterConfig;
 
 use crate::{block::check_integrity, filter::extract_relevant_info, logic::BlockScanResult};
 
@@ -11,10 +12,11 @@ pub fn process_blockscan(
     block: &Block,
     inclusion_proof: &Option<L1TxProof>,
     rollup_params: &RollupParams,
+    filter_config: &TxFilterConfig,
 ) -> BlockScanResult {
     assert!(check_integrity(block, inclusion_proof));
 
-    let (deposits, prev_checkpoint) = extract_relevant_info(block, rollup_params);
+    let (deposits, prev_checkpoint) = extract_relevant_info(block, rollup_params, filter_config);
 
     BlockScanResult {
         header_raw: serialize(&block.header),

--- a/crates/proof-impl/l1-batch/Cargo.toml
+++ b/crates/proof-impl/l1-batch/Cargo.toml
@@ -11,6 +11,7 @@ serde.workspace = true
 strata-primitives.workspace = true
 strata-proofimpl-btc-blockspace.workspace = true
 strata-state.workspace = true
+strata-tx-parser.workspace = true
 strata-zkvm.workspace = true
 
 [dev-dependencies]


### PR DESCRIPTION
## Description
Instead of computing a new TxFilterConfig for each L1 block scan, reuse the same TxFilterConfig for the entire batch.<!--
Provide a brief summary of the changes and the motivation behind them.
-->

### Type of Change

<!--
Select the type of change your PR introduces (put an `x` in all that apply):
-->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature/Enhancement (non-breaking change which adds functionality or enhances an existing one)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Refactor
- [ ] New or updated tests
- [ ] Dependency Update

## Notes to Reviewers

<!--
Anything in particular you want to note that will help reviewers fulfill their role
in reviewing this PR?
-->

## Checklist

<!--
Ensure all the following are checked:
-->

- [ ] I have performed a self-review of my code.
- [ ] I have commented my code where necessary.
- [ ] I have updated the documentation if needed.
- [ ] My changes do not introduce new warnings.
- [ ] I have added tests that prove my changes are effective or that my feature works.
- [ ] New and existing tests pass with my changes.

## Related Issues

<!--
Link any related issues (e.g., `closes #123`, `fixes #456`).
-->
