### PR TITLE
ci: cargo-audit ressurect with new 0.21.1 version

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -25,10 +25,8 @@ jobs:
         with:
           cache-on-failure: true
 
-       # HACK: v0.21.0 fails during dependency resolution. Remove when this is resolved
-       # https://github.com/rustsec/rustsec/issues/1249#issuecomment-2423257490
-      - name: Install cargo-audit v0.20.0
-        run: cargo install cargo-audit --version 0.20.0 --force
+      - name: Install cargo-audit
+        run: cargo install cargo-audit --force --locked
 
         #  HACK: not denying warnings as we depend on `yaml-rust` via `format-serde-error` which is unmaintained
       - name: Check for audit warnings


### PR DESCRIPTION
## Description

Enable `security.yml` GH Actions workflow with the new `cargo-audit@.21.1` release.

`cargo-audit` version `0.21.1` no longer gives errors when parsing our `Cargo.lock`.

Hence, we can activate it back.
CI is failing because of REAL RUSTSEC warnings (amongst them the vulnerability, RED alert/error, from `idna` can be fixed with #542).

Tagging @AaronFeickert if he wants to take a look, and is available.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature/Enhancement (non-breaking change which adds functionality or enhances an existing one)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactor
- [x] New or updated tests
- [ ] Dependency Update

## Checklist

- [x] I have performed a self-review of my code.
- [x] I have commented my code where necessary.
- [x] I have updated the documentation if needed.
- [x] My changes do not introduce new warnings.
- [x] I have added tests that prove my changes are effective or that my feature works.
- [x] New and existing tests pass with my changes.

## Related Issues

STR-601