### PR TITLE
STR-985: Make `ArbitraryGenerator` generate more entropy on the fly

### DIFF
--- a/bin/prover-client/src/task_tracker.rs
+++ b/bin/prover-client/src/task_tracker.rs
@@ -221,7 +221,7 @@ mod tests {
     fn gen_task_with_deps(n: u64) -> (ProofKey, Vec<ProofKey>) {
         let mut deps = Vec::with_capacity(n as usize);
         let host = ProofZkVm::Native;
-        let mut gen = ArbitraryGenerator::new();
+        let mut gen = ArbitraryGenerator::new_with_size(2_048);
 
         let start: L1BlockId = gen.generate();
         let end: L1BlockId = gen.generate();

--- a/bin/strata-client/src/extractor.rs
+++ b/bin/strata-client/src/extractor.rs
@@ -599,7 +599,7 @@ mod tests {
         let empty_deposits = empty_chain_state.deposits_table_mut();
         let mut deposits_table = DepositsTable::new_empty();
 
-        let mut arb = ArbitraryGenerator::new();
+        let mut arb = ArbitraryGenerator::new_with_size(4_096);
 
         let mut operators: Vec<OperatorIdx> = arb.generate();
         loop {

--- a/crates/btcio/src/reader/query.rs
+++ b/crates/btcio/src/reader/query.rs
@@ -493,8 +493,8 @@ mod test {
     /// remain unchanged
     #[tokio::test]
     async fn test_epoch_change() {
-        let mut chstate: Chainstate = ArbitraryGenerator::new().generate();
-        let clstate: ClientState = ArbitraryGenerator::new().generate();
+        let mut chstate: Chainstate = ArbitraryGenerator::new_with_size(4_096 * 2).generate();
+        let clstate: ClientState = ArbitraryGenerator::new_with_size(4_096 * 2).generate();
         let curr_epoch = chstate.cur_epoch();
         println!("curr epoch {:?}", curr_epoch);
 
@@ -520,12 +520,12 @@ mod test {
     /// to the height of last finalized checkpoint.
     #[tokio::test]
     async fn test_new_filter_rule() {
-        let mut chstate: Chainstate = ArbitraryGenerator::new().generate();
+        let mut chstate: Chainstate = ArbitraryGenerator::new_with_size(4_096 * 2).generate();
         let curr_epoch = chstate.cur_epoch();
 
         // Create client state with a finalized checkpoint
-        let mut clstate: ClientState = ArbitraryGenerator::new().generate();
-        let mut checkpt: L1Checkpoint = ArbitraryGenerator::new().generate();
+        let mut clstate: ClientState = ArbitraryGenerator::new_with_size(4_096 * 2).generate();
+        let mut checkpt: L1Checkpoint = ArbitraryGenerator::new_with_size(4_096 * 2).generate();
 
         let chkpt_height = N_RECENT_BLOCKS as u64 - 5; // within recent blocks range, else panics
         checkpt.height = chkpt_height;

--- a/crates/btcio/src/reader/tx_indexer.rs
+++ b/crates/btcio/src/reader/tx_indexer.rs
@@ -290,7 +290,8 @@ mod test {
         let num_envelopes = 1;
         let l1_payloads: Vec<_> = (0..num_envelopes)
             .map(|_| {
-                let signed_checkpoint: SignedCheckpoint = ArbitraryGenerator::new().generate();
+                let signed_checkpoint: SignedCheckpoint =
+                    ArbitraryGenerator::new_with_size(4_096 * 4).generate();
                 L1Payload::new_checkpoint(borsh::to_vec(&signed_checkpoint).unwrap())
             })
             .collect();

--- a/crates/btcio/src/test_utils.rs
+++ b/crates/btcio/src/test_utils.rs
@@ -425,8 +425,8 @@ pub(crate) mod test_context {
             .unwrap();
         let cfg = Arc::new(WriterConfig::default());
         let status_channel = StatusChannel::new(
-            ArbitraryGenerator::new().generate(),
-            ArbitraryGenerator::new().generate(),
+            ArbitraryGenerator::new_with_size(4_096 * 2).generate(),
+            ArbitraryGenerator::new_with_size(4_096 * 2).generate(),
             None,
         );
         let params = Arc::new(gen_params());

--- a/crates/btcio/src/writer/task.rs
+++ b/crates/btcio/src/writer/task.rs
@@ -343,20 +343,20 @@ mod test {
     fn test_initialize_writer_state_with_existing_payloads() {
         let iops = get_envelope_ops();
 
-        let mut e1: BundledPayloadEntry = ArbitraryGenerator::new().generate();
+        let mut e1: BundledPayloadEntry = ArbitraryGenerator::new_with_size(4_096).generate();
         e1.status = L1BundleStatus::Finalized;
         iops.put_payload_entry_blocking(0, e1).unwrap();
 
-        let mut e2: BundledPayloadEntry = ArbitraryGenerator::new().generate();
+        let mut e2: BundledPayloadEntry = ArbitraryGenerator::new_with_size(4_096).generate();
         e2.status = L1BundleStatus::Published;
         iops.put_payload_entry_blocking(1, e2).unwrap();
         let expected_idx = 1; // All entries before this do not need to be watched.
 
-        let mut e3: BundledPayloadEntry = ArbitraryGenerator::new().generate();
+        let mut e3: BundledPayloadEntry = ArbitraryGenerator::new_with_size(4_096).generate();
         e3.status = L1BundleStatus::Unsigned;
         iops.put_payload_entry_blocking(2, e3).unwrap();
 
-        let mut e4: BundledPayloadEntry = ArbitraryGenerator::new().generate();
+        let mut e4: BundledPayloadEntry = ArbitraryGenerator::new_with_size(4_096).generate();
         e4.status = L1BundleStatus::Unsigned;
         iops.put_payload_entry_blocking(3, e4).unwrap();
 

--- a/crates/chaintsn/src/transition.rs
+++ b/crates/chaintsn/src/transition.rs
@@ -385,7 +385,7 @@ mod tests {
 
     #[test]
     fn test_process_l1_view_update_with_deposit_update_tx() {
-        let mut chs: Chainstate = ArbitraryGenerator::new().generate();
+        let mut chs: Chainstate = ArbitraryGenerator::new_with_size(4096 * 2).generate();
         // get the l1 view state of the chain state
         let params = gen_params();
         let header_record = chs.l1_view();
@@ -399,9 +399,9 @@ mod tests {
         let new_payloads_with_deposit_update_tx: Vec<L1HeaderPayload> =
             (1..=params.rollup().l1_reorg_safe_depth + 1)
                 .map(|idx| {
-                    let record = ArbitraryGenerator::new_with_size(1 << 15).generate();
-                    let proof = ArbitraryGenerator::new_with_size(1 << 12).generate();
-                    let tx = ArbitraryGenerator::new_with_size(1 << 12).generate();
+                    let record = ArbitraryGenerator::new_with_size(32_768).generate();
+                    let proof = ArbitraryGenerator::new_with_size(4_096).generate();
+                    let tx = ArbitraryGenerator::new_with_size(4_096).generate();
 
                     let l1tx = if idx == 1 {
                         let protocol_op = ProtocolOperation::Deposit(DepositInfo {
@@ -411,7 +411,7 @@ mod tests {
                         });
                         L1Tx::new(proof, tx, vec![protocol_op])
                     } else {
-                        ArbitraryGenerator::new_with_size(1 << 15).generate()
+                        ArbitraryGenerator::new_with_size(32_768).generate()
                     };
 
                     let deposit_update_tx = DepositUpdateTx::new(l1tx, idx);
@@ -437,7 +437,7 @@ mod tests {
 
     #[test]
     fn test_process_l1_view_update_with_empty_payload() {
-        let chs: Chainstate = ArbitraryGenerator::new().generate();
+        let chs: Chainstate = ArbitraryGenerator::new_with_size(4_096).generate();
         let params = gen_params();
 
         let mut state_cache = StateCache::new(chs.clone());
@@ -454,7 +454,7 @@ mod tests {
 
     #[test]
     fn test_process_l1_view_update_maturation_check() {
-        let mut chs: Chainstate = ArbitraryGenerator::new().generate();
+        let mut chs: Chainstate = ArbitraryGenerator::new_with_size(4_096).generate();
         let params = gen_params();
         let header_record = chs.l1_view();
         let old_safe_height = header_record.safe_height();
@@ -467,7 +467,7 @@ mod tests {
         let new_payloads_matured: Vec<L1HeaderPayload> = (1..params.rollup().l1_reorg_safe_depth
             + to_mature_blk_num)
             .map(|idx| {
-                let record = ArbitraryGenerator::new_with_size(1 << 15).generate();
+                let record = ArbitraryGenerator::new_with_size(32_768).generate();
                 L1HeaderPayload::new(old_safe_height + idx as u64, record)
                     .with_deposit_update_txs(vec![])
                     .build()

--- a/crates/evmexec/src/engine.rs
+++ b/crates/evmexec/src/engine.rs
@@ -518,7 +518,7 @@ mod tests {
 
         let el_payload = random_el_payload();
 
-        let mut arb = strata_test_utils::ArbitraryGenerator::new();
+        let mut arb = strata_test_utils::ArbitraryGenerator::new_with_size(32_768);
         let l2block: L2Block = arb.generate();
         let accessory = L2BlockAccessory::new(borsh::to_vec(&el_payload).unwrap());
         let l2block_bundle = L2BlockBundle::new(l2block, accessory);

--- a/crates/l1tx/src/filter/mod.rs
+++ b/crates/l1tx/src/filter/mod.rs
@@ -110,7 +110,8 @@ mod test {
         let num_envelopes = 2;
         let l1_payloads: Vec<_> = (0..num_envelopes)
             .map(|_| {
-                let signed_checkpoint: SignedCheckpoint = ArbitraryGenerator::new().generate();
+                let signed_checkpoint: SignedCheckpoint =
+                    ArbitraryGenerator::new_with_size(4_096 * 4).generate();
                 L1Payload::new_checkpoint(borsh::to_vec(&signed_checkpoint).unwrap())
             })
             .collect();

--- a/crates/primitives/src/l1/btc.rs
+++ b/crates/primitives/src/l1/btc.rs
@@ -1327,7 +1327,7 @@ mod tests {
 
     #[test]
     fn test_bitcoin_tx_arbitrary_generation() {
-        let mut generator = ArbitraryGenerator::new();
+        let mut generator = ArbitraryGenerator::new_with_size(4_096 * 4);
         let raw_tx: RawBitcoinTx = generator.generate();
         let _: Transaction = raw_tx.try_into().expect("should generate valid tx");
 

--- a/crates/proof-impl/btc-blockspace/src/tx_indexer.rs
+++ b/crates/proof-impl/btc-blockspace/src/tx_indexer.rs
@@ -226,7 +226,8 @@ mod test {
         let num_envelopes = 1;
         let l1_payloads: Vec<_> = (0..num_envelopes)
             .map(|_| {
-                let signed_checkpoint: SignedCheckpoint = ArbitraryGenerator::new().generate();
+                let signed_checkpoint: SignedCheckpoint =
+                    ArbitraryGenerator::new_with_size(4_096 * 4).generate();
                 L1Payload::new_checkpoint(borsh::to_vec(&signed_checkpoint).unwrap())
             })
             .collect();

--- a/crates/rocksdb-store/src/bridge/db.rs
+++ b/crates/rocksdb-store/src/bridge/db.rs
@@ -233,7 +233,7 @@ mod tests {
     fn test_bridge_duty_status_db() {
         let db = setup_duty_db();
 
-        let mut arb = ArbitraryGenerator::new();
+        let mut arb = ArbitraryGenerator::new_with_size(4_096 * 4);
 
         let duty_status: BridgeDutyStatus = arb.generate();
         let txid: BitcoinTxid = arb.generate();

--- a/crates/rocksdb-store/src/bridge_relay/db.rs
+++ b/crates/rocksdb-store/src/bridge_relay/db.rs
@@ -118,7 +118,7 @@ mod tests {
     }
 
     fn make_bridge_msg() -> (u128, BridgeMessage) {
-        let mut arb = ArbitraryGenerator::new();
+        let mut arb = ArbitraryGenerator::new_with_size(4_096 * 2);
 
         let msg: BridgeMessage = arb.generate();
 

--- a/crates/rocksdb-store/src/chain_state/db.rs
+++ b/crates/rocksdb-store/src/chain_state/db.rs
@@ -148,7 +148,7 @@ mod tests {
 
     #[test]
     fn test_write_genesis_state() {
-        let genesis_state: Chainstate = ArbitraryGenerator::new().generate();
+        let genesis_state: Chainstate = ArbitraryGenerator::new_with_size(4_096 * 2).generate();
         let db = setup_db();
 
         let res = db.get_earliest_write_idx();
@@ -173,7 +173,7 @@ mod tests {
     #[test]
     fn test_write_state_update() {
         let db = setup_db();
-        let genesis_state: Chainstate = ArbitraryGenerator::new().generate();
+        let genesis_state: Chainstate = ArbitraryGenerator::new_with_size(4_096 * 2).generate();
         let batch = WriteBatch::new_replace(genesis_state.clone());
 
         let res = db.put_write_batch(1, batch.clone());
@@ -197,7 +197,7 @@ mod tests {
     #[test]
     fn test_get_earliest_and_last_state_idx() {
         let db = setup_db();
-        let genesis_state: Chainstate = ArbitraryGenerator::new().generate();
+        let genesis_state: Chainstate = ArbitraryGenerator::new_with_size(4_096 * 2).generate();
         let batch = WriteBatch::new_replace(genesis_state.clone());
 
         db.write_genesis_state(genesis_state).unwrap();
@@ -212,7 +212,7 @@ mod tests {
     #[test]
     fn test_purge() {
         let db = setup_db();
-        let genesis_state: Chainstate = ArbitraryGenerator::new().generate();
+        let genesis_state: Chainstate = ArbitraryGenerator::new_with_size(4_096 * 2).generate();
         let batch = WriteBatch::new_replace(genesis_state.clone());
 
         db.write_genesis_state(genesis_state).unwrap();
@@ -248,7 +248,7 @@ mod tests {
     #[test]
     fn test_rollback() {
         let db = setup_db();
-        let genesis_state: Chainstate = ArbitraryGenerator::new().generate();
+        let genesis_state: Chainstate = ArbitraryGenerator::new_with_size(4_096 * 2).generate();
         let batch = WriteBatch::new_replace(genesis_state.clone());
 
         db.write_genesis_state(genesis_state).unwrap();
@@ -289,7 +289,7 @@ mod tests {
     #[test]
     fn test_purge_and_rollback() {
         let db = setup_db();
-        let genesis_state: Chainstate = ArbitraryGenerator::new().generate();
+        let genesis_state: Chainstate = ArbitraryGenerator::new_with_size(4_096 * 2).generate();
         let batch = WriteBatch::new_replace(genesis_state.clone());
 
         db.write_genesis_state(genesis_state).unwrap();

--- a/crates/rocksdb-store/src/checkpoint/db.rs
+++ b/crates/rocksdb-store/src/checkpoint/db.rs
@@ -57,7 +57,7 @@ mod tests {
         let seq_db = RBCheckpointDB::new(db, db_ops);
 
         let batchidx = 1;
-        let checkpoint: CheckpointEntry = ArbitraryGenerator::new().generate();
+        let checkpoint: CheckpointEntry = ArbitraryGenerator::new_with_size(4_096 * 4).generate();
         seq_db
             .put_batch_checkpoint(batchidx, checkpoint.clone())
             .unwrap();
@@ -72,7 +72,7 @@ mod tests {
         let seq_db = RBCheckpointDB::new(db, db_ops);
 
         let batchidx = 1;
-        let checkpoint: CheckpointEntry = ArbitraryGenerator::new().generate();
+        let checkpoint: CheckpointEntry = ArbitraryGenerator::new_with_size(4_096 * 4).generate();
         seq_db
             .put_batch_checkpoint(batchidx, checkpoint.clone())
             .unwrap();
@@ -87,7 +87,7 @@ mod tests {
         let (db, db_ops) = get_rocksdb_tmp_instance().unwrap();
         let seq_db = RBCheckpointDB::new(db, db_ops);
 
-        let checkpoint: CheckpointEntry = ArbitraryGenerator::new().generate();
+        let checkpoint: CheckpointEntry = ArbitraryGenerator::new_with_size(4_096 * 4).generate();
         seq_db
             .put_batch_checkpoint(100, checkpoint.clone())
             .unwrap();
@@ -100,7 +100,7 @@ mod tests {
         let (db, db_ops) = get_rocksdb_tmp_instance().unwrap();
         let seq_db = RBCheckpointDB::new(db, db_ops);
 
-        let checkpoint: CheckpointEntry = ArbitraryGenerator::new().generate();
+        let checkpoint: CheckpointEntry = ArbitraryGenerator::new_with_size(4_096 * 4).generate();
         seq_db
             .put_batch_checkpoint(100, checkpoint.clone())
             .unwrap();
@@ -122,7 +122,7 @@ mod tests {
         let (db, db_ops) = get_rocksdb_tmp_instance().unwrap();
         let seq_db = RBCheckpointDB::new(db, db_ops);
 
-        let checkpoint: CheckpointEntry = ArbitraryGenerator::new().generate();
+        let checkpoint: CheckpointEntry = ArbitraryGenerator::new_with_size(4_096 * 4).generate();
 
         for expected_idx in 0..=256 {
             let last_idx = seq_db.get_last_batch_idx().unwrap().unwrap_or(0);

--- a/crates/rocksdb-store/src/client_state/db.rs
+++ b/crates/rocksdb-store/src/client_state/db.rs
@@ -90,7 +90,7 @@ mod tests {
 
     #[test]
     fn test_write_consensus_output() {
-        let output: ClientUpdateOutput = ArbitraryGenerator::new().generate();
+        let output: ClientUpdateOutput = ArbitraryGenerator::new_with_size(4_096).generate();
         let db = setup_db();
 
         let res = db.put_client_update(2, output.clone());
@@ -113,7 +113,7 @@ mod tests {
         let idx = db.get_last_state_idx();
         assert!(matches!(idx, Err(DbError::NotBootstrapped)));
 
-        let output: ClientUpdateOutput = ArbitraryGenerator::new().generate();
+        let output: ClientUpdateOutput = ArbitraryGenerator::new_with_size(4_096).generate();
         db.put_client_update(0, output.clone())
             .expect("test: insert");
         db.put_client_update(1, output.clone())
@@ -125,7 +125,7 @@ mod tests {
 
     #[test]
     fn test_get_consensus_update() {
-        let output: ClientUpdateOutput = ArbitraryGenerator::new().generate();
+        let output: ClientUpdateOutput = ArbitraryGenerator::new_with_size(4_096).generate();
 
         let db = setup_db();
         db.put_client_update(0, output.clone())

--- a/crates/rocksdb-store/src/l1/db.rs
+++ b/crates/rocksdb-store/src/l1/db.rs
@@ -201,7 +201,7 @@ mod tests {
         db: &L1Db,
         num_txs: usize,
     ) -> (L1BlockManifest, Vec<L1Tx>, CompactMmr) {
-        let mut arb = ArbitraryGenerator::new_with_size(1 << 12);
+        let mut arb = ArbitraryGenerator::new_with_size(4_096);
 
         // TODO maybe tweak this to make it a bit more realistic?
         let mf: L1BlockManifest = arb.generate();
@@ -248,11 +248,11 @@ mod tests {
         let invalid_idxs = vec![1, 2, 5000, 1000, 1002, 999]; // basically any id beside idx + 1
         for invalid_idx in invalid_idxs {
             let txs: Vec<L1Tx> = (0..10)
-                .map(|_| ArbitraryGenerator::new().generate())
+                .map(|_| ArbitraryGenerator::new_with_size(2_048).generate())
                 .collect();
             let res = db.put_block_data(
                 invalid_idx,
-                ArbitraryGenerator::new().generate::<L1BlockManifest>(),
+                ArbitraryGenerator::new_with_size(1_024).generate::<L1BlockManifest>(),
                 txs,
             );
             assert!(res.is_err(), "Should fail to insert to db");
@@ -260,9 +260,13 @@ mod tests {
 
         let valid_idx = idx + 1;
         let txs: Vec<L1Tx> = (0..10)
-            .map(|_| ArbitraryGenerator::new().generate())
+            .map(|_| ArbitraryGenerator::new_with_size(1_024).generate())
             .collect();
-        let res = db.put_block_data(valid_idx, ArbitraryGenerator::new().generate(), txs);
+        let res = db.put_block_data(
+            valid_idx,
+            ArbitraryGenerator::new_with_size(1_024).generate(),
+            txs,
+        );
         assert!(res.is_ok(), "Should successfully insert to db");
     }
 
@@ -330,7 +334,7 @@ mod tests {
     fn test_put_mmr_checkpoint_invalid() {
         let db = setup_db();
         let _ = insert_block_data(1, &db, 10);
-        let mmr: CompactMmr = ArbitraryGenerator::new().generate();
+        let mmr: CompactMmr = ArbitraryGenerator::new_with_size(2_048).generate();
         let invalid_idxs = vec![0, 2, 4, 5, 6, 100, 1000]; // any idx except 1
         for idx in invalid_idxs {
             let res = db.put_mmr_checkpoint(idx, mmr.clone());
@@ -342,7 +346,7 @@ mod tests {
     fn test_put_mmr_checkpoint_valid() {
         let db = setup_db();
         let _ = insert_block_data(1, &db, 10);
-        let mmr: CompactMmr = ArbitraryGenerator::new().generate();
+        let mmr: CompactMmr = ArbitraryGenerator::new_with_size(2_048).generate();
         let res = db.put_mmr_checkpoint(1, mmr);
         assert!(res.is_ok());
     }

--- a/crates/rocksdb-store/src/l2/db.rs
+++ b/crates/rocksdb-store/src/l2/db.rs
@@ -114,7 +114,7 @@ mod tests {
     use crate::test_utils::get_rocksdb_tmp_instance;
 
     fn get_mock_data() -> L2BlockBundle {
-        let mut arb = ArbitraryGenerator::new_with_size(1 << 14);
+        let mut arb = ArbitraryGenerator::new_with_size(16_384);
         let l2_block: L2BlockBundle = arb.generate();
 
         l2_block

--- a/crates/rocksdb-store/src/sync_event/db.rs
+++ b/crates/rocksdb-store/src/sync_event/db.rs
@@ -127,7 +127,7 @@ mod tests {
     }
 
     fn insert_event(db: &SyncEventDb) -> SyncEvent {
-        let ev: SyncEvent = ArbitraryGenerator::new().generate();
+        let ev: SyncEvent = ArbitraryGenerator::new_with_size(4_096).generate();
         let res = db.write_sync_event(ev.clone());
         assert!(res.is_ok());
         ev

--- a/crates/rocksdb-store/src/writer/db.rs
+++ b/crates/rocksdb-store/src/writer/db.rs
@@ -107,7 +107,7 @@ mod tests {
         let (db, db_ops) = get_rocksdb_tmp_instance().unwrap();
         let seq_db = RBL1WriterDb::new(db, db_ops);
 
-        let blob: BundledPayloadEntry = ArbitraryGenerator::new().generate();
+        let blob: BundledPayloadEntry = ArbitraryGenerator::new_with_size(4_096).generate();
 
         seq_db.put_payload_entry(0, blob.clone()).unwrap();
 
@@ -119,7 +119,7 @@ mod tests {
     fn test_put_blob_existing_entry() {
         let (db, db_ops) = get_rocksdb_tmp_instance().unwrap();
         let seq_db = RBL1WriterDb::new(db, db_ops);
-        let blob: BundledPayloadEntry = ArbitraryGenerator::new().generate();
+        let blob: BundledPayloadEntry = ArbitraryGenerator::new_with_size(4_096).generate();
 
         seq_db.put_payload_entry(0, blob.clone()).unwrap();
 
@@ -134,12 +134,13 @@ mod tests {
         let (db, db_ops) = get_rocksdb_tmp_instance().unwrap();
         let seq_db = RBL1WriterDb::new(db, db_ops);
 
-        let entry: BundledPayloadEntry = ArbitraryGenerator::new().generate();
+        let entry: BundledPayloadEntry = ArbitraryGenerator::new_with_size(4_096).generate();
 
         // Insert
         seq_db.put_payload_entry(0, entry.clone()).unwrap();
 
-        let updated_entry: BundledPayloadEntry = ArbitraryGenerator::new().generate();
+        let updated_entry: BundledPayloadEntry =
+            ArbitraryGenerator::new_with_size(4_096).generate();
 
         // Update existing idx
         seq_db.put_payload_entry(0, updated_entry.clone()).unwrap();
@@ -152,7 +153,7 @@ mod tests {
         let (db, db_ops) = get_rocksdb_tmp_instance().unwrap();
         let seq_db = RBL1WriterDb::new(db, db_ops);
 
-        let blob: BundledPayloadEntry = ArbitraryGenerator::new().generate();
+        let blob: BundledPayloadEntry = ArbitraryGenerator::new_with_size(4_096).generate();
 
         let next_blob_idx = seq_db.get_next_payload_idx().unwrap();
         assert_eq!(
@@ -165,7 +166,7 @@ mod tests {
             .unwrap();
         // Now the next idx is 1
 
-        let blob: BundledPayloadEntry = ArbitraryGenerator::new().generate();
+        let blob: BundledPayloadEntry = ArbitraryGenerator::new_with_size(4_096).generate();
 
         seq_db.put_payload_entry(1, blob.clone()).unwrap();
         let next_blob_idx = seq_db.get_next_payload_idx().unwrap();
@@ -181,7 +182,7 @@ mod tests {
         let (db, db_ops) = get_rocksdb_tmp_instance().unwrap();
         let seq_db = RBL1WriterDb::new(db, db_ops);
 
-        let intent: IntentEntry = ArbitraryGenerator::new().generate();
+        let intent: IntentEntry = ArbitraryGenerator::new_with_size(4_096).generate();
         let intent_id: Buf32 = [0; 32].into();
 
         seq_db.put_intent_entry(intent_id, intent.clone()).unwrap();
@@ -194,7 +195,7 @@ mod tests {
     fn test_put_intent_entry() {
         let (db, db_ops) = get_rocksdb_tmp_instance().unwrap();
         let seq_db = RBL1WriterDb::new(db, db_ops);
-        let intent: IntentEntry = ArbitraryGenerator::new().generate();
+        let intent: IntentEntry = ArbitraryGenerator::new_with_size(4_096).generate();
         let intent_id: Buf32 = [0; 32].into();
 
         let result = seq_db.put_intent_entry(intent_id, intent.clone());

--- a/crates/sequencer/src/block_template/block_assembly.rs
+++ b/crates/sequencer/src/block_template/block_assembly.rs
@@ -371,7 +371,7 @@ mod tests {
 
     #[test]
     fn test_find_pivot_noop() {
-        let mut ag = ArbitraryGenerator::new_with_size(1 << 12);
+        let mut ag = ArbitraryGenerator::new_with_size(4_096);
 
         let blkids: [L1BlockId; 10] = ag.generate();
         eprintln!("{blkids:#?}");
@@ -394,7 +394,7 @@ mod tests {
 
     #[test]
     fn test_find_pivot_noop_offset() {
-        let mut ag = ArbitraryGenerator::new_with_size(1 << 12);
+        let mut ag = ArbitraryGenerator::new_with_size(4_096);
 
         let blkids: [L1BlockId; 10] = ag.generate();
         eprintln!("{blkids:#?}");
@@ -417,7 +417,7 @@ mod tests {
 
     #[test]
     fn test_find_pivot_simple_extend() {
-        let mut ag = ArbitraryGenerator::new_with_size(1 << 12);
+        let mut ag = ArbitraryGenerator::new_with_size(4_096);
 
         let blkids1: [L1BlockId; 10] = ag.generate();
         let mut blkids2 = Vec::from(blkids1);
@@ -449,7 +449,7 @@ mod tests {
 
     #[test]
     fn test_find_pivot_typical_reorg() {
-        let mut ag = ArbitraryGenerator::new_with_size(1 << 16);
+        let mut ag = ArbitraryGenerator::new_with_size(65_536);
 
         let mut blkids1: Vec<L1BlockId> = Vec::new();
         for _ in 0..10 {
@@ -486,7 +486,7 @@ mod tests {
 
     #[test]
     fn test_find_pivot_cur_shorter_reorg() {
-        let mut ag = ArbitraryGenerator::new_with_size(1 << 16);
+        let mut ag = ArbitraryGenerator::new_with_size(65_536);
 
         let mut blkids1: Vec<L1BlockId> = Vec::new();
         for _ in 0..10 {
@@ -527,7 +527,7 @@ mod tests {
 
     #[test]
     fn test_find_pivot_disjoint() {
-        let mut ag = ArbitraryGenerator::new_with_size(1 << 16);
+        let mut ag = ArbitraryGenerator::new_with_size(65_536);
 
         let mut blkids1: Vec<L1BlockId> = Vec::new();
         for _ in 0..10 {

--- a/crates/state/src/block.rs
+++ b/crates/state/src/block.rs
@@ -195,11 +195,11 @@ mod tests {
     #[test]
     fn test_verify_block_hashes() {
         // use arbitrary generator to get the new block
-        let block: L2Block = ArbitraryGenerator::new().generate();
+        let block: L2Block = ArbitraryGenerator::new_with_size(4_096).generate();
         assert!(validate_block_segments(&block));
 
-        let arb_exec_segment: ExecSegment = ArbitraryGenerator::new().generate();
-        let arb_l1_segment: L1Segment = ArbitraryGenerator::new().generate();
+        let arb_exec_segment: ExecSegment = ArbitraryGenerator::new_with_size(4_096).generate();
+        let arb_l1_segment: L1Segment = ArbitraryGenerator::new_with_size(4_096).generate();
         // mutate the l2Block's body to create a new block with arbitrary exec segment
         let blk_body = L2BlockBody::new(block.body().l1_segment().clone(), arb_exec_segment);
         let arb_exec_block = L2Block::new(block.header().clone(), blk_body);

--- a/crates/test-utils/src/l2.rs
+++ b/crates/test-utils/src/l2.rs
@@ -20,7 +20,7 @@ use strata_state::{
 use crate::{bitcoin::get_btc_chain, ArbitraryGenerator};
 
 pub fn gen_block(parent: Option<&SignedL2BlockHeader>) -> L2BlockBundle {
-    let mut arb = ArbitraryGenerator::new_with_size(1 << 12);
+    let mut arb = ArbitraryGenerator::new_with_size(4_096);
     let header: L2BlockHeader = arb.generate();
     let body: L2BlockBody = arb.generate();
     let accessory: L2BlockAccessory = arb.generate();

--- a/crates/test-utils/src/lib.rs
+++ b/crates/test-utils/src/lib.rs
@@ -7,7 +7,7 @@ pub mod evm_ee;
 pub mod l2;
 
 /// The default buffer size for the `ArbitraryGenerator`.
-const ARB_GEN_LEN: usize = 65_536;
+const ARB_GEN_LEN: usize = 1_024;
 
 pub struct ArbitraryGenerator {
     buf: Vec<u8>, // Persistent buffer


### PR DESCRIPTION
## Description

The default was 65kb, which was even called for `u64`, e.g. `BitcoinAmount`.
So let's make `ArbitraryGenerator` reasonable where the default is 1kb and calling `new_with_size()` for bigger sizes.

### Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature/Enhancement (non-breaking change which adds functionality or enhances an existing one)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Refactor
- [ ] New or updated tests
- [ ] Dependency Update

## Checklist

- [x] I have performed a self-review of my code.
- [x] I have commented my code where necessary.
- [x] I have updated the documentation if needed.
- [x] My changes do not introduce new warnings.
- [x] I have added (where necessary) tests that prove my changes are effective or that my feature works.
- [x] New and existing tests pass with my changes.

## Related Issues

STR-985
