### PR TITLE
Split transition information from `BatchInfo` to `BatchTransition`

### DIFF
--- a/bin/strata-client/src/rpc_server.rs
+++ b/bin/strata-client/src/rpc_server.rs
@@ -741,10 +741,10 @@ impl StrataSequencerApiServer for SequencerServerImpl {
         verify_proof(&checkpoint, &proof_receipt, self.params.rollup())
             .map_err(|e| Error::InvalidProof(idx, e.to_string()))?;
 
-        entry.proof = proof_receipt.proof().clone();
+        entry.checkpoint.update_proof(proof_receipt.proof().clone());
         entry.proving_status = CheckpointProvingStatus::ProofReady;
 
-        debug!(%idx, "Proof is pending, setting proof reaedy");
+        debug!(%idx, "Proof is pending, setting proof ready");
 
         self.checkpoint_handle
             .put_checkpoint(idx, entry)

--- a/bin/strata-client/src/rpc_server.rs
+++ b/bin/strata-client/src/rpc_server.rs
@@ -116,12 +116,12 @@ impl StrataRpcImpl {
         };
 
         // in current implementation, chainstate idx == l2 block idx
-        let (_, end_slot) = last_checkpoint.batch_info.l2_range;
+        let (_, end_commitment) = last_checkpoint.batch_info.l2_range;
 
         Ok(self
             .storage
             .chainstate()
-            .get_toplevel_chainstate_async(end_slot)
+            .get_toplevel_chainstate_async(end_commitment.slot())
             .await?
             .map(Arc::new))
     }

--- a/bin/strata-client/src/rpc_server.rs
+++ b/bin/strata-client/src/rpc_server.rs
@@ -552,7 +552,7 @@ impl StrataApiServer for StrataRpcImpl {
             Ok(client_state
                 .l1_view()
                 .last_finalized_checkpoint()
-                .map(|checkpoint| checkpoint.batch_info.idx()))
+                .map(|checkpoint| checkpoint.batch_info.epoch()))
         } else {
             // get latest checkpoint index from db
             let idx = self
@@ -741,7 +741,7 @@ impl StrataSequencerApiServer for SequencerServerImpl {
         verify_proof(&checkpoint, &proof_receipt, self.params.rollup())
             .map_err(|e| Error::InvalidProof(idx, e.to_string()))?;
 
-        entry.proof = proof_receipt;
+        entry.proof = proof_receipt.proof().clone();
         entry.proving_status = CheckpointProvingStatus::ProofReady;
 
         debug!(%idx, "Proof is pending, setting proof reaedy");

--- a/bin/strata-sequencer-client/src/duty_executor.rs
+++ b/bin/strata-sequencer-client/src/duty_executor.rs
@@ -125,9 +125,9 @@ async fn handle_commit_batch_duty<R>(
 where
     R: StrataSequencerApiClient + Send + Sync,
 {
-    let sig = sign_checkpoint(duty.checkpoint(), &idata.key);
+    let sig = sign_checkpoint(duty.inner(), &idata.key);
 
-    rpc.complete_checkpoint_signature(duty.checkpoint().batch_info().idx(), HexBytes64(sig.0))
+    rpc.complete_checkpoint_signature(duty.inner().batch_info().epoch(), HexBytes64(sig.0))
         .await
         .map_err(DutyExecError::CompleteCheckpoint)?;
 

--- a/crates/consensus-logic/src/csm/client_transition.rs
+++ b/crates/consensus-logic/src/csm/client_transition.rs
@@ -207,7 +207,7 @@ pub fn process_event(
                             L1Checkpoint::new(
                                 batch_checkpoint.batch_info().clone(),
                                     batch_checkpoint.batch_transition().clone(),
-                                batch_checkpoint.bootstrap_state().clone(),
+                                batch_checkpoint.checkpoint_base_state().clone(),
                                 !batch_checkpoint.proof().is_empty(),
                                 *height,
                             )

--- a/crates/consensus-logic/src/csm/client_transition.rs
+++ b/crates/consensus-logic/src/csm/client_transition.rs
@@ -312,7 +312,7 @@ fn handle_mature_l1_height(
         // If l2 blocks is not in db then finalization will happen when
         // l2Block is fetched from the network and the corresponding
         //checkpoint is already finalized.
-        let blkid = checkpt.batch_info.l2_blockid;
+        let blkid = *checkpt.batch_info.final_l2_blockid();
 
         match context.get_l2_block_data(&blkid) {
             Ok(_) => {
@@ -403,7 +403,12 @@ fn find_l1_height_for_l2_blockid(
     target_l2_blockid: &L2BlockId,
 ) -> Option<u64> {
     checkpoints
-        .binary_search_by(|checkpoint| checkpoint.batch_info.l2_blockid.cmp(target_l2_blockid))
+        .binary_search_by(|checkpoint| {
+            checkpoint
+                .batch_info
+                .final_l2_blockid()
+                .cmp(target_l2_blockid)
+        })
         .ok()
         .map(|index| checkpoints[index].height)
 }

--- a/crates/consensus-logic/src/csm/client_transition.rs
+++ b/crates/consensus-logic/src/csm/client_transition.rs
@@ -206,8 +206,8 @@ pub fn process_event(
                                 &batch_checkpoint_with_commitment.batch_checkpoint;
                             L1Checkpoint::new(
                                 batch_checkpoint.batch_info().clone(),
-                                    batch_checkpoint.batch_transition().clone(),
-                                batch_checkpoint.checkpoint_base_state().clone(),
+                                batch_checkpoint.batch_transition().clone(),
+                                batch_checkpoint.base_state_commitment().clone(),
                                 !batch_checkpoint.proof().is_empty(),
                                 *height,
                             )

--- a/crates/consensus-logic/src/csm/worker.rs
+++ b/crates/consensus-logic/src/csm/worker.rs
@@ -364,10 +364,7 @@ fn apply_action(
                 let pstatus = CheckpointProvingStatus::ProofReady;
                 let cstatus = CheckpointConfStatus::Confirmed;
                 let entry = CheckpointEntry::new(
-                    batch_ckp.batch_info().clone(),
-                    batch_ckp.batch_transition().clone(),
-                    batch_ckp.checkpoint_base_state().clone(),
-                    batch_ckp.proof().clone(),
+                    batch_ckp.clone(),
                     pstatus,
                     cstatus,
                     Some(c.commitment.clone().into()),
@@ -385,10 +382,7 @@ fn apply_action(
                 let pstatus = CheckpointProvingStatus::ProofReady;
                 let cstatus = CheckpointConfStatus::Finalized;
                 let entry = CheckpointEntry::new(
-                    batch_ckp.batch_info().clone(),
-                    batch_ckp.batch_transition().clone(),
-                    batch_ckp.checkpoint_base_state().clone(),
-                    batch_ckp.proof().clone(),
+                    batch_ckp.clone(),
                     pstatus,
                     cstatus,
                     Some(c.commitment.clone().into()),

--- a/crates/consensus-logic/src/csm/worker.rs
+++ b/crates/consensus-logic/src/csm/worker.rs
@@ -366,7 +366,7 @@ fn apply_action(
                 let entry = CheckpointEntry::new(
                     batch_ckp.batch_info().clone(),
                     batch_ckp.batch_transition().clone(),
-                    batch_ckp.bootstrap_state().clone(),
+                    batch_ckp.checkpoint_base_state().clone(),
                     batch_ckp.proof().clone(),
                     pstatus,
                     cstatus,
@@ -387,7 +387,7 @@ fn apply_action(
                 let entry = CheckpointEntry::new(
                     batch_ckp.batch_info().clone(),
                     batch_ckp.batch_transition().clone(),
-                    batch_ckp.bootstrap_state().clone(),
+                    batch_ckp.checkpoint_base_state().clone(),
                     batch_ckp.proof().clone(),
                     pstatus,
                     cstatus,

--- a/crates/consensus-logic/src/csm/worker.rs
+++ b/crates/consensus-logic/src/csm/worker.rs
@@ -360,13 +360,14 @@ fn apply_action(
         SyncAction::WriteCheckpoints(_height, checkpoints) => {
             for c in checkpoints.iter() {
                 let batch_ckp = &c.batch_checkpoint;
-                let idx = batch_ckp.batch_info().idx();
+                let idx = batch_ckp.batch_info().epoch();
                 let pstatus = CheckpointProvingStatus::ProofReady;
                 let cstatus = CheckpointConfStatus::Confirmed;
                 let entry = CheckpointEntry::new(
                     batch_ckp.batch_info().clone(),
+                    batch_ckp.batch_transition().clone(),
                     batch_ckp.bootstrap_state().clone(),
-                    batch_ckp.clone().into_proof_receipt(),
+                    batch_ckp.proof().clone(),
                     pstatus,
                     cstatus,
                     Some(c.commitment.clone().into()),
@@ -380,13 +381,14 @@ fn apply_action(
         SyncAction::FinalizeCheckpoints(_height, checkpoints) => {
             for c in checkpoints.iter() {
                 let batch_ckp = &c.batch_checkpoint;
-                let idx = batch_ckp.batch_info().idx();
+                let idx = batch_ckp.batch_info().epoch();
                 let pstatus = CheckpointProvingStatus::ProofReady;
                 let cstatus = CheckpointConfStatus::Finalized;
                 let entry = CheckpointEntry::new(
                     batch_ckp.batch_info().clone(),
+                    batch_ckp.batch_transition().clone(),
                     batch_ckp.bootstrap_state().clone(),
-                    batch_ckp.clone().into_proof_receipt(),
+                    batch_ckp.proof().clone(),
                     pstatus,
                     cstatus,
                     Some(c.commitment.clone().into()),

--- a/crates/consensus-logic/src/duty/worker.rs
+++ b/crates/consensus-logic/src/duty/worker.rs
@@ -159,7 +159,7 @@ fn update_tracker(
     let latest_finalized_batch = state
         .l1_view()
         .last_finalized_checkpoint()
-        .map(|x| x.batch_info.idx());
+        .map(|x| x.batch_info.epoch());
 
     let tracker_update = types::StateUpdate::new(
         block_idx,

--- a/crates/consensus-logic/src/l1_handler.rs
+++ b/crates/consensus-logic/src/l1_handler.rs
@@ -184,7 +184,7 @@ pub fn verify_proof(
     rollup_params: &RollupParams,
 ) -> ZkVmResult<()> {
     let rollup_vk = rollup_params.rollup_vk;
-    let checkpoint_idx = checkpoint.batch_info().idx();
+    let checkpoint_idx = checkpoint.batch_info().epoch();
     info!(%checkpoint_idx, "verifying proof");
 
     // FIXME: we are accepting empty proofs for now (devnet) to reduce dependency on the prover
@@ -197,7 +197,7 @@ pub fn verify_proof(
         return Ok(());
     }
 
-    let expected_public_output = checkpoint.proof_output();
+    let expected_public_output = checkpoint.get_proof_output();
     let actual_public_output: CheckpointProofOutput =
         borsh::from_slice(proof_receipt.public_values().as_bytes())
             .map_err(|e| ZkVmError::OutputExtractionError { source: e.into() })?;

--- a/crates/db/src/types.rs
+++ b/crates/db/src/types.rs
@@ -12,7 +12,7 @@ use strata_primitives::{
     l1::payload::{L1Payload, PayloadIntent},
 };
 use strata_state::batch::{
-    BatchCheckpoint, BatchInfo, BatchTransition, BootstrapState, CommitmentInfo,
+    BatchCheckpoint, BatchInfo, BatchTransition, CheckpointBaseState, CommitmentInfo,
 };
 use zkaleido::Proof;
 
@@ -192,9 +192,8 @@ pub struct CheckpointEntry {
     /// Transition data for L1 and L2 states, which is verified by the proof.
     pub batch_transition: BatchTransition,
 
-    /// Includes the initial and final hashed state of both the `L1StateTransition` and
-    /// `L2StateTransition` that happened in this batch
-    pub bootstrap: BootstrapState,
+    /// Reference state against which checkpoint transitions and proofs are verified
+    pub checkpoint_base_state: CheckpointBaseState,
 
     /// Proof
     pub proof: Proof,
@@ -213,7 +212,7 @@ impl CheckpointEntry {
     pub fn new(
         batch_info: BatchInfo,
         batch_transition: BatchTransition,
-        bootstrap: BootstrapState,
+        checkpoint_base_state: CheckpointBaseState,
         proof: Proof,
         proving_status: CheckpointProvingStatus,
         confirmation_status: CheckpointConfStatus,
@@ -221,7 +220,7 @@ impl CheckpointEntry {
     ) -> Self {
         Self {
             batch_info,
-            bootstrap,
+            checkpoint_base_state,
             batch_transition,
             proof,
             proving_status,
@@ -234,7 +233,7 @@ impl CheckpointEntry {
         BatchCheckpoint::new(
             self.batch_info,
             self.batch_transition,
-            self.bootstrap,
+            self.checkpoint_base_state,
             self.proof,
         )
     }
@@ -243,12 +242,12 @@ impl CheckpointEntry {
     pub fn new_pending_proof(
         info: BatchInfo,
         transition: BatchTransition,
-        bootstrap: BootstrapState,
+        checkpoint_base_state: CheckpointBaseState,
     ) -> Self {
         Self::new(
             info,
             transition,
-            bootstrap,
+            checkpoint_base_state,
             Proof::default(),
             CheckpointProvingStatus::PendingProof,
             CheckpointConfStatus::Pending,

--- a/crates/db/src/types.rs
+++ b/crates/db/src/types.rs
@@ -264,6 +264,7 @@ pub enum CheckpointConfStatus {
     Finalized,
 }
 
+// TODO: why is this needed? can this information be part of `L1Checkpoint`?
 #[derive(Debug, Clone, PartialEq, BorshSerialize, BorshDeserialize, Arbitrary)]
 pub struct CheckpointCommitment {
     pub blockhash: Buf32,

--- a/crates/db/src/types.rs
+++ b/crates/db/src/types.rs
@@ -186,17 +186,8 @@ pub enum L1TxStatus {
 /// Entry corresponding to a BatchCommitment
 #[derive(Debug, Clone, PartialEq, BorshSerialize, BorshDeserialize, Arbitrary)]
 pub struct CheckpointEntry {
-    /// Info related to the batch
-    pub batch_info: BatchInfo,
-
-    /// Transition data for L1 and L2 states, which is verified by the proof.
-    pub batch_transition: BatchTransition,
-
-    /// Reference state against which checkpoint transitions and proofs are verified
-    pub checkpoint_base_state: CheckpointBaseState,
-
-    /// Proof
-    pub proof: Proof,
+    /// The batch checkpoint containing metadata, state transitions, and proof data.
+    pub checkpoint: BatchCheckpoint,
 
     /// Proving Status
     pub proving_status: CheckpointProvingStatus,
@@ -210,19 +201,13 @@ pub struct CheckpointEntry {
 
 impl CheckpointEntry {
     pub fn new(
-        batch_info: BatchInfo,
-        batch_transition: BatchTransition,
-        checkpoint_base_state: CheckpointBaseState,
-        proof: Proof,
+        checkpoint: BatchCheckpoint,
         proving_status: CheckpointProvingStatus,
         confirmation_status: CheckpointConfStatus,
         commitment: Option<CheckpointCommitment>,
     ) -> Self {
         Self {
-            batch_info,
-            checkpoint_base_state,
-            batch_transition,
-            proof,
+            checkpoint,
             proving_status,
             confirmation_status,
             commitment,
@@ -230,12 +215,7 @@ impl CheckpointEntry {
     }
 
     pub fn into_batch_checkpoint(self) -> BatchCheckpoint {
-        BatchCheckpoint::new(
-            self.batch_info,
-            self.batch_transition,
-            self.checkpoint_base_state,
-            self.proof,
-        )
+        self.checkpoint
     }
 
     /// Creates a new instance for a freshly defined checkpoint.
@@ -244,11 +224,10 @@ impl CheckpointEntry {
         transition: BatchTransition,
         checkpoint_base_state: CheckpointBaseState,
     ) -> Self {
+        let checkpoint =
+            BatchCheckpoint::new(info, transition, checkpoint_base_state, Proof::default());
         Self::new(
-            info,
-            transition,
-            checkpoint_base_state,
-            Proof::default(),
+            checkpoint,
             CheckpointProvingStatus::PendingProof,
             CheckpointConfStatus::Pending,
             None,

--- a/crates/db/src/types.rs
+++ b/crates/db/src/types.rs
@@ -12,7 +12,7 @@ use strata_primitives::{
     l1::payload::{L1Payload, PayloadIntent},
 };
 use strata_state::batch::{
-    BatchCheckpoint, BatchInfo, BatchTransition, CheckpointBaseStateCommitment, CommitmentInfo,
+    BaseStateCommitment, BatchCheckpoint, BatchInfo, BatchTransition, CommitmentInfo,
 };
 use zkaleido::Proof;
 
@@ -222,10 +222,10 @@ impl CheckpointEntry {
     pub fn new_pending_proof(
         info: BatchInfo,
         transition: BatchTransition,
-        checkpoint_base_state: CheckpointBaseStateCommitment,
+        base_state_commitment: BaseStateCommitment,
     ) -> Self {
         let checkpoint =
-            BatchCheckpoint::new(info, transition, checkpoint_base_state, Proof::default());
+            BatchCheckpoint::new(info, transition, base_state_commitment, Proof::default());
         Self::new(
             checkpoint,
             CheckpointProvingStatus::PendingProof,

--- a/crates/db/src/types.rs
+++ b/crates/db/src/types.rs
@@ -12,7 +12,7 @@ use strata_primitives::{
     l1::payload::{L1Payload, PayloadIntent},
 };
 use strata_state::batch::{
-    BatchCheckpoint, BatchInfo, BatchTransition, CheckpointBaseState, CommitmentInfo,
+    BatchCheckpoint, BatchInfo, BatchTransition, CheckpointBaseStateCommitment, CommitmentInfo,
 };
 use zkaleido::Proof;
 
@@ -222,7 +222,7 @@ impl CheckpointEntry {
     pub fn new_pending_proof(
         info: BatchInfo,
         transition: BatchTransition,
-        checkpoint_base_state: CheckpointBaseState,
+        checkpoint_base_state: CheckpointBaseStateCommitment,
     ) -> Self {
         let checkpoint =
             BatchCheckpoint::new(info, transition, checkpoint_base_state, Proof::default());

--- a/crates/primitives/src/l1/block.rs
+++ b/crates/primitives/src/l1/block.rs
@@ -46,6 +46,7 @@ impl From<L1BlockId> for BlockHash {
 }
 
 #[derive(
+    Debug,
     Copy,
     Clone,
     Eq,

--- a/crates/proof-impl/checkpoint/src/lib.rs
+++ b/crates/proof-impl/checkpoint/src/lib.rs
@@ -6,7 +6,7 @@ use borsh::{BorshDeserialize, BorshSerialize};
 use strata_primitives::{params::RollupParams, proof::RollupVerifyingKey};
 use strata_proofimpl_cl_stf::L2BatchProofOutput;
 use strata_proofimpl_l1_batch::L1BatchProofOutput;
-use strata_state::batch::{BatchInfo, CheckpointProofOutput};
+use strata_state::batch::{BatchTransition, CheckpointProofOutput};
 use zkaleido::{ProofReceipt, ZkVmEnv};
 
 pub mod prover;
@@ -38,65 +38,50 @@ pub fn process_checkpoint_proof(
     );
 
     // Create BatchInfo based on `l1_batch` and `l2_batch`
-    let mut batch_info = BatchInfo::new(
-        0,
+    let batch_transition = BatchTransition::new(
         (
-            l1_batch_output.initial_snapshot.block_num,
-            l1_batch_output.final_snapshot.block_num,
+            l1_batch_output.initial_state_hash,
+            l1_batch_output.final_state_hash,
         ),
         (
-            l2_batch_output.initial_snapshot.slot,
-            l2_batch_output.final_snapshot.slot,
-        ),
-        (
-            l1_batch_output.initial_snapshot.hash,
-            l1_batch_output.final_snapshot.hash,
-        ),
-        (
-            l2_batch_output.initial_snapshot.hash,
-            l2_batch_output.final_snapshot.hash,
-        ),
-        l2_batch_output.final_snapshot.l2_blockid,
-        (
-            l1_batch_output.initial_snapshot.acc_pow,
-            l1_batch_output.final_snapshot.acc_pow,
+            l2_batch_output.initial_state_hash,
+            l2_batch_output.final_state_hash,
         ),
         l1_batch_output.rollup_params_commitment,
     );
 
     let (bootstrap, opt_prev_output) = match l1_batch_output.prev_checkpoint.as_ref() {
         // Genesis batch: initialize with initial bootstrap state
-        None => (batch_info.get_initial_bootstrap_state(), None),
+        None => (batch_transition.get_initial_bootstrap_state(), None),
         Some(prev_checkpoint) => {
             // Ensure sequential state transition
             assert_eq!(
-                prev_checkpoint.batch_info().get_final_bootstrap_state(),
-                batch_info.get_initial_bootstrap_state()
+                prev_checkpoint
+                    .batch_transition()
+                    .get_final_bootstrap_state(),
+                batch_transition.get_initial_bootstrap_state()
             );
 
             assert_eq!(
-                prev_checkpoint.batch_info().rollup_params_commitment(),
-                batch_info.rollup_params_commitment()
+                prev_checkpoint
+                    .batch_transition()
+                    .rollup_params_commitment(),
+                batch_transition.rollup_params_commitment()
             );
-
-            batch_info.idx = prev_checkpoint.batch_info().idx + 1;
 
             // If there exist proof for the prev_batch, use the prev_batch bootstrap state, else set
             // the current batch initial info as bootstrap
             if prev_checkpoint.proof().is_empty() {
                 // No proof in previous checkpoint: use initial bootstrap state
-                (batch_info.get_initial_bootstrap_state(), None)
+                (batch_transition.get_initial_bootstrap_state(), None)
             } else {
                 // Use previous checkpoint's bootstrap state and include previous proof
                 let bootstrap = prev_checkpoint.bootstrap_state().clone();
-                (
-                    bootstrap,
-                    Some(prev_checkpoint.clone().into_proof_receipt()),
-                )
+                (bootstrap, Some(prev_checkpoint.get_proof_receipt()))
             }
         }
     };
-    let output = CheckpointProofOutput::new(batch_info, bootstrap);
+    let output = CheckpointProofOutput::new(batch_transition, bootstrap);
     (output, opt_prev_output)
 }
 

--- a/crates/proof-impl/checkpoint/src/lib.rs
+++ b/crates/proof-impl/checkpoint/src/lib.rs
@@ -50,16 +50,16 @@ pub fn process_checkpoint_proof(
         l1_batch_output.rollup_params_commitment,
     );
 
-    let (bootstrap, opt_prev_output) = match l1_batch_output.prev_checkpoint.as_ref() {
-        // Genesis batch: initialize with initial bootstrap state
-        None => (batch_transition.get_initial_bootstrap_state(), None),
+    let (checkpoint_base_state, opt_prev_output) = match l1_batch_output.prev_checkpoint.as_ref() {
+        // Genesis batch: initialize with initial checkpoint_base_state state
+        None => (batch_transition.get_initial_checkpoint_base_state(), None),
         Some(prev_checkpoint) => {
             // Ensure sequential state transition
             assert_eq!(
                 prev_checkpoint
                     .batch_transition()
-                    .get_final_bootstrap_state(),
-                batch_transition.get_initial_bootstrap_state()
+                    .get_final_checkpoint_base_state(),
+                batch_transition.get_initial_checkpoint_base_state()
             );
 
             assert_eq!(
@@ -69,19 +69,22 @@ pub fn process_checkpoint_proof(
                 batch_transition.rollup_params_commitment()
             );
 
-            // If there exist proof for the prev_batch, use the prev_batch bootstrap state, else set
-            // the current batch initial info as bootstrap
+            // If there exist proof for the prev_batch, use the prev_batch checkpoint_base_state
+            // state, else set the current batch initial info as checkpoint_base_state
             if prev_checkpoint.proof().is_empty() {
-                // No proof in previous checkpoint: use initial bootstrap state
-                (batch_transition.get_initial_bootstrap_state(), None)
+                // No proof in previous checkpoint: use initial checkpoint_base_state state
+                (batch_transition.get_initial_checkpoint_base_state(), None)
             } else {
-                // Use previous checkpoint's bootstrap state and include previous proof
-                let bootstrap = prev_checkpoint.bootstrap_state().clone();
-                (bootstrap, Some(prev_checkpoint.get_proof_receipt()))
+                // Use previous checkpoint's checkpoint_base_state state and include previous proof
+                let checkpoint_base_state = prev_checkpoint.checkpoint_base_state().clone();
+                (
+                    checkpoint_base_state,
+                    Some(prev_checkpoint.get_proof_receipt()),
+                )
             }
         }
     };
-    let output = CheckpointProofOutput::new(batch_transition, bootstrap);
+    let output = CheckpointProofOutput::new(batch_transition, checkpoint_base_state);
     (output, opt_prev_output)
 }
 

--- a/crates/proof-impl/checkpoint/src/lib.rs
+++ b/crates/proof-impl/checkpoint/src/lib.rs
@@ -50,16 +50,16 @@ pub fn process_checkpoint_proof(
         l1_batch_output.rollup_params_commitment,
     );
 
-    let (checkpoint_base_state, opt_prev_output) = match l1_batch_output.prev_checkpoint.as_ref() {
-        // Genesis batch: initialize with initial checkpoint_base_state state
-        None => (batch_transition.get_initial_checkpoint_base_state(), None),
+    let (base_state_commitment, opt_prev_output) = match l1_batch_output.prev_checkpoint.as_ref() {
+        // Genesis batch: initialize with initial base_state_commitment state
+        None => (batch_transition.get_initial_base_state_commitment(), None),
         Some(prev_checkpoint) => {
             // Ensure sequential state transition
             assert_eq!(
                 prev_checkpoint
                     .batch_transition()
-                    .get_final_checkpoint_base_state(),
-                batch_transition.get_initial_checkpoint_base_state()
+                    .get_final_base_state_commitment(),
+                batch_transition.get_initial_base_state_commitment()
             );
 
             assert_eq!(
@@ -69,22 +69,22 @@ pub fn process_checkpoint_proof(
                 batch_transition.rollup_params_commitment()
             );
 
-            // If there exist proof for the prev_batch, use the prev_batch checkpoint_base_state
-            // state, else set the current batch initial info as checkpoint_base_state
+            // If there exist proof for the prev_batch, use the prev_batch base_state_commitment
+            // state, else set the current batch initial info as base_state_commitment
             if prev_checkpoint.proof().is_empty() {
-                // No proof in previous checkpoint: use initial checkpoint_base_state state
-                (batch_transition.get_initial_checkpoint_base_state(), None)
+                // No proof in previous checkpoint: use initial base_state_commitment state
+                (batch_transition.get_initial_base_state_commitment(), None)
             } else {
-                // Use previous checkpoint's checkpoint_base_state state and include previous proof
-                let checkpoint_base_state = prev_checkpoint.checkpoint_base_state().clone();
+                // Use previous checkpoint's base_state_commitment state and include previous proof
+                let base_state_commitment = prev_checkpoint.base_state_commitment().clone();
                 (
-                    checkpoint_base_state,
+                    base_state_commitment,
                     Some(prev_checkpoint.get_proof_receipt()),
                 )
             }
         }
     };
-    let output = CheckpointProofOutput::new(batch_transition, checkpoint_base_state);
+    let output = CheckpointProofOutput::new(batch_transition, base_state_commitment);
     (output, opt_prev_output)
 }
 

--- a/crates/proof-impl/cl-agg/src/lib.rs
+++ b/crates/proof-impl/cl-agg/src/lib.rs
@@ -11,11 +11,7 @@ pub fn process_cl_agg(zkvm: &impl ZkVmEnv, cl_stf_vk: &[u32; 8]) {
         "At least one CL proof is required for aggregation"
     );
 
-    let mut cl_proof_pp_start: L2BatchProofOutput = zkvm.read_verified_borsh(cl_stf_vk);
-    // `BatchInfo` has range which is inclusive. This makes it compatible and avoids off by 1 issue.
-    // TODO: Do this in a better way
-    cl_proof_pp_start.initial_snapshot.slot += 1;
-
+    let cl_proof_pp_start: L2BatchProofOutput = zkvm.read_verified_borsh(cl_stf_vk);
     let mut cl_proof_pp_prev = cl_proof_pp_start.clone();
     let mut acc_deposits = cl_proof_pp_start.deposits.clone();
 
@@ -36,8 +32,8 @@ pub fn process_cl_agg(zkvm: &impl ZkVmEnv, cl_stf_vk: &[u32; 8]) {
     // proof of the batch
     let public_params = L2BatchProofOutput {
         deposits: acc_deposits,
-        initial_snapshot: cl_proof_pp_start.initial_snapshot,
-        final_snapshot: cl_proof_pp_prev.final_snapshot,
+        initial_state_hash: cl_proof_pp_start.initial_state_hash,
+        final_state_hash: cl_proof_pp_prev.final_state_hash,
         rollup_params_commitment,
     };
 
@@ -50,8 +46,8 @@ fn validate_proof_consistency(
     next_proof_cs_snap: &L2BatchProofOutput,
 ) {
     assert_eq!(
-        current_proof_cs_snap.final_snapshot.hash, // post-state root of the current proof
-        next_proof_cs_snap.initial_snapshot.hash,  // initial state root of the next proof
+        current_proof_cs_snap.final_state_hash, // post-state root of the current proof
+        next_proof_cs_snap.initial_state_hash,  // initial state root of the next proof
         "State root mismatch between proofs"
     );
 }

--- a/crates/rpc/types/src/types.rs
+++ b/crates/rpc/types/src/types.rs
@@ -9,7 +9,8 @@ use serde::{Deserialize, Serialize};
 use strata_db::types::{CheckpointCommitment, CheckpointConfStatus, CheckpointEntry};
 use strata_primitives::{
     bridge::OperatorIdx,
-    l1::{BitcoinAmount, L1TxRef, OutputRef},
+    l1::{BitcoinAmount, L1BlockCommitment, L1TxRef, OutputRef},
+    l2::L2BlockCommitment,
     prelude::L1Status,
 };
 use strata_state::{
@@ -292,15 +293,10 @@ impl From<CheckpointEntry> for RpcCheckpointConfStatus {
 pub struct RpcCheckpointInfo {
     /// The index of the checkpoint
     pub idx: u64,
-    /// L1 height  the checkpoint covers
-    /// TODO: use std::ops::Range
-    pub l1_range: (u64, u64),
-    /// L2 height the checkpoint covers
-    /// TODO: use std::ops::Range
-    pub l2_range: (u64, u64),
-    /// L2 block that this checkpoint covers
-    /// TODO: likely unused and should be removed.
-    pub l2_blockid: L2BlockId,
+    /// L1 range  the checkpoint covers
+    pub l1_range: (L1BlockCommitment, L1BlockCommitment),
+    /// L2 range the checkpoint covers
+    pub l2_range: (L2BlockCommitment, L2BlockCommitment),
     /// Info on txn where checkpoint is committed on chain
     pub commitment: Option<RpcCheckpointCommitmentInfo>,
     /// Confirmation status of checkpoint
@@ -313,7 +309,6 @@ impl From<BatchInfo> for RpcCheckpointInfo {
             idx: value.epoch,
             l1_range: value.l1_range,
             l2_range: value.l2_range,
-            l2_blockid: value.l2_blockid,
             commitment: None,
             confirmation_status: None,
         }

--- a/crates/rpc/types/src/types.rs
+++ b/crates/rpc/types/src/types.rs
@@ -322,7 +322,7 @@ impl From<BatchInfo> for RpcCheckpointInfo {
 
 impl From<CheckpointEntry> for RpcCheckpointInfo {
     fn from(value: CheckpointEntry) -> Self {
-        let mut item: Self = value.batch_info.into();
+        let mut item: Self = value.checkpoint.batch_info().clone().into();
         item.commitment = value.commitment.map(Into::into);
         item.confirmation_status = Some(value.confirmation_status.into());
         item

--- a/crates/rpc/types/src/types.rs
+++ b/crates/rpc/types/src/types.rs
@@ -310,7 +310,7 @@ pub struct RpcCheckpointInfo {
 impl From<BatchInfo> for RpcCheckpointInfo {
     fn from(value: BatchInfo) -> Self {
         Self {
-            idx: value.idx,
+            idx: value.epoch,
             l1_range: value.l1_range,
             l2_range: value.l2_range,
             l2_blockid: value.l2_blockid,

--- a/crates/sequencer/src/checkpoint/worker.rs
+++ b/crates/sequencer/src/checkpoint/worker.rs
@@ -6,7 +6,7 @@ use strata_consensus_logic::csm::message::ClientUpdateNotif;
 use strata_db::{traits::Database, types::CheckpointEntry, DbError};
 use strata_primitives::{buf::Buf32, l1::L1BlockCommitment, l2::L2BlockCommitment, params::Params};
 use strata_state::{
-    batch::{BatchInfo, BatchTransition, CheckpointBaseState},
+    batch::{BatchInfo, BatchTransition, CheckpointBaseStateCommitment},
     client_state::ClientState,
 };
 use strata_storage::NodeStorage;
@@ -104,7 +104,7 @@ fn get_next_batch(
     state: &ClientState,
     storage: &NodeStorage,
     rollup_params_commitment: Buf32,
-) -> Result<(BatchInfo, BatchTransition, CheckpointBaseState), Error> {
+) -> Result<(BatchInfo, BatchTransition, CheckpointBaseStateCommitment), Error> {
     if !state.is_chain_active() {
         debug!("chain not active, no duties created");
         return Err(Error::ChainInactive);
@@ -184,7 +184,7 @@ fn get_next_batch(
             // Build the batch transition and batch info.
             let new_transition =
                 BatchTransition::new(l1_transition, l2_transition, rollup_params_commitment);
-            let new_batch = BatchInfo::new(first_checkpoint_idx, l1_range, l2_range, tip_id);
+            let new_batch = BatchInfo::new(first_checkpoint_idx, l1_range, l2_range);
             let genesis_state = new_transition.get_initial_checkpoint_base_state();
 
             Ok((new_batch, new_transition, genesis_state))
@@ -216,7 +216,7 @@ fn get_next_batch(
             let current_chain_state_root = current_chain_state.compute_state_root();
             let l2_transition = (batch_transition.l2_transition.1, current_chain_state_root);
 
-            let new_batch_info = BatchInfo::new(batch_info.epoch + 1, l1_range, l2_range, tip_id);
+            let new_batch_info = BatchInfo::new(batch_info.epoch + 1, l1_range, l2_range);
             let new_transition =
                 BatchTransition::new(l1_transition, l2_transition, rollup_params_commitment);
 

--- a/crates/sequencer/src/checkpoint/worker.rs
+++ b/crates/sequencer/src/checkpoint/worker.rs
@@ -6,7 +6,7 @@ use strata_consensus_logic::csm::message::ClientUpdateNotif;
 use strata_db::{traits::Database, types::CheckpointEntry};
 use strata_primitives::{buf::Buf32, params::Params};
 use strata_state::{
-    batch::{BatchInfo, BootstrapState},
+    batch::{BatchInfo, BatchTransition, BootstrapState},
     client_state::ClientState,
 };
 use strata_storage::NodeStorage;
@@ -68,22 +68,23 @@ pub fn checkpoint_worker<D: Database>(
             continue;
         }
 
-        let (batch_info, bootstrap_state) =
+        let (batch_info, batch_transition, bootstrap_state) =
             match get_next_batch(state, storage.as_ref(), rollup_params_commitment) {
                 Err(error) => {
                     warn!(?error, "Failed to get next batch");
                     continue;
                 }
-                Ok((b, bs)) => (b, bs),
+                Ok((b, bt, bs)) => (b, bt, bs),
             };
 
-        let checkpoint_idx = batch_info.idx();
+        let checkpoint_idx = batch_info.epoch();
         // sanity check
         assert!(checkpoint_idx == next_checkpoint_idx);
 
         // else save a pending proof checkpoint entry
         debug!("save checkpoint pending proof: {}", checkpoint_idx);
-        let entry = CheckpointEntry::new_pending_proof(batch_info, bootstrap_state);
+        let entry =
+            CheckpointEntry::new_pending_proof(batch_info, batch_transition, bootstrap_state);
         if let Err(e) = checkpoint_handle.put_checkpoint_and_notify_blocking(checkpoint_idx, entry)
         {
             warn!(?e, "Failed to save checkpoint at idx: {}", checkpoint_idx);
@@ -95,7 +96,7 @@ pub fn checkpoint_worker<D: Database>(
 fn get_next_batch_idx(state: &ClientState) -> u64 {
     match state.l1_view().last_finalized_checkpoint() {
         None => 0,
-        Some(prev_checkpoint) => prev_checkpoint.batch_info.idx + 1,
+        Some(prev_checkpoint) => prev_checkpoint.batch_info.epoch + 1,
     }
 }
 
@@ -103,7 +104,7 @@ fn get_next_batch(
     state: &ClientState,
     storage: &NodeStorage,
     rollup_params_commitment: Buf32,
-) -> Result<(BatchInfo, BootstrapState), Error> {
+) -> Result<(BatchInfo, BatchTransition, BootstrapState), Error> {
     let chsman = storage.chainstate();
 
     if !state.is_chain_active() {
@@ -166,65 +167,50 @@ fn get_next_batch(
             let current_chain_state_root = current_chain_state.compute_state_root();
             let l2_transition = (initial_chain_state_root, current_chain_state_root);
 
-            let new_batch = BatchInfo::new(
-                first_checkpoint_idx,
-                l1_range,
-                l2_range,
-                l1_transition,
-                l2_transition,
-                tip_id,
-                (0, current_l1_state.total_accumulated_pow),
-                rollup_params_commitment,
-            );
+            let new_transition =
+                BatchTransition::new(l1_transition, l2_transition, rollup_params_commitment);
 
-            let genesis_bootstrap = new_batch.get_initial_bootstrap_state();
-            Ok((new_batch, genesis_bootstrap))
+            let new_batch = BatchInfo::new(first_checkpoint_idx, l1_range, l2_range, tip_id);
+
+            let genesis_bootstrap = new_transition.get_initial_bootstrap_state();
+            Ok((new_batch, new_transition, genesis_bootstrap))
         }
         Some(prev_checkpoint) => {
-            let checkpoint = prev_checkpoint.batch_info.clone();
+            let batch_info = prev_checkpoint.batch_info.clone();
+            let batch_transition = prev_checkpoint.batch_transition.clone();
 
             let current_l1_state = state
                 .l1_view()
                 .tip_verification_state()
                 .ok_or(Error::ChainInactive)?;
             let l1_range = (
-                checkpoint.l1_range.1 + 1,
+                batch_info.l1_range.1 + 1,
                 current_l1_state.last_verified_block_num as u64,
             );
             let current_l1_state_hash = current_l1_state.compute_hash().unwrap();
-            let l1_transition = (checkpoint.l1_transition.1, current_l1_state_hash);
+            let l1_transition = (batch_transition.l1_transition.1, current_l1_state_hash);
 
             // Also, rather than tip heights, we might need to limit the max range a prover will
             // be proving
-            let l2_range = (checkpoint.l2_range.1 + 1, tip_height);
+            let l2_range = (batch_info.l2_range.1 + 1, tip_height);
             let current_chain_state = chsman
                 .get_toplevel_chainstate_blocking(tip_height)?
                 .ok_or(Error::MissingIdxChainstate(0))?;
             let current_chain_state_root = current_chain_state.compute_state_root();
-            let l2_transition = (checkpoint.l2_transition.1, current_chain_state_root);
+            let l2_transition = (batch_transition.l2_transition.1, current_chain_state_root);
 
-            let new_batch = BatchInfo::new(
-                checkpoint.idx + 1,
-                l1_range,
-                l2_range,
-                l1_transition,
-                l2_transition,
-                tip_id,
-                (
-                    checkpoint.l1_pow_transition.1,
-                    current_l1_state.total_accumulated_pow,
-                ),
-                rollup_params_commitment,
-            );
+            let new_batch_info = BatchInfo::new(batch_info.epoch + 1, l1_range, l2_range, tip_id);
+            let new_transition =
+                BatchTransition::new(l1_transition, l2_transition, rollup_params_commitment);
 
             // If prev checkpoint was proved, use the bootstrap state of the prev checkpoint
             // else create a bootstrap state based on initial info of this batch
             let bootstrap_state = if prev_checkpoint.is_proved {
                 prev_checkpoint.bootstrap_state.clone()
             } else {
-                new_batch.get_initial_bootstrap_state()
+                new_transition.get_initial_bootstrap_state()
             };
-            Ok((new_batch, bootstrap_state))
+            Ok((new_batch_info, new_transition, bootstrap_state))
         }
     }
 }

--- a/crates/sequencer/src/checkpoint/worker.rs
+++ b/crates/sequencer/src/checkpoint/worker.rs
@@ -3,8 +3,8 @@
 use std::sync::Arc;
 
 use strata_consensus_logic::csm::message::ClientUpdateNotif;
-use strata_db::{traits::Database, types::CheckpointEntry};
-use strata_primitives::{buf::Buf32, params::Params};
+use strata_db::{traits::Database, types::CheckpointEntry, DbError};
+use strata_primitives::{buf::Buf32, l1::L1BlockCommitment, l2::L2BlockCommitment, params::Params};
 use strata_state::{
     batch::{BatchInfo, BatchTransition, CheckpointBaseState},
     client_state::ClientState,
@@ -105,97 +105,114 @@ fn get_next_batch(
     storage: &NodeStorage,
     rollup_params_commitment: Buf32,
 ) -> Result<(BatchInfo, BatchTransition, CheckpointBaseState), Error> {
-    let chsman = storage.chainstate();
-
     if !state.is_chain_active() {
-        // before genesis
         debug!("chain not active, no duties created");
         return Err(Error::ChainInactive);
-    };
+    }
 
-    let Some(sync_state) = state.sync() else {
-        return Err(Error::ChainInactive);
-    };
-
+    let sync_state = state.sync().ok_or(Error::ChainInactive)?;
     let tip_height = sync_state.chain_tip_height();
     let tip_id = *sync_state.chain_tip_blkid();
 
-    // Still not ready to make a batch?  This should be only if the epoch is
-    // something else.
     if tip_height == 0 {
         return Err(Error::ChainInactive);
     }
 
+    let chsman = storage.chainstate();
+
+    // Fetch the current L1 verification state (required in both branches).
+    let current_l1_state = state
+        .l1_view()
+        .tip_verification_state()
+        .ok_or(Error::ChainInactive)?;
+    let current_l1_state_hash = current_l1_state.compute_hash().unwrap();
+
+    // Helper closures to get L1 and L2 block commitments.
+    let get_l1_commitment = |height: u64| -> Result<L1BlockCommitment, Error> {
+        let manifest = storage
+            .l1()
+            .get_block_manifest(height)?
+            .ok_or(DbError::MissingL1BlockBody(height))?;
+        Ok(L1BlockCommitment::new(height, manifest.block_hash()))
+    };
+
+    let get_l2_commitment = |height: u64| -> Result<L2BlockCommitment, Error> {
+        let blocks = storage.l2().get_blocks_at_height_blocking(height)?;
+        let block_id = blocks.first().ok_or(DbError::MissingL2State(height))?;
+        Ok(L2BlockCommitment::new(height, *block_id))
+    };
+
     match state.l1_view().last_finalized_checkpoint() {
-        // Cool, we are producing first batch!
+        // --- Branch: First batch (no finalized checkpoint exists yet) ---
         None => {
             debug!(
                 ?tip_height,
                 ?tip_id,
-                "No finalized checkpoint, creating new checkpiont"
+                "No finalized checkpoint, creating new checkpoint"
             );
-
             let first_checkpoint_idx = 0;
 
-            let current_l1_state = state
-                .l1_view()
-                .tip_verification_state()
-                .ok_or(Error::ChainInactive)?;
-
-            // Include blocks after genesis l1 height to last verified height
-            let l1_range = (
-                state.genesis_l1_height() + 1,
-                current_l1_state.last_verified_block_num as u64,
-            );
             let genesis_l1_state_hash = state
                 .genesis_verification_hash()
                 .ok_or(Error::ChainInactive)?;
-            let current_l1_state_hash = current_l1_state.compute_hash().unwrap();
+
+            // Determine the L1 range.
+            let initial_l1_height = state.genesis_l1_height() + 1;
+            let initial_l1_commitment = get_l1_commitment(initial_l1_height)?;
+            let final_l1_height = current_l1_state.last_verified_block_num as u64;
+            let final_l1_commitment = get_l1_commitment(final_l1_height)?;
+            let l1_range = (initial_l1_commitment, final_l1_commitment);
             let l1_transition = (genesis_l1_state_hash, current_l1_state_hash);
 
-            // Start from first non-genesis l2 block height
-            let l2_range = (1, tip_height);
+            // Determine the L2 range.
+            let initial_l2_height = 1;
+            let initial_l2_commitment = get_l2_commitment(initial_l2_height)?;
+            let final_l2_commitment = L2BlockCommitment::new(tip_height, tip_id);
+            let l2_range = (initial_l2_commitment, final_l2_commitment);
 
+            // Compute the L2 chainstate transition.
             let initial_chain_state = chsman
                 .get_toplevel_chainstate_blocking(0)?
                 .ok_or(Error::MissingIdxChainstate(0))?;
             let initial_chain_state_root = initial_chain_state.compute_state_root();
-
             let current_chain_state = chsman
                 .get_toplevel_chainstate_blocking(tip_height)?
-                .ok_or(Error::MissingIdxChainstate(0))?;
+                .ok_or(Error::MissingIdxChainstate(tip_height))?;
             let current_chain_state_root = current_chain_state.compute_state_root();
             let l2_transition = (initial_chain_state_root, current_chain_state_root);
 
+            // Build the batch transition and batch info.
             let new_transition =
                 BatchTransition::new(l1_transition, l2_transition, rollup_params_commitment);
-
             let new_batch = BatchInfo::new(first_checkpoint_idx, l1_range, l2_range, tip_id);
-
             let genesis_state = new_transition.get_initial_checkpoint_base_state();
+
             Ok((new_batch, new_transition, genesis_state))
         }
+
+        // --- Branch: Subsequent batches (using the last finalized checkpoint) ---
         Some(prev_checkpoint) => {
             let batch_info = prev_checkpoint.batch_info.clone();
             let batch_transition = prev_checkpoint.batch_transition.clone();
 
-            let current_l1_state = state
-                .l1_view()
-                .tip_verification_state()
-                .ok_or(Error::ChainInactive)?;
-            let l1_range = (
-                batch_info.l1_range.1 + 1,
-                current_l1_state.last_verified_block_num as u64,
-            );
-            let current_l1_state_hash = current_l1_state.compute_hash().unwrap();
+            // Build the L1 range for the new batch.
+            let initial_l1_height = batch_info.l1_range.1.height() + 1;
+            let initial_l1_commitment = get_l1_commitment(initial_l1_height)?;
+            let final_l1_height = current_l1_state.last_verified_block_num as u64;
+            // Use the block id from the current verification state.
+            let final_l1_commitment =
+                L1BlockCommitment::new(final_l1_height, current_l1_state.last_verified_block_hash);
+            let l1_range = (initial_l1_commitment, final_l1_commitment);
             let l1_transition = (batch_transition.l1_transition.1, current_l1_state_hash);
 
-            // Also, rather than tip heights, we might need to limit the max range a prover will
-            // be proving
-            let l2_range = (batch_info.l2_range.1 + 1, tip_height);
+            // Build the L2 range for the new batch.
+            let initial_l2_height = batch_info.l2_range.1.slot() + 1;
+            let initial_l2_commitment = get_l2_commitment(initial_l2_height)?;
+            let final_l2_commitment = L2BlockCommitment::new(tip_height, tip_id);
+            let l2_range = (initial_l2_commitment, final_l2_commitment);
             let current_chain_state = chsman
                 .get_toplevel_chainstate_blocking(tip_height)?
-                .ok_or(Error::MissingIdxChainstate(0))?;
+                .ok_or(Error::MissingIdxChainstate(tip_height))?;
             let current_chain_state_root = current_chain_state.compute_state_root();
             let l2_transition = (batch_transition.l2_transition.1, current_chain_state_root);
 
@@ -203,13 +220,12 @@ fn get_next_batch(
             let new_transition =
                 BatchTransition::new(l1_transition, l2_transition, rollup_params_commitment);
 
-            // If prev checkpoint was proved, use the checkpoint base state of the prev checkpoint
-            // else create a checkpoint base state based on initial info of this batch
             let checkpoint_base_state = if prev_checkpoint.is_proved {
                 prev_checkpoint.checkpoint_base_state.clone()
             } else {
                 new_transition.get_initial_checkpoint_base_state()
             };
+
             Ok((new_batch_info, new_transition, checkpoint_base_state))
         }
     }

--- a/crates/sequencer/src/duty/types.rs
+++ b/crates/sequencer/src/duty/types.rs
@@ -5,7 +5,10 @@ use std::{collections::HashSet, time};
 use borsh::{BorshDeserialize, BorshSerialize};
 use serde::{Deserialize, Serialize};
 use strata_primitives::{buf::Buf32, hash::compute_borsh_hash};
-use strata_state::{batch::BatchCheckpoint, id::L2BlockId};
+use strata_state::{
+    batch::{BatchInfo, BatchTransition, BootstrapState},
+    id::L2BlockId,
+};
 
 /// Describes when we'll stop working to fulfill a duty.
 #[derive(Clone, Debug)]
@@ -97,23 +100,44 @@ impl BlockSigningDuty {
 /// batch proof in the proof db.
 #[derive(Clone, Debug, BorshSerialize, Serialize, Deserialize)]
 pub struct BatchCheckpointDuty {
-    checkpoint: BatchCheckpoint,
+    /// Checkpoint/batch info
+    batch_info: BatchInfo,
+
+    /// Checkpoint/batch transition which needs to be proven
+    batch_transition: BatchTransition,
+
+    /// Bootstrapping state based on which the `batch_transition` will be verified
+    bootstrap_state: BootstrapState,
 }
 
 impl BatchCheckpointDuty {
-    /// Create new duty from [`BatchCheckpoint`]
-    pub fn new(checkpoint: BatchCheckpoint) -> Self {
-        Self { checkpoint }
+    pub fn new(
+        batch_info: BatchInfo,
+        batch_transition: BatchTransition,
+        bootstrap_state: BootstrapState,
+    ) -> Self {
+        Self {
+            batch_info,
+            batch_transition,
+            bootstrap_state,
+        }
     }
 
     /// Gen checkpoint index.
     pub fn idx(&self) -> u64 {
-        self.checkpoint.batch_info().idx()
+        self.batch_info.epoch()
     }
 
-    /// Get reference to checkpoint.
-    pub fn checkpoint(&self) -> &BatchCheckpoint {
-        &self.checkpoint
+    pub fn batch_info(&self) -> &BatchInfo {
+        &self.batch_info
+    }
+
+    pub fn batch_transition(&self) -> &BatchTransition {
+        &self.batch_transition
+    }
+
+    pub fn bootstrap_state(&self) -> &BootstrapState {
+        &self.bootstrap_state
     }
 }
 

--- a/crates/sequencer/src/duty/worker.rs
+++ b/crates/sequencer/src/duty/worker.rs
@@ -142,7 +142,7 @@ fn update_tracker(
     let latest_finalized_batch = state
         .l1_view()
         .last_finalized_checkpoint()
-        .map(|x| x.batch_info.idx());
+        .map(|x| x.batch_info.epoch());
 
     let tracker_update = StateUpdate::new(
         block_idx,

--- a/crates/state/src/batch.rs
+++ b/crates/state/src/batch.rs
@@ -222,12 +222,14 @@ impl BatchTransition {
         }
     }
 
-    /// Creates a [`CheckpointBaseState`] by taking the initial state of the [`BatchTransition`]
+    /// Creates a [`CheckpointBaseStateCommitment`] by taking the initial state of the
+    /// [`BatchTransition`]
     pub fn get_initial_checkpoint_base_state(&self) -> CheckpointBaseStateCommitment {
         CheckpointBaseStateCommitment::new(self.l1_transition.0, self.l2_transition.0)
     }
 
-    /// Creates a [`CheckpointBaseState`] by taking the final state of the [`BatchTransition`]
+    /// Creates a [`CheckpointBaseStateCommitment`] by taking the final state of the
+    /// [`BatchTransition`]
     pub fn get_final_checkpoint_base_state(&self) -> CheckpointBaseStateCommitment {
         CheckpointBaseStateCommitment::new(self.l1_transition.1, self.l2_transition.1)
     }

--- a/crates/state/src/batch.rs
+++ b/crates/state/src/batch.rs
@@ -25,7 +25,7 @@ pub struct BatchCheckpoint {
 
     /// Reference state commitment against which batch transition and corresponding proof is
     /// verified
-    checkpoint_base_state: CheckpointBaseStateCommitment,
+    base_state_commitment: BaseStateCommitment,
 
     /// Proof for the batch obtained from prover manager
     proof: Proof,
@@ -35,13 +35,13 @@ impl BatchCheckpoint {
     pub fn new(
         batch_info: BatchInfo,
         transition: BatchTransition,
-        checkpoint_base_state: CheckpointBaseStateCommitment,
+        base_state_commitment: BaseStateCommitment,
         proof: Proof,
     ) -> Self {
         Self {
             batch_info,
             transition,
-            checkpoint_base_state,
+            base_state_commitment,
             proof,
         }
     }
@@ -54,8 +54,8 @@ impl BatchCheckpoint {
         &self.transition
     }
 
-    pub fn checkpoint_base_state(&self) -> &CheckpointBaseStateCommitment {
-        &self.checkpoint_base_state
+    pub fn base_state_commitment(&self) -> &BaseStateCommitment {
+        &self.base_state_commitment
     }
 
     pub fn proof(&self) -> &Proof {
@@ -69,7 +69,7 @@ impl BatchCheckpoint {
     pub fn get_proof_output(&self) -> CheckpointProofOutput {
         CheckpointProofOutput::new(
             self.batch_transition().clone(),
-            self.checkpoint_base_state().clone(),
+            self.base_state_commitment().clone(),
         )
     }
 
@@ -222,16 +222,16 @@ impl BatchTransition {
         }
     }
 
-    /// Creates a [`CheckpointBaseStateCommitment`] by taking the initial state of the
+    /// Creates a [`BaseStateCommitment`] by taking the initial state of the
     /// [`BatchTransition`]
-    pub fn get_initial_checkpoint_base_state(&self) -> CheckpointBaseStateCommitment {
-        CheckpointBaseStateCommitment::new(self.l1_transition.0, self.l2_transition.0)
+    pub fn get_initial_base_state_commitment(&self) -> BaseStateCommitment {
+        BaseStateCommitment::new(self.l1_transition.0, self.l2_transition.0)
     }
 
-    /// Creates a [`CheckpointBaseStateCommitment`] by taking the final state of the
+    /// Creates a [`BaseStateCommitment`] by taking the final state of the
     /// [`BatchTransition`]
-    pub fn get_final_checkpoint_base_state(&self) -> CheckpointBaseStateCommitment {
-        CheckpointBaseStateCommitment::new(self.l1_transition.1, self.l2_transition.1)
+    pub fn get_final_base_state_commitment(&self) -> BaseStateCommitment {
+        BaseStateCommitment::new(self.l1_transition.1, self.l2_transition.1)
     }
 
     pub fn rollup_params_commitment(&self) -> Buf32 {
@@ -248,12 +248,12 @@ impl BatchTransition {
 #[derive(
     Clone, Debug, PartialEq, Eq, Arbitrary, BorshDeserialize, BorshSerialize, Deserialize, Serialize,
 )]
-pub struct CheckpointBaseStateCommitment {
+pub struct BaseStateCommitment {
     pub initial_l1_state: Buf32,
     pub initial_l2_state: Buf32,
 }
 
-impl CheckpointBaseStateCommitment {
+impl BaseStateCommitment {
     pub fn new(initial_l1_state: Buf32, initial_l2_state: Buf32) -> Self {
         Self {
             initial_l1_state,
@@ -265,17 +265,17 @@ impl CheckpointBaseStateCommitment {
 #[derive(Clone, Debug, PartialEq, Eq, BorshDeserialize, BorshSerialize)]
 pub struct CheckpointProofOutput {
     pub batch_transition: BatchTransition,
-    pub checkpoint_base_state: CheckpointBaseStateCommitment,
+    pub base_state_commitment: BaseStateCommitment,
 }
 
 impl CheckpointProofOutput {
     pub fn new(
         batch_transition: BatchTransition,
-        checkpoint_base_state: CheckpointBaseStateCommitment,
+        base_state_commitment: BaseStateCommitment,
     ) -> CheckpointProofOutput {
         Self {
             batch_transition,
-            checkpoint_base_state,
+            base_state_commitment,
         }
     }
 }

--- a/crates/state/src/batch.rs
+++ b/crates/state/src/batch.rs
@@ -21,7 +21,7 @@ pub struct BatchCheckpoint {
     /// Transition data for L1 and L2 states, which is verified by the proof.
     transition: BatchTransition,
 
-    /// Reference state against which checkpoint transitions and corresponding proof is verified
+    /// Reference state against which batch transitions and corresponding proof is verified
     checkpoint_base_state: CheckpointBaseState,
 
     /// Proof for the batch obtained from prover manager
@@ -57,6 +57,10 @@ impl BatchCheckpoint {
 
     pub fn proof(&self) -> &Proof {
         &self.proof
+    }
+
+    pub fn update_proof(&mut self, proof: Proof) {
+        self.proof = proof
     }
 
     pub fn get_proof_output(&self) -> CheckpointProofOutput {
@@ -177,12 +181,12 @@ impl BatchTransition {
         }
     }
 
-    /// Creates a [`checkpoint_base_stateState`] by taking the initial state of the [`BatchInfo`]
+    /// Creates a [`CheckpointBaseState`] by taking the initial state of the [`BatchTransition`]
     pub fn get_initial_checkpoint_base_state(&self) -> CheckpointBaseState {
         CheckpointBaseState::new(self.l1_transition.0, self.l2_transition.0)
     }
 
-    /// Creates a [`checkpoint_base_stateState`] by taking the final state of the [`BatchInfo`]
+    /// Creates a [`CheckpointBaseState`] by taking the final state of the [`BatchTransition`]
     pub fn get_final_checkpoint_base_state(&self) -> CheckpointBaseState {
         CheckpointBaseState::new(self.l1_transition.1, self.l2_transition.1)
     }
@@ -225,7 +229,7 @@ impl BatchInfo {
     }
 }
 
-/// Represents the reference state against which checkpoint transitions and proofs are verified.
+/// Represents the reference state against which batch transitions and proofs are verified.
 ///
 /// NOTE/TODO: This state serves as the starting point for verifying a checkpoint proof. If we move
 /// towards a strict mode where we prove each checkpoint recursively, this should be replaced with

--- a/crates/state/src/batch.rs
+++ b/crates/state/src/batch.rs
@@ -7,14 +7,19 @@ use zkaleido::{Proof, ProofReceipt, PublicValues};
 
 use crate::id::L2BlockId;
 
-/// Public parameters for batch proof to be posted to DA.
-/// Will be updated as prover specs evolve.
+/// Consolidates all information required to describe and verify a batch checkpoint.
+/// This includes metadata about the batch, the state transitions, bootstrap info,
+/// and the proof itself. The proof verifies that the transition in [`BatchTransition`]
+/// is valid for the batch described by [`BatchInfo`].
 #[derive(
     Clone, Debug, PartialEq, Eq, Arbitrary, BorshDeserialize, BorshSerialize, Deserialize, Serialize,
 )]
 pub struct BatchCheckpoint {
     /// Information regarding the current batch checkpoint
     batch_info: BatchInfo,
+
+    /// Transition data for L1 and L2 states, which is verified by the proof.
+    transition: BatchTransition,
 
     /// Bootstrap info based on which the checkpoint transition and proof is verified
     bootstrap: BootstrapState,
@@ -24,9 +29,15 @@ pub struct BatchCheckpoint {
 }
 
 impl BatchCheckpoint {
-    pub fn new(batch_info: BatchInfo, bootstrap: BootstrapState, proof: Proof) -> Self {
+    pub fn new(
+        batch_info: BatchInfo,
+        transition: BatchTransition,
+        bootstrap: BootstrapState,
+        proof: Proof,
+    ) -> Self {
         Self {
             batch_info,
+            transition,
             bootstrap,
             proof,
         }
@@ -36,25 +47,32 @@ impl BatchCheckpoint {
         &self.batch_info
     }
 
+    pub fn batch_transition(&self) -> &BatchTransition {
+        &self.transition
+    }
+
     pub fn bootstrap_state(&self) -> &BootstrapState {
         &self.bootstrap
     }
 
-    pub fn proof_output(&self) -> CheckpointProofOutput {
-        CheckpointProofOutput::new(self.batch_info().clone(), self.bootstrap_state().clone())
+    pub fn proof(&self) -> &Proof {
+        &self.proof
     }
 
-    pub fn into_proof_receipt(self) -> ProofReceipt {
-        let proof = self.proof;
-        let output = CheckpointProofOutput::new(self.batch_info, self.bootstrap);
+    pub fn get_proof_output(&self) -> CheckpointProofOutput {
+        CheckpointProofOutput::new(
+            self.batch_transition().clone(),
+            self.bootstrap_state().clone(),
+        )
+    }
+
+    pub fn get_proof_receipt(&self) -> ProofReceipt {
+        let proof = self.proof().clone();
+        let output = self.get_proof_output();
         let public_values = PublicValues::new(
             borsh::to_vec(&output).expect("could not serialize checkpoint proof output"),
         );
         ProofReceipt::new(proof, public_values)
-    }
-
-    pub fn proof(&self) -> &Proof {
-        &self.proof
     }
 
     pub fn hash(&self) -> Buf32 {
@@ -102,12 +120,14 @@ impl From<SignedBatchCheckpoint> for BatchCheckpoint {
     }
 }
 
+/// Contains metadata describing a batch checkpoint, including the L1 and L2 height ranges
+/// it covers and the final L2 block ID in that range.
 #[derive(
     Clone, Debug, Eq, PartialEq, Arbitrary, BorshDeserialize, BorshSerialize, Deserialize, Serialize,
 )]
 pub struct BatchInfo {
-    /// The index of the checkpoint
-    pub idx: u64,
+    /// Checkpoint epoch
+    pub epoch: u64,
 
     /// L1 height range(inclusive) the checkpoint covers
     pub l1_range: (u64, u64),
@@ -115,110 +135,86 @@ pub struct BatchInfo {
     /// L2 height range(inclusive) the checkpoint covers
     pub l2_range: (u64, u64),
 
+    /// The last L2 block upto which this checkpoint covers since the previous checkpoint
+    pub l2_blockid: L2BlockId,
+}
+
+/// Describes state transitions for both L1 and L2, along with a commitment to the
+/// rollup parameters. The proof associated with the batch verifies this transition.
+#[derive(
+    Clone, Debug, Eq, PartialEq, Arbitrary, BorshDeserialize, BorshSerialize, Deserialize, Serialize,
+)]
+pub struct BatchTransition {
     /// The inclusive hash range of `HeaderVerificationState` for L1 blocks.
-    /// This represents the transition of L1 state from the starting state to the
-    /// ending state. The hash is computed via
-    /// [`super::l1::HeaderVerificationState::compute_hash`].
+    ///
+    /// Represents a transition from the starting L1 state to the ending L1 state.
+    /// The hash is computed via [`super::l1::HeaderVerificationState::compute_hash`].
     pub l1_transition: (Buf32, Buf32),
 
     /// The inclusive hash range of `Chainstate` for L2 blocks.
-    /// This represents the transition of L2 state from the starting state to the
-    /// ending state. The state root is computed via
-    /// [`super::chain_state::Chainstate::compute_state_root`].
+    ///
+    /// Represents a transition from the starting L2 state to the ending L2 state.
+    /// The state root is computed via [`super::chain_state::Chainstate::compute_state_root`].
     pub l2_transition: (Buf32, Buf32),
 
-    /// The last L2 block upto which this checkpoint covers since the previous checkpoint
-    pub l2_blockid: L2BlockId,
-
-    /// PoW transition in the given `l1_range`
-    pub l1_pow_transition: (u128, u128),
-
-    /// Commitment of the `RollupParams` calculated by
-    /// [`strata_primitives::params::RollupParams::compute_hash`]
+    /// A commitment to the `RollupParams`, as computed by
+    /// [`strata_primitives::params::RollupParams::compute_hash`].
+    ///
+    /// This indicates that the transition is valid under these rollup parameters.
     pub rollup_params_commitment: Buf32,
 }
 
-impl BatchInfo {
-    #[allow(clippy::too_many_arguments)] // FIXME
+impl BatchTransition {
     pub fn new(
-        checkpoint_idx: u64,
-        l1_range: (u64, u64),
-        l2_range: (u64, u64),
         l1_transition: (Buf32, Buf32),
         l2_transition: (Buf32, Buf32),
-        l2_blockid: L2BlockId,
-        l1_pow_transition: (u128, u128),
         rollup_params_commitment: Buf32,
     ) -> Self {
         Self {
-            idx: checkpoint_idx,
-            l1_range,
-            l2_range,
             l1_transition,
             l2_transition,
-            l2_blockid,
-            l1_pow_transition,
             rollup_params_commitment,
         }
     }
 
-    pub fn idx(&self) -> u64 {
-        self.idx
+    /// Creates a [`BootstrapState`] by taking the initial state of the [`BatchInfo`]
+    pub fn get_initial_bootstrap_state(&self) -> BootstrapState {
+        BootstrapState::new(self.l1_transition.0, self.l2_transition.0)
+    }
+
+    /// Creates a [`BootstrapState`] by taking the final state of the [`BatchInfo`]
+    pub fn get_final_bootstrap_state(&self) -> BootstrapState {
+        BootstrapState::new(self.l1_transition.1, self.l2_transition.1)
+    }
+
+    pub fn rollup_params_commitment(&self) -> Buf32 {
+        self.rollup_params_commitment
+    }
+}
+
+impl BatchInfo {
+    pub fn new(
+        checkpoint_idx: u64,
+        l1_range: (u64, u64),
+        l2_range: (u64, u64),
+        l2_blockid: L2BlockId,
+    ) -> Self {
+        Self {
+            epoch: checkpoint_idx,
+            l1_range,
+            l2_range,
+            l2_blockid,
+        }
+    }
+
+    pub fn epoch(&self) -> u64 {
+        self.epoch
     }
 
     pub fn l2_blockid(&self) -> &L2BlockId {
         &self.l2_blockid
     }
 
-    pub fn initial_l1_state_hash(&self) -> &Buf32 {
-        &self.l1_transition.0
-    }
-
-    pub fn final_l1_state_hash(&self) -> &Buf32 {
-        &self.l1_transition.1
-    }
-
-    pub fn initial_l2_state_hash(&self) -> &Buf32 {
-        &self.l2_transition.0
-    }
-
-    pub fn final_l2_state_hash(&self) -> &Buf32 {
-        &self.l2_transition.1
-    }
-
-    pub fn initial_acc_pow(&self) -> u128 {
-        self.l1_pow_transition.0
-    }
-
-    pub fn final_acc_pow(&self) -> u128 {
-        self.l1_pow_transition.1
-    }
-
-    pub fn rollup_params_commitment(&self) -> Buf32 {
-        self.rollup_params_commitment
-    }
-
-    /// Creates a [`BootstrapState`] by taking the initial state of the [`BatchInfo`]
-    pub fn get_initial_bootstrap_state(&self) -> BootstrapState {
-        BootstrapState::new(
-            self.l1_range.0,
-            self.l1_transition.0,
-            self.l2_range.0,
-            self.l2_transition.0,
-            self.l1_pow_transition.0,
-        )
-    }
-
-    /// Creates a [`BootstrapState`] by taking the final state of the [`BatchInfo`]
-    pub fn get_final_bootstrap_state(&self) -> BootstrapState {
-        BootstrapState::new(
-            self.l1_range.1 + 1, // because each batch is inclusive
-            self.l1_transition.1,
-            self.l2_range.1 + 1, // because each batch is inclusive
-            self.l2_transition.1,
-            self.l1_pow_transition.1,
-        )
-    }
     /// check for whether the l2 block is covered by the checkpoint
     pub fn includes_l2_block(&self, block_height: u64) -> bool {
         let (_, last_l2_height) = self.l2_range;
@@ -237,42 +233,32 @@ impl BatchInfo {
     Clone, Debug, PartialEq, Eq, Arbitrary, BorshDeserialize, BorshSerialize, Deserialize, Serialize,
 )]
 pub struct BootstrapState {
-    pub start_l1_height: u64,
-    // TODO is this a blkid?
     pub initial_l1_state: Buf32,
-    pub start_l2_height: u64,
     pub initial_l2_state: Buf32,
-    pub total_acc_pow: u128,
 }
 
 impl BootstrapState {
-    pub fn new(
-        start_l1_height: u64,
-        initial_l1_state: Buf32,
-        start_l2_height: u64,
-        initial_l2_state: Buf32,
-        total_acc_pow: u128,
-    ) -> Self {
+    pub fn new(initial_l1_state: Buf32, initial_l2_state: Buf32) -> Self {
         Self {
-            start_l1_height,
             initial_l1_state,
-            start_l2_height,
             initial_l2_state,
-            total_acc_pow,
         }
     }
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, BorshDeserialize, BorshSerialize)]
 pub struct CheckpointProofOutput {
-    pub batch_info: BatchInfo,
+    pub batch_transition: BatchTransition,
     pub bootstrap_state: BootstrapState,
 }
 
 impl CheckpointProofOutput {
-    pub fn new(batch_info: BatchInfo, bootstrap_state: BootstrapState) -> CheckpointProofOutput {
+    pub fn new(
+        batch_transition: BatchTransition,
+        bootstrap_state: BootstrapState,
+    ) -> CheckpointProofOutput {
         Self {
-            batch_info,
+            batch_transition,
             bootstrap_state,
         }
     }

--- a/crates/state/src/client_state.rs
+++ b/crates/state/src/client_state.rs
@@ -10,7 +10,7 @@ use strata_primitives::buf::Buf32;
 use tracing::*;
 
 use crate::{
-    batch::{BatchInfo, BatchTransition, BootstrapState},
+    batch::{BatchInfo, BatchTransition, CheckpointBaseState},
     id::L2BlockId,
     l1::{HeaderVerificationState, L1BlockId},
     operation::{ClientUpdateOutput, SyncAction},
@@ -306,9 +306,8 @@ pub struct L1Checkpoint {
     /// The inner checkpoint batch transition
     pub batch_transition: BatchTransition,
 
-    /// The inner checkpoint batch info
-    // TODO why is this called bootstrap state?
-    pub bootstrap_state: BootstrapState,
+    /// Reference state against which batch transitions is verified
+    pub checkpoint_base_state: CheckpointBaseState,
 
     /// If the checkpoint included proof
     pub is_proved: bool,
@@ -321,14 +320,14 @@ impl L1Checkpoint {
     pub fn new(
         batch_info: BatchInfo,
         batch_transition: BatchTransition,
-        bootstrap_state: BootstrapState,
+        checkpoint_base_state: CheckpointBaseState,
         is_proved: bool,
         height: u64,
     ) -> Self {
         Self {
             batch_info,
             batch_transition,
-            bootstrap_state,
+            checkpoint_base_state,
             is_proved,
             height,
         }

--- a/crates/state/src/client_state.rs
+++ b/crates/state/src/client_state.rs
@@ -10,7 +10,7 @@ use strata_primitives::buf::Buf32;
 use tracing::*;
 
 use crate::{
-    batch::{BatchInfo, BootstrapState},
+    batch::{BatchInfo, BatchTransition, BootstrapState},
     id::L2BlockId,
     l1::{HeaderVerificationState, L1BlockId},
     operation::{ClientUpdateOutput, SyncAction},
@@ -303,6 +303,9 @@ pub struct L1Checkpoint {
     /// The inner checkpoint batch info
     pub batch_info: BatchInfo,
 
+    /// The inner checkpoint batch transition
+    pub batch_transition: BatchTransition,
+
     /// The inner checkpoint batch info
     // TODO why is this called bootstrap state?
     pub bootstrap_state: BootstrapState,
@@ -317,12 +320,14 @@ pub struct L1Checkpoint {
 impl L1Checkpoint {
     pub fn new(
         batch_info: BatchInfo,
+        batch_transition: BatchTransition,
         bootstrap_state: BootstrapState,
         is_proved: bool,
         height: u64,
     ) -> Self {
         Self {
             batch_info,
+            batch_transition,
             bootstrap_state,
             is_proved,
             height,

--- a/crates/state/src/client_state.rs
+++ b/crates/state/src/client_state.rs
@@ -10,7 +10,7 @@ use strata_primitives::buf::Buf32;
 use tracing::*;
 
 use crate::{
-    batch::{BatchInfo, BatchTransition, CheckpointBaseState},
+    batch::{BatchInfo, BatchTransition, CheckpointBaseStateCommitment},
     id::L2BlockId,
     l1::{HeaderVerificationState, L1BlockId},
     operation::{ClientUpdateOutput, SyncAction},
@@ -306,8 +306,8 @@ pub struct L1Checkpoint {
     /// The inner checkpoint batch transition
     pub batch_transition: BatchTransition,
 
-    /// Reference state against which batch transitions is verified
-    pub checkpoint_base_state: CheckpointBaseState,
+    /// Reference state commitment against which batch transitions is verified
+    pub checkpoint_base_state: CheckpointBaseStateCommitment,
 
     /// If the checkpoint included proof
     pub is_proved: bool,
@@ -320,7 +320,7 @@ impl L1Checkpoint {
     pub fn new(
         batch_info: BatchInfo,
         batch_transition: BatchTransition,
-        checkpoint_base_state: CheckpointBaseState,
+        checkpoint_base_state: CheckpointBaseStateCommitment,
         is_proved: bool,
         height: u64,
     ) -> Self {

--- a/crates/state/src/l1/header_verification.rs
+++ b/crates/state/src/l1/header_verification.rs
@@ -70,22 +70,6 @@ pub struct HeaderVerificationState {
     pub last_11_blocks_timestamps: TimestampStore,
 }
 
-/// Summary of the HeaderVerificationState that is propagated to the CheckpointProof as public
-/// output
-#[derive(Clone, Debug, BorshSerialize, BorshDeserialize, Deserialize, Serialize)]
-pub struct HeaderVerificationStateSnapshot {
-    /// Hash of the [`HeaderVerificationState`]
-    pub hash: Buf32,
-
-    /// [HeaderVerificationState::last_verified_block_num]
-    ///
-    /// Note: This field and struct is here only since `BatchInfo` requires that
-    pub block_num: u64,
-
-    /// Total accumulated [difficulty](bitcoin::pow::Target::difficulty)
-    pub acc_pow: u128,
-}
-
 impl HeaderVerificationState {
     /// Computes the [`CompactTarget`] from a difficulty adjustment.
     ///
@@ -235,23 +219,6 @@ impl HeaderVerificationState {
         new_self.total_accumulated_pow += header.difficulty(params.inner());
 
         new_self
-    }
-
-    // Need to improve upon this?
-    pub fn compute_initial_snapshot(&self) -> HeaderVerificationStateSnapshot {
-        HeaderVerificationStateSnapshot {
-            hash: self.compute_hash().unwrap(),
-            block_num: self.last_verified_block_num as u64 + 1, // because inclusive
-            acc_pow: self.total_accumulated_pow,
-        }
-    }
-
-    pub fn compute_final_snapshot(&self) -> HeaderVerificationStateSnapshot {
-        HeaderVerificationStateSnapshot {
-            hash: self.compute_hash().unwrap(),
-            block_num: self.last_verified_block_num as u64,
-            acc_pow: self.total_accumulated_pow,
-        }
     }
 
     /// Calculate the hash of the verification state

--- a/crates/state/src/operation.rs
+++ b/crates/state/src/operation.rs
@@ -245,7 +245,7 @@ pub fn apply_writes_to_state(
                         .last_finalized_checkpoint
                         .as_ref()
                         .is_none_or(|prev_chp| {
-                            checkpt.batch_info.idx() == prev_chp.batch_info.idx() + 1
+                            checkpt.batch_info.epoch() == prev_chp.batch_info.epoch() + 1
                         })
                     {
                         panic!("operation: mismatched indices of pending checkpoint");

--- a/crates/state/src/operation.rs
+++ b/crates/state/src/operation.rs
@@ -251,7 +251,7 @@ pub fn apply_writes_to_state(
                         panic!("operation: mismatched indices of pending checkpoint");
                     }
 
-                    let fin_blockid = *checkpt.batch_info.l2_blockid();
+                    let fin_blockid = *checkpt.batch_info.final_l2_blockid();
                     l1v.last_finalized_checkpoint = Some(checkpt);
 
                     // Update finalized blockid in StateSync

--- a/functional-tests/tests/sync/sync_bitcoin_reorg.py
+++ b/functional-tests/tests/sync/sync_bitcoin_reorg.py
@@ -122,7 +122,7 @@ def check_nth_checkpoint_finalized_on_reorg(
     btcrpc.proxy.generatetoaddress(finality_depth + 1, new_addr)
 
     batch_info = seqrpc.strata_getCheckpointInfo(checkpt_idx)
-    to_finalize_blkid = batch_info["l2_blockid"]
+    to_finalize_blkid = batch_info["l2_range"][1]["blkid"]
 
     # Check finalized
     wait_until(

--- a/functional-tests/utils/utils.py
+++ b/functional-tests/utils/utils.py
@@ -172,14 +172,14 @@ def check_nth_checkpoint_finalized(
         timeout=3,
     )
 
-    assert syncstat["finalized_block_id"] != batch_info["l2_blockid"], (
+    assert syncstat["finalized_block_id"] != batch_info["l2_range"][1]["blkid"], (
         "Checkpoint block should not yet finalize"
     )
     assert batch_info["idx"] == idx
     checkpoint_info_next = seqrpc.strata_getCheckpointInfo(idx + 1)
     assert checkpoint_info_next is None, f"There should be no checkpoint info for {idx + 1} index"
 
-    to_finalize_blkid = batch_info["l2_blockid"]
+    to_finalize_blkid = batch_info["l2_range"][1]["blkid"]
 
     # Submit checkpoint if proof_timeout is not set
     if proof_timeout is None:


### PR DESCRIPTION
## Description

<!--
Provide a brief summary of the changes and the motivation behind them.
-->
Currently, the entire BatchInfo (including block heights and L1/L2 states) is proven, even though the block heights are already committed in the state. This leads to redundant data and unnatural edge cases—such as inclusive block ranges requiring small hacks to handle transitions.

This PR addresses those issues by splitting the structure into:

BatchTransition – contains only the essential proof data.
BatchInfo – handles auxiliary bookkeeping.
This separation removes duplication and simplifies handling of batch transitions.

### Type of Change

<!--
Select the type of change your PR introduces (put an `x` in all that apply):
-->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature/Enhancement (non-breaking change which adds functionality or enhances an existing one)
- [X] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactor
- [ ] New or updated tests
- [ ] Dependency Update

## Notes to Reviewers

<!--
Anything in particular you want to note that will help reviewers fulfill their role
in reviewing this PR?
-->

## Checklist

<!--
Ensure all the following are checked:
-->

- [ ] I have performed a self-review of my code.
- [ ] I have commented my code where necessary.
- [ ] I have updated the documentation if needed.
- [ ] My changes do not introduce new warnings.
- [ ] I have added tests that prove my changes are effective or that my feature works.
- [ ] New and existing tests pass with my changes.

## Related Issues

<!--
Link any related issues (e.g., `closes #123`, `fixes #456`).
-->
