### PR TITLE
ci: update bitcoin to 28.1

### DIFF
--- a/.github/workflows/functional.yml
+++ b/.github/workflows/functional.yml
@@ -70,9 +70,9 @@ jobs:
 
       - name: Install bitcoind
         env:
-          BITCOIND_VERSION: "28.0"
+          BITCOIND_VERSION: "28.1"
           BITCOIND_ARCH: "x86_64-linux-gnu"
-          SHASUM: "7fe294b02b25b51acb8e8e0a0eb5af6bbafa7cd0c5b0e5fcbb61263104a82fbc"
+          SHASUM: "07f77afd326639145b9ba9562912b2ad2ccec47b8a305bd075b4f4cb127b7ed7"
         run: |
           curl -fsSLO --proto "=https" --tlsv1.2 "https://bitcoincore.org/bin/bitcoin-core-$BITCOIND_VERSION/bitcoin-$BITCOIND_VERSION-$BITCOIND_ARCH.tar.gz"
           sha256sum -c <<< "$SHASUM bitcoin-$BITCOIND_VERSION-$BITCOIND_ARCH.tar.gz"

--- a/.github/workflows/unit.yml
+++ b/.github/workflows/unit.yml
@@ -76,8 +76,6 @@ jobs:
         uses: ./.github/actions/cleanup # zizmor: ignore[unpinned-uses]
 
       - uses: dtolnay/rust-toolchain@nightly
-        with:
-          toolchain: nightly-2024-07-27
       - uses: Swatinem/rust-cache@v2
         with:
           cache-on-failure: true

--- a/functional-tests/factory/factory.py
+++ b/functional-tests/factory/factory.py
@@ -37,7 +37,7 @@ class BitcoinFactory(flexitest.Factory):
             "bitcoind",
             "-txindex",
             "-regtest",
-            "-listen",
+            "-listen=0",
             f"-port={p2p_port}",
             "-printtoconsole",
             "-fallbackfee=0.00001",


### PR DESCRIPTION
## Description

Updates Bitcoin to 28.1 and fixes a change in how to call `bitcoind`.

### Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature/Enhancement (non-breaking change which adds functionality or enhances an existing one)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactor
- [x] New or updated tests
- [x] Dependency Update

## Notes to Reviewers

Can someone replicate this? I was struggling for the past 4 days with my updated bitcoin 28.1 and local tests.

## Checklist

- [x] I have performed a self-review of my code.
- [x] I have commented my code where necessary.
- [x] I have updated the documentation if needed.
- [x] My changes do not introduce new warnings.
- [x] I have added tests that prove my changes are effective or that my feature works.
- [x] New and existing tests pass with my changes.
