### PR TITLE
CI: Post prover performance metrics on pr only

### DIFF
--- a/.github/workflows/prover.yml
+++ b/.github/workflows/prover.yml
@@ -53,11 +53,15 @@ jobs:
 
       - name: Run performance evaluation
         run: |
+          # If this is a pull_request event, set --post-to-gba
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            POST_FLAG="--post-to-gh"
+          fi
           cargo run --profile prover-ci -- \
-          --post-to-gh \
           --github-token "${{ secrets.GITHUB_TOKEN }}" \
           --pr-number "${{ github.event.pull_request.number }}" \
           --commit-hash "${{ github.sha }}" \
+          $POST_FLAG
         working-directory: provers/perf
         env:
           RUSTFLAGS: "-C target-cpu=native -C link-arg=-fuse-ld=lld"


### PR DESCRIPTION
## Description
Currently, we run the Prover CI and add a performance report as a PR comment. Because the CI is triggered by both pull_request and merge_group events, we need to disable posting the performance report when the CI runs on merge_group.  

<!--
Provide a brief summary of the changes and the motivation behind them.
-->

### Type of Change

<!--
Select the type of change your PR introduces (put an `x` in all that apply):
-->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature/Enhancement (non-breaking change which adds functionality or enhances an existing one)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactor
- [ ] New or updated tests
- [ ] Dependency Update

## Notes to Reviewers

<!--
Anything in particular you want to note that will help reviewers fulfill their role
in reviewing this PR?
-->

## Checklist

<!--
Ensure all the following are checked:
-->

- [ ] I have performed a self-review of my code.
- [ ] I have commented my code where necessary.
- [ ] I have updated the documentation if needed.
- [ ] My changes do not introduce new warnings.
- [ ] I have added tests that prove my changes are effective or that my feature works.
- [ ] New and existing tests pass with my changes.

## Related Issues

<!--
Link any related issues (e.g., `closes #123`, `fixes #456`).
-->
