### PR TITLE
STR-953: `btcio` backport (and some new) strata-bridge RPCs

### DIFF
--- a/crates/btcio/src/rpc/client.rs
+++ b/crates/btcio/src/rpc/client.rs
@@ -130,9 +130,12 @@ impl BitcoinClient {
             trace!(?response, "Response received");
             match response {
                 Ok(resp) => {
-                    let data = resp
-                        .json::<Response<T>>()
+                    let raw_response = resp
+                        .text()
                         .await
+                        .map_err(|e| ClientError::Parse(e.to_string()))?;
+                    trace!(%raw_response, "Raw response received");
+                    let data: Response<T> = serde_json::from_str(&raw_response)
                         .map_err(|e| ClientError::Parse(e.to_string()))?;
                     if let Some(err) = data.error {
                         return Err(ClientError::Server(err.code, err.message));

--- a/crates/btcio/src/rpc/client.rs
+++ b/crates/btcio/src/rpc/client.rs
@@ -29,7 +29,7 @@ use crate::rpc::{
     types::{
         CreateWallet, GetBlockVerbosityZero, GetBlockchainInfo, GetNewAddress, GetTransaction,
         GetTxOut, ImportDescriptor, ImportDescriptorResult, ListDescriptors, ListTransactions,
-        ListUnspent, SignRawTransactionWithWallet, TestMempoolAccept,
+        ListUnspent, SignRawTransactionWithWallet, SubmitPackage, TestMempoolAccept,
     },
 };
 
@@ -263,6 +263,12 @@ impl ReaderRpc for BitcoinClient {
             ],
         )
         .await
+    }
+
+    async fn submit_package(&self, txs: &[Transaction]) -> ClientResult<SubmitPackage> {
+        let txstrs: Vec<String> = txs.iter().map(serialize_hex).collect();
+        self.call::<SubmitPackage>("submitpackage", &[to_value(txstrs)?])
+            .await
     }
 
     async fn network(&self) -> ClientResult<Network> {

--- a/crates/btcio/src/rpc/client.rs
+++ b/crates/btcio/src/rpc/client.rs
@@ -238,6 +238,12 @@ impl ReaderRpc for BitcoinClient {
             .await
     }
 
+    async fn get_current_timestamp(&self) -> ClientResult<u32> {
+        let best_block_hash = self.call::<BlockHash>("getbestblockhash", &[]).await?;
+        let block = self.get_block(&best_block_hash).await?;
+        Ok(block.header.time)
+    }
+
     async fn get_raw_mempool(&self) -> ClientResult<Vec<Txid>> {
         self.call::<Vec<Txid>>("getrawmempool", &[]).await
     }
@@ -408,6 +414,12 @@ mod test {
         // get_blockchain_info
         let get_blockchain_info = client.get_blockchain_info().await.unwrap();
         assert_eq!(get_blockchain_info.blocks, 0);
+
+        // get_current_timestamp
+        let _ = client
+            .get_current_timestamp()
+            .await
+            .expect("must be able to get current timestamp");
 
         let blocks = mine_blocks(&bitcoind, 101, None).unwrap();
 

--- a/crates/btcio/src/rpc/client.rs
+++ b/crates/btcio/src/rpc/client.rs
@@ -645,11 +645,11 @@ mod test {
     /// that we don't control.
     #[tokio::test()]
     async fn submit_package() {
-        logging::init(logging::LoggerConfig::with_base_name("btcio-tests"));
+        logging::init(logging::LoggerConfig::with_base_name("btcio-submitpackage"));
 
         let (bitcoind, client) = get_bitcoind_and_client();
 
-        // network
+        // network sanity check
         let got = client.network().await.unwrap();
         let expected = Network::Regtest;
         assert_eq!(expected, got);
@@ -661,7 +661,8 @@ mod test {
         let destination = client.get_new_address().await.unwrap();
         let change_address = client.get_new_address().await.unwrap();
         let amount = Amount::from_btc(1.0).unwrap();
-        let change_amount = Amount::from_btc(48.999).unwrap(); // 0.0001 fee
+        let fees = Amount::from_btc(0.0001).unwrap();
+        let change_amount = COINBASE_AMOUNT - amount - fees;
         let amount_minus_fees = Amount::from_sat(amount.to_sat() - 2_000);
 
         let send_back_address = client.get_new_address().await.unwrap();

--- a/crates/btcio/src/rpc/traits.rs
+++ b/crates/btcio/src/rpc/traits.rs
@@ -5,8 +5,8 @@ use crate::rpc::{
     client::ClientResult,
     types::{
         CreateRawTransaction, GetBlockchainInfo, GetTransaction, GetTxOut, ImportDescriptor,
-        ImportDescriptorResult, ListTransactions, ListUnspent, SignRawTransactionWithWallet,
-        SubmitPackage, TestMempoolAccept,
+        ImportDescriptorResult, ListTransactions, ListUnspent, PreviousTransactionOutput,
+        SignRawTransactionWithWallet, SubmitPackage, TestMempoolAccept,
     },
 };
 
@@ -190,6 +190,7 @@ pub trait SignerRpc {
     async fn sign_raw_transaction_with_wallet(
         &self,
         tx: &Transaction,
+        prev_outputs: Option<Vec<PreviousTransactionOutput>>,
     ) -> ClientResult<SignRawTransactionWithWallet>;
 
     /// Gets the underlying [`Xpriv`] from the wallet.

--- a/crates/btcio/src/rpc/traits.rs
+++ b/crates/btcio/src/rpc/traits.rs
@@ -4,9 +4,9 @@ use bitcoin::{bip32::Xpriv, Address, Block, BlockHash, Network, Transaction, Txi
 use crate::rpc::{
     client::ClientResult,
     types::{
-        GetBlockchainInfo, GetTransaction, GetTxOut, ImportDescriptor, ImportDescriptorResult,
-        ListTransactions, ListUnspent, SignRawTransactionWithWallet, SubmitPackage,
-        TestMempoolAccept,
+        CreateRawTransaction, GetBlockchainInfo, GetTransaction, GetTxOut, ImportDescriptor,
+        ImportDescriptorResult, ListTransactions, ListUnspent, SignRawTransactionWithWallet,
+        SubmitPackage, TestMempoolAccept,
     },
 };
 
@@ -159,6 +159,12 @@ pub trait WalletRpc {
 
     /// Lists all wallets in the underlying Bitcoin client.
     async fn list_wallets(&self) -> ClientResult<Vec<String>>;
+
+    /// Creates a raw transaction.
+    async fn create_raw_transaction(
+        &self,
+        raw_tx: CreateRawTransaction,
+    ) -> ClientResult<Transaction>;
 }
 
 /// Signing functionality that any Bitcoin client **with private keys** that

--- a/crates/btcio/src/rpc/traits.rs
+++ b/crates/btcio/src/rpc/traits.rs
@@ -4,7 +4,7 @@ use bitcoin::{bip32::Xpriv, Address, Block, BlockHash, Network, Transaction, Txi
 use crate::rpc::{
     client::ClientResult,
     types::{
-        GetBlockchainInfo, GetTransaction, ImportDescriptor, ImportDescriptorResult,
+        GetBlockchainInfo, GetTransaction, GetTxOut, ImportDescriptor, ImportDescriptorResult,
         ListTransactions, ListUnspent, SignRawTransactionWithWallet, TestMempoolAccept,
     },
 };
@@ -67,6 +67,14 @@ pub trait ReaderRpc {
 
     /// Gets all transaction ids in mempool.
     async fn get_raw_mempool(&self) -> ClientResult<Vec<Txid>>;
+
+    /// Returns details about an unspent transaction output.
+    async fn get_tx_out(
+        &self,
+        txid: &Txid,
+        vout: u32,
+        include_mempool: bool,
+    ) -> ClientResult<GetTxOut>;
 
     /// Gets the underlying [`Network`] information.
     async fn network(&self) -> ClientResult<Network>;

--- a/crates/btcio/src/rpc/traits.rs
+++ b/crates/btcio/src/rpc/traits.rs
@@ -5,7 +5,7 @@ use crate::rpc::{
     client::ClientResult,
     types::{
         GetBlockchainInfo, GetTransaction, ImportDescriptor, ImportDescriptorResult,
-        ListTransactions, ListUnspent, SignRawTransactionWithWallet,
+        ListTransactions, ListUnspent, SignRawTransactionWithWallet, TestMempoolAccept,
     },
 };
 
@@ -92,6 +92,9 @@ pub trait BroadcasterRpc {
     /// - `tx`: The raw transaction to send. This should be a byte array containing the serialized
     ///   raw transaction data.
     async fn send_raw_transaction(&self, tx: &Transaction) -> ClientResult<Txid>;
+
+    /// Tests if a raw transaction is valid.
+    async fn test_mempool_accept(&self, tx: &Transaction) -> ClientResult<Vec<TestMempoolAccept>>;
 }
 
 /// Wallet functionality that any Bitcoin client **without private keys** that

--- a/crates/btcio/src/rpc/traits.rs
+++ b/crates/btcio/src/rpc/traits.rs
@@ -5,7 +5,8 @@ use crate::rpc::{
     client::ClientResult,
     types::{
         GetBlockchainInfo, GetTransaction, GetTxOut, ImportDescriptor, ImportDescriptorResult,
-        ListTransactions, ListUnspent, SignRawTransactionWithWallet, TestMempoolAccept,
+        ListTransactions, ListUnspent, SignRawTransactionWithWallet, SubmitPackage,
+        TestMempoolAccept,
     },
 };
 
@@ -75,6 +76,18 @@ pub trait ReaderRpc {
         vout: u32,
         include_mempool: bool,
     ) -> ClientResult<GetTxOut>;
+
+    /// Submit a package of raw transactions (serialized, hex-encoded) to local node.
+    ///
+    /// The package will be validated according to consensus and mempool policy rules. If any
+    /// transaction passes, it will be accepted to mempool. This RPC is experimental and the
+    /// interface may be unstable. Refer to doc/policy/packages.md for documentation on package
+    /// policies.
+    ///
+    /// # Warning
+    ///
+    /// Successful submission does not mean the transactions will propagate throughout the network.
+    async fn submit_package(&self, txs: &[Transaction]) -> ClientResult<SubmitPackage>;
 
     /// Gets the underlying [`Network`] information.
     async fn network(&self) -> ClientResult<Network>;

--- a/crates/btcio/src/rpc/traits.rs
+++ b/crates/btcio/src/rpc/traits.rs
@@ -58,6 +58,13 @@ pub trait ReaderRpc {
     /// Gets various state info regarding blockchain processing.
     async fn get_blockchain_info(&self) -> ClientResult<GetBlockchainInfo>;
 
+    /// Gets the timestamp in the block header of the current best block in bitcoin.
+    ///
+    /// # Note
+    ///
+    /// Time is Unix epoch time in seconds.
+    async fn get_current_timestamp(&self) -> ClientResult<u32>;
+
     /// Gets all transaction ids in mempool.
     async fn get_raw_mempool(&self) -> ClientResult<Vec<Txid>>;
 

--- a/crates/btcio/src/rpc/types.rs
+++ b/crates/btcio/src/rpc/types.rs
@@ -148,6 +148,47 @@ pub struct GetBlockVerbosityOne {
 
 /// Result of JSON-RPC method `gettxout`.
 ///
+/// > gettxout "txid" n ( include_mempool )
+/// >
+/// > Returns details about an unspent transaction output.
+/// >
+/// > Arguments:
+/// > 1. txid               (string, required) The transaction id
+/// > 2. n                  (numeric, required) vout number
+#[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+pub struct GetTxOut {
+    /// The hash of the block at the tip of the chain.
+    #[serde(rename = "bestblock")]
+    pub best_block: String,
+    /// The number of confirmations.
+    pub confirmations: u32, // TODO: Change this to an i64.
+    /// The transaction value in BTC.
+    pub value: f64,
+    /// The script pubkey.
+    #[serde(rename = "scriptPubkey")]
+    pub script_pubkey: Option<ScriptPubkey>,
+    /// Coinbase or not.
+    pub coinbase: bool,
+}
+
+/// A script pubkey.
+#[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize)]
+pub struct ScriptPubkey {
+    /// Script assembly.
+    pub asm: String,
+    /// Script hex.
+    pub hex: String,
+    #[serde(rename = "reqSigs")]
+    pub req_sigs: i64,
+    /// The type, eg pubkeyhash.
+    #[serde(rename = "type")]
+    pub type_: String,
+    /// Bitcoin address.
+    pub address: Option<String>,
+}
+
+/// Result of JSON-RPC method `gettxout`.
+///
 /// # Note
 ///
 /// This assumes that the UTXOs are present in the underlying Bitcoin

--- a/crates/btcio/src/rpc/types.rs
+++ b/crates/btcio/src/rpc/types.rs
@@ -299,7 +299,7 @@ pub struct SubmitPackageTxResult {
     #[serde(rename = "other-wtxid")]
     pub other_wtxid: Option<String>,
     /// Sigops-adjusted virtual transaction size.
-    pub vsize: Option<i64>,
+    pub vsize: i64,
     /// Transaction fees.
     pub fees: Option<SubmitPackageTxResultFees>,
     /// The transaction error string, if it was rejected by the mempool

--- a/crates/btcio/src/rpc/types.rs
+++ b/crates/btcio/src/rpc/types.rs
@@ -1,3 +1,5 @@
+use std::collections::BTreeMap;
+
 use bitcoin::{
     absolute::Height,
     address::{self, NetworkUnchecked},
@@ -185,6 +187,79 @@ pub struct ScriptPubkey {
     pub type_: String,
     /// Bitcoin address.
     pub address: Option<String>,
+}
+
+/// Result of JSON-RPC method `submitpackage`.
+///
+/// > submitpackage ["rawtx",...] ( maxfeerate maxburnamount )
+/// >
+/// > Submit a package of raw transactions (serialized, hex-encoded) to local node.
+/// > The package will be validated according to consensus and mempool policy rules. If any
+/// > transaction passes, it will be accepted to mempool.
+/// > This RPC is experimental and the interface may be unstable. Refer to doc/policy/packages.md
+/// > for documentation on package policies.
+/// > Warning: successful submission does not mean the transactions will propagate throughout the
+/// > network.
+/// >
+/// > Arguments:
+/// > 1. package          (json array, required) An array of raw transactions.
+/// > The package must solely consist of a child and its parents. None of the parents may depend on
+/// > each other.
+/// > The package must be topologically sorted, with the child being the last element in the array.
+/// > [
+/// > "rawtx",     (string)
+/// > ...
+/// > ]
+#[allow(clippy::doc_lazy_continuation)]
+#[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+pub struct SubmitPackage {
+    /// The transaction package result message.
+    ///
+    /// "success" indicates all transactions were accepted into or are already in the mempool.
+    pub package_msg: String,
+    /// Transaction results keyed by wtxid.
+    #[serde(rename = "tx-results")]
+    pub tx_results: BTreeMap<String, SubmitPackageTxResult>,
+    /// List of txids of replaced transactions.
+    #[serde(rename = "replaced-transactions")]
+    pub replaced_transactions: Vec<String>,
+}
+
+/// Models the per-transaction result included in the JSON-RPC method `submitpackage`.
+#[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+pub struct SubmitPackageTxResult {
+    /// The transaction id.
+    pub txid: String,
+    /// The wtxid of a different transaction with the same txid but different witness found in the
+    /// mempool.
+    ///
+    /// If set, this means the submitted transaction was ignored.
+    #[serde(rename = "other-wtxid")]
+    pub other_wtxid: Option<String>,
+    /// Sigops-adjusted virtual transaction size.
+    pub vsize: Option<i64>,
+    /// Transaction fees.
+    pub fees: Option<SubmitPackageTxResultFees>,
+    /// The transaction error string, if it was rejected by the mempool
+    pub error: Option<String>,
+}
+
+/// Models the fees included in the per-transaction result of the JSON-RPC method `submitpackage`.
+#[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+pub struct SubmitPackageTxResultFees {
+    /// Transaction fee.
+    #[serde(rename = "base")]
+    pub base_fee: f64,
+    /// The effective feerate.
+    ///
+    /// Will be `None` if the transaction was already in the mempool. For example, the package
+    /// feerate and/or feerate with modified fees from the `prioritisetransaction` JSON-RPC method.
+    #[serde(rename = "effective-feerate")]
+    pub effective_fee_rate: Option<f64>,
+    /// If [`Self::effective_fee_rate`] is provided, this holds the wtxid's of the transactions
+    /// whose fees and vsizes are included in effective-feerate.
+    #[serde(rename = "effective-includes")]
+    pub effective_includes: Option<Vec<String>>,
 }
 
 /// Result of JSON-RPC method `gettxout`.

--- a/crates/btcio/src/rpc/types.rs
+++ b/crates/btcio/src/rpc/types.rs
@@ -317,6 +317,16 @@ pub struct ListTransactions {
     pub txid: Txid,
 }
 
+/// Models the result of JSON-RPC method `testmempoolaccept`.
+#[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+pub struct TestMempoolAccept {
+    /// The transaction id.
+    #[serde(deserialize_with = "deserialize_txid")]
+    pub txid: Txid,
+    /// Rejection reason, if any.
+    pub reject_reason: Option<String>,
+}
+
 /// Models the result of JSON-RPC method `signrawtransactionwithwallet`.
 ///
 /// # Note

--- a/crates/btcio/src/rpc/types.rs
+++ b/crates/btcio/src/rpc/types.rs
@@ -521,6 +521,46 @@ pub struct SignRawTransactionWithWallet {
     pub errors: Option<Vec<SignRawTransactionWithWalletError>>,
 }
 
+/// Models the optional previous transaction outputs argument for the method
+/// `signrawtransactionwithwallet`.
+///
+/// These are the outputs that this transaction depends on but may not yet be in the block chain.
+/// Widely used for One Parent One Child (1P1C) Relay in Bitcoin >28.0.
+///
+/// > transaction outputs
+/// > [
+/// > {                            (json object)
+/// > "txid": "hex",             (string, required) The transaction id
+/// > "vout": n,                 (numeric, required) The output number
+/// > "scriptPubKey": "hex",     (string, required) The output script
+/// > "redeemScript": "hex",     (string, optional) (required for P2SH) redeem script
+/// > "witnessScript": "hex",    (string, optional) (required for P2WSH or P2SH-P2WSH) witness
+/// > script
+/// > "amount": amount,          (numeric or string, optional) (required for Segwit inputs) the
+/// > amount spent
+/// > },
+/// > ...
+/// > ]
+#[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+pub struct PreviousTransactionOutput {
+    /// The transaction id.
+    #[serde(deserialize_with = "deserialize_txid")]
+    pub txid: Txid,
+    /// The output number.
+    pub vout: u32,
+    /// The output script.
+    #[serde(rename = "scriptPubKey")]
+    pub script_pubkey: String,
+    /// The redeem script.
+    #[serde(rename = "redeemScript")]
+    pub redeem_script: Option<String>,
+    /// The witness script.
+    #[serde(rename = "witnessScript")]
+    pub witness_script: Option<String>,
+    /// The amount spent.
+    pub amount: Option<f64>,
+}
+
 /// Models the result of the JSON-RPC method `listdescriptors`.
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
 pub struct ListDescriptors {

--- a/crates/btcio/src/test_utils.rs
+++ b/crates/btcio/src/test_utils.rs
@@ -1,3 +1,5 @@
+use std::collections::BTreeMap;
+
 use async_trait::async_trait;
 use bitcoin::{
     bip32::Xpriv,
@@ -15,7 +17,7 @@ use crate::{
         types::{
             GetBlockchainInfo, GetTransaction, GetTxOut, ImportDescriptor, ImportDescriptorResult,
             ListTransactions, ListUnspent, ScriptPubkey, SignRawTransactionWithWallet,
-            TestMempoolAccept,
+            SubmitPackage, SubmitPackageTxResult, TestMempoolAccept,
         },
         ClientResult,
     },
@@ -124,6 +126,27 @@ impl ReaderRpc for TestBitcoinClient {
                 address: Some("bc1q0z5n5kmynh5aa27ef99wn0zp70yuzwph68my2c".to_string()),
             }),
             coinbase: false,
+        })
+    }
+
+    async fn submit_package(&self, _txs: &[Transaction]) -> ClientResult<SubmitPackage> {
+        let some_tx: Transaction = consensus::encode::deserialize_hex(SOME_TX).unwrap();
+        let wtxid = some_tx.compute_wtxid();
+        let vsize = some_tx.vsize();
+        let tx_results = BTreeMap::from([(
+            wtxid.to_string(),
+            SubmitPackageTxResult {
+                txid: some_tx.compute_txid().to_string(),
+                other_wtxid: None,
+                vsize: Some(vsize as i64),
+                fees: None,
+                error: None,
+            },
+        )]);
+        Ok(SubmitPackage {
+            package_msg: "success".to_string(),
+            tx_results,
+            replaced_transactions: vec![],
         })
     }
 

--- a/crates/btcio/src/test_utils.rs
+++ b/crates/btcio/src/test_utils.rs
@@ -14,7 +14,7 @@ use crate::{
         traits::{BroadcasterRpc, ReaderRpc, SignerRpc, WalletRpc},
         types::{
             GetBlockchainInfo, GetTransaction, ImportDescriptor, ImportDescriptorResult,
-            ListTransactions, ListUnspent, SignRawTransactionWithWallet,
+            ListTransactions, ListUnspent, SignRawTransactionWithWallet, TestMempoolAccept,
         },
         ClientResult,
     },
@@ -113,6 +113,13 @@ impl BroadcasterRpc for TestBitcoinClient {
     // send_raw_transaction sends a raw transaction to the network
     async fn send_raw_transaction(&self, _tx: &Transaction) -> ClientResult<Txid> {
         Ok(Txid::from_slice(&[1u8; 32]).unwrap())
+    }
+    async fn test_mempool_accept(&self, _tx: &Transaction) -> ClientResult<Vec<TestMempoolAccept>> {
+        let some_tx: Transaction = consensus::encode::deserialize_hex(SOME_TX).unwrap();
+        Ok(vec![TestMempoolAccept {
+            txid: some_tx.compute_txid(),
+            reject_reason: None,
+        }])
     }
 }
 

--- a/crates/btcio/src/test_utils.rs
+++ b/crates/btcio/src/test_utils.rs
@@ -95,6 +95,10 @@ impl ReaderRpc for TestBitcoinClient {
         })
     }
 
+    async fn get_current_timestamp(&self) -> ClientResult<u32> {
+        Ok(1_000)
+    }
+
     async fn get_raw_mempool(&self) -> ClientResult<Vec<Txid>> {
         Ok(vec![])
     }

--- a/crates/btcio/src/test_utils.rs
+++ b/crates/btcio/src/test_utils.rs
@@ -16,8 +16,9 @@ use crate::{
         traits::{BroadcasterRpc, ReaderRpc, SignerRpc, WalletRpc},
         types::{
             CreateRawTransaction, GetBlockchainInfo, GetTransaction, GetTxOut, ImportDescriptor,
-            ImportDescriptorResult, ListTransactions, ListUnspent, ScriptPubkey,
-            SignRawTransactionWithWallet, SubmitPackage, SubmitPackageTxResult, TestMempoolAccept,
+            ImportDescriptorResult, ListTransactions, ListUnspent, PreviousTransactionOutput,
+            ScriptPubkey, SignRawTransactionWithWallet, SubmitPackage, SubmitPackageTxResult,
+            TestMempoolAccept,
         },
         ClientResult,
     },
@@ -254,6 +255,7 @@ impl SignerRpc for TestBitcoinClient {
     async fn sign_raw_transaction_with_wallet(
         &self,
         tx: &Transaction,
+        _prev_outputs: Option<Vec<PreviousTransactionOutput>>,
     ) -> ClientResult<SignRawTransactionWithWallet> {
         let tx_hex = consensus::encode::serialize_hex(tx);
         Ok(SignRawTransactionWithWallet {

--- a/crates/btcio/src/test_utils.rs
+++ b/crates/btcio/src/test_utils.rs
@@ -13,8 +13,9 @@ use crate::{
     rpc::{
         traits::{BroadcasterRpc, ReaderRpc, SignerRpc, WalletRpc},
         types::{
-            GetBlockchainInfo, GetTransaction, ImportDescriptor, ImportDescriptorResult,
-            ListTransactions, ListUnspent, SignRawTransactionWithWallet, TestMempoolAccept,
+            GetBlockchainInfo, GetTransaction, GetTxOut, ImportDescriptor, ImportDescriptorResult,
+            ListTransactions, ListUnspent, ScriptPubkey, SignRawTransactionWithWallet,
+            TestMempoolAccept,
         },
         ClientResult,
     },
@@ -101,6 +102,29 @@ impl ReaderRpc for TestBitcoinClient {
 
     async fn get_raw_mempool(&self) -> ClientResult<Vec<Txid>> {
         Ok(vec![])
+    }
+
+    async fn get_tx_out(
+        &self,
+        _txid: &Txid,
+        _vout: u32,
+        _include_mempool: bool,
+    ) -> ClientResult<GetTxOut> {
+        Ok(GetTxOut {
+            best_block: BlockHash::all_zeros().to_string(),
+            confirmations: 1,
+            value: 1.0,
+            script_pubkey: Some(ScriptPubkey {
+                // Taken from mainnet txid
+                // e35e3357cac58a56dab78fa3c544f52f091561ff84428da28bdc5c49fc4c5ffc
+                asm: "OP_0 OP_PUSHBYTES_20 78a93a5b649de9deabd9494ae9bc41f3c9c13837".to_string(),
+                hex: "001478a93a5b649de9deabd9494ae9bc41f3c9c13837".to_string(),
+                req_sigs: 1,
+                type_: "V0_P2WPKH".to_string(),
+                address: Some("bc1q0z5n5kmynh5aa27ef99wn0zp70yuzwph68my2c".to_string()),
+            }),
+            coinbase: false,
+        })
     }
 
     async fn network(&self) -> ClientResult<Network> {

--- a/crates/btcio/src/test_utils.rs
+++ b/crates/btcio/src/test_utils.rs
@@ -15,9 +15,9 @@ use crate::{
     rpc::{
         traits::{BroadcasterRpc, ReaderRpc, SignerRpc, WalletRpc},
         types::{
-            GetBlockchainInfo, GetTransaction, GetTxOut, ImportDescriptor, ImportDescriptorResult,
-            ListTransactions, ListUnspent, ScriptPubkey, SignRawTransactionWithWallet,
-            SubmitPackage, SubmitPackageTxResult, TestMempoolAccept,
+            CreateRawTransaction, GetBlockchainInfo, GetTransaction, GetTxOut, ImportDescriptor,
+            ImportDescriptorResult, ListTransactions, ListUnspent, ScriptPubkey,
+            SignRawTransactionWithWallet, SubmitPackage, SubmitPackageTxResult, TestMempoolAccept,
         },
         ClientResult,
     },
@@ -238,6 +238,14 @@ impl WalletRpc for TestBitcoinClient {
 
     async fn list_wallets(&self) -> ClientResult<Vec<String>> {
         Ok(vec![])
+    }
+
+    async fn create_raw_transaction(
+        &self,
+        _raw_tx: CreateRawTransaction,
+    ) -> ClientResult<Transaction> {
+        let some_tx: Transaction = consensus::encode::deserialize_hex(SOME_TX).unwrap();
+        Ok(some_tx)
     }
 }
 

--- a/crates/btcio/src/test_utils.rs
+++ b/crates/btcio/src/test_utils.rs
@@ -138,7 +138,7 @@ impl ReaderRpc for TestBitcoinClient {
             SubmitPackageTxResult {
                 txid: some_tx.compute_txid().to_string(),
                 other_wtxid: None,
-                vsize: Some(vsize as i64),
+                vsize: vsize as i64,
                 fees: None,
                 error: None,
             },

--- a/crates/btcio/src/writer/signer.rs
+++ b/crates/btcio/src/writer/signer.rs
@@ -31,7 +31,7 @@ pub async fn create_and_sign_payload_envelopes<W: WriterRpc>(
     debug!(commit_txid = ?ctxid, "Signing commit transaction");
     let signed_commit = ctx
         .client
-        .sign_raw_transaction_with_wallet(&commit)
+        .sign_raw_transaction_with_wallet(&commit, None)
         .await
         .map_err(|e| EnvelopeError::SignRawTransaction(e.to_string()))?
         .hex;


### PR DESCRIPTION
## Description

Backports `strata-bridge::btcio` RPCs to `strata::btcio`.
Needed to remove `strata-bridge`'s `btcio` and use the `strata::btcio` instead.

- [x] `get_current_timestamp`
- [x] `test_mempool_accept`
- [x] `get_tx_out`
- [x] `submit_package`

### Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature/Enhancement (non-breaking change which adds functionality or enhances an existing one)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactor
- [ ] New or updated tests
- [ ] Dependency Update

## Checklist

- [x] I have performed a self-review of my code.
- [x] I have commented my code where necessary.
- [x] I have updated the documentation if needed.
- [x] My changes do not introduce new warnings.
- [x] I have added tests that prove my changes are effective or that my feature works.
- [x] New and existing tests pass with my changes.

## Related Issues

STR-953