### PR TITLE
ci: fix permissions for cron-nightly-rust

### DIFF
--- a/.github/workflows/cron-nightly-rust.yml
+++ b/.github/workflows/cron-nightly-rust.yml
@@ -14,6 +14,9 @@ jobs:
   format:
     name: Update nightly Rustc
     runs-on: ubuntu-latest
+    permissions:
+      contents: write # Needed to create commits
+      pull-requests: write # Needed to create a PR
     steps:
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
## Description

In #617 I forgot to add this permission to the PR job. This will fail once it runs in Feb 1st.
Note that this is necessary and it is used in the `dependencies.yml` cron CI job: https://github.com/alpenlabs/strata/blob/f2495caeccf11fee9ce4250e2cc0ae27c765ecdb/.github/workflows/dependencies.yml#L34-L36

### Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature/Enhancement (non-breaking change which adds functionality or enhances an existing one)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactor
- [x] New or updated tests
- [ ] Dependency Update
## Checklist

- [x] I have performed a self-review of my code.
- [x] I have commented my code where necessary.
- [x] I have updated the documentation if needed.
- [x] My changes do not introduce new warnings.
- [x] I have added tests that prove my changes are effective or that my feature works.
- [x] New and existing tests pass with my changes.

