### PR TITLE
fix: reth rpc should provide results for pending block related queries

### DIFF
--- a/bin/strata-reth/res/alpen-dev-chain.json
+++ b/bin/strata-reth/res/alpen-dev-chain.json
@@ -29,6 +29,7 @@
         "londonBlock": 0,
         "terminalTotalDifficulty": 0,
         "terminalTotalDifficultyPassed": true,
-        "shanghaiTime": 0
+        "shanghaiTime": 0,
+        "mergeNetsplitBlock": 0
     }
 }

--- a/bin/strata-reth/res/devnet-chain.json
+++ b/bin/strata-reth/res/devnet-chain.json
@@ -23,6 +23,7 @@
         "londonBlock": 0,
         "terminalTotalDifficulty": 0,
         "terminalTotalDifficultyPassed": true,
-        "shanghaiTime": 0
+        "shanghaiTime": 0,
+        "mergeNetsplitBlock": 0
     }
 }

--- a/functional-tests/tests/el_pending_block.py
+++ b/functional-tests/tests/el_pending_block.py
@@ -1,0 +1,30 @@
+import flexitest
+
+from envs import testenv
+
+
+@flexitest.register
+class ElPendingBlock(testenv.StrataTester):
+    def __init__(self, ctx: flexitest.InitContext):
+        ctx.set_env("basic")
+
+    def main(self, ctx: flexitest.RunContext):
+        reth = ctx.get_service("reth")
+        address = reth.create_web3().address
+
+        rethrpc = reth.create_rpc()
+        block = rethrpc.eth_getBlockByNumber("pending", True)
+
+        assert block is not None, "get pending block"
+
+        gas = rethrpc.eth_estimateGas(
+            {
+                "chainId": "0x3039",
+                "from": address,
+                "to": "0x" + "00" * 20,
+                "nonce": "0x0",
+            },
+            "pending",
+        )
+
+        assert gas is not None, "estimate gas on pending block"


### PR DESCRIPTION
## Description

<!--
Provide a brief summary of the changes and the motivation behind them.
-->

Fixes issues with reth rpc failing to provide responses at "pending" block.

Missing 'mergeNetsplitBlock' in chain config resulted in missing [header total difficulty](https://github.com/paradigmxyz/reth/blob/1ba631ba9581973e7c6cadeea92cfe1802aceb4a/crates/storage/provider/src/providers/database/provider.rs#L1522) causing a [HeaderNotFound error](https://github.com/paradigmxyz/reth/blob/1ba631ba9581973e7c6cadeea92cfe1802aceb4a/crates/storage/provider/src/providers/database/provider.rs#L2181) when creating a temp pending block from local mempool.

### Type of Change

<!--
Select the type of change your PR introduces (put an `x` in all that apply):
-->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature/Enhancement (non-breaking change which adds functionality or enhances an existing one)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactor
- [ ] New or updated tests
- [ ] Dependency Update

## Notes to Reviewers

<!--
Anything in particular you want to note that will help reviewers fulfill their role
in reviewing this PR?
-->

## Checklist

<!--
Ensure all the following are checked:
-->

- [x] I have performed a self-review of my code.
- [ ] I have commented my code where necessary.
- [ ] I have updated the documentation if needed.
- [x] My changes do not introduce new warnings.
- [x] I have added tests that prove my changes are effective or that my feature works.
- [x] New and existing tests pass with my changes.

## Related Issues

<!--
Link any related issues (e.g., `closes #123`, `fixes #456`).
-->
