### PR TITLE
fix: `key-derivation` and `datatool`

### DIFF
--- a/bin/datatool/src/args.rs
+++ b/bin/datatool/src/args.rs
@@ -53,18 +53,11 @@ pub(crate) struct SubcXpriv {
 #[argh(
     subcommand,
     name = "genseqpubkey",
-    description = "generates a sequencer pubkey from a master xpriv"
+    description = "generates a sequencer pubkey from an xpriv"
 )]
 pub(crate) struct SubcSeqPubkey {
     #[argh(option, description = "reads key from specified file", short = 'f')]
-    pub(crate) key_file: Option<PathBuf>,
-
-    #[argh(
-        switch,
-        description = "reads key from envvar STRATA_SEQ_KEY",
-        short = 'E'
-    )]
-    pub(crate) key_from_env: bool,
+    pub(crate) key_file: PathBuf,
 }
 
 /// Generate the sequencer pubkey to pass around.
@@ -76,7 +69,7 @@ pub(crate) struct SubcSeqPubkey {
 )]
 pub(crate) struct SubcSeqPrivkey {
     #[argh(option, description = "reads key from specified file", short = 'f')]
-    pub(crate) key_file: Option<PathBuf>,
+    pub(crate) key_file: PathBuf,
 
     #[argh(
         switch,
@@ -91,18 +84,11 @@ pub(crate) struct SubcSeqPrivkey {
 #[argh(
     subcommand,
     name = "genopxpub",
-    description = "generates an operator xpub from a master xpriv"
+    description = "generates an operator xpub from an xpriv"
 )]
 pub(crate) struct SubcOpXpub {
     #[argh(option, description = "reads key from specified file", short = 'f')]
-    pub(crate) key_file: Option<PathBuf>,
-
-    #[argh(
-        switch,
-        description = "reads key from envvar STRATA_OP_KEY",
-        short = 'E'
-    )]
-    pub(crate) key_from_env: bool,
+    pub(crate) key_file: PathBuf,
 }
 
 /// Generate a network's param file from inputs.

--- a/bin/datatool/src/args.rs
+++ b/bin/datatool/src/args.rs
@@ -148,17 +148,31 @@ pub(crate) struct SubcParams {
 
     #[argh(
         option,
-        description = "add a bridge operator key (must be at least one, appended after file keys)",
-        short = 'b'
+        description = "add a bridge operator message key (must be at least one, appended after file keys)",
+        short = 'm'
     )]
-    pub(crate) opkey: Vec<String>,
+    pub(crate) op_msg_key: Vec<String>,
 
     #[argh(
         option,
-        description = "read bridge operator keys by line from file",
-        short = 'B'
+        description = "read bridge operator message keys by line from file",
+        short = 'M'
     )]
-    pub(crate) opkeys: Option<PathBuf>,
+    pub(crate) op_msg_keys: Option<PathBuf>,
+
+    #[argh(
+        option,
+        description = "add a bridge operator signing key (must be at least one, appended after file keys)",
+        short = 'k'
+    )]
+    pub(crate) op_sign_key: Vec<String>,
+
+    #[argh(
+        option,
+        description = "read bridge operator signing keys by line from file",
+        short = 'K'
+    )]
+    pub(crate) op_sign_keys: Option<PathBuf>,
 
     #[argh(option, description = "deposit amount in sats (default \"10 BTC\")")]
     pub(crate) deposit_sats: Option<String>,

--- a/crates/key-derivation/src/operator.rs
+++ b/crates/key-derivation/src/operator.rs
@@ -19,8 +19,8 @@
 use bitcoin::bip32::{ChildNumber, Xpriv, Xpub};
 use secp256k1::SECP256K1;
 use strata_primitives::constants::{
-    STRATA_OPERATOR_BASE_DERIVATION_PATH, STRATA_OPERATOR_MESSAGE_IDX, STRATA_OPERATOR_WALLET_IDX,
-    STRATA_OP_MESSAGE_DERIVATION_PATH, STRATA_OP_WALLET_DERIVATION_PATH,
+    STRATA_OPERATOR_BASE_DERIVATION_PATH, STRATA_OP_MESSAGE_DERIVATION_PATH,
+    STRATA_OP_WALLET_DERIVATION_PATH,
 };
 #[cfg(feature = "zeroize")]
 use zeroize::{Zeroize, ZeroizeOnDrop};
@@ -259,24 +259,6 @@ impl Zeroize for OperatorKeys {
 
 #[cfg(feature = "zeroize")]
 impl ZeroizeOnDrop for OperatorKeys {}
-
-/// Converts the base [`Xpub`] to the message [`Xpub`].
-pub fn convert_base_xpub_to_message_xpub(base_xpub: &Xpub) -> Xpub {
-    let message_partial_path = ChildNumber::from_normal_idx(STRATA_OPERATOR_MESSAGE_IDX)
-        .expect("unfallible as long MESSAGE_IDX is not changed");
-    base_xpub
-        .derive_pub(SECP256K1, &message_partial_path)
-        .expect("unfallible")
-}
-
-/// Converts the base [`Xpub`] to the wallet [`Xpub`].
-pub fn convert_base_xpub_to_wallet_xpub(base_xpub: &Xpub) -> Xpub {
-    let wallet_partial_path = ChildNumber::from_normal_idx(STRATA_OPERATOR_WALLET_IDX)
-        .expect("unfallible as long WALLET_IDX is not changed");
-    base_xpub
-        .derive_pub(SECP256K1, &wallet_partial_path)
-        .expect("unfallible")
-}
 
 #[cfg(test)]
 mod tests {

--- a/crates/primitives/src/constants.rs
+++ b/crates/primitives/src/constants.rs
@@ -76,7 +76,7 @@ pub static STRATA_OPERATOR_BASE_DERIVATION_PATH: LazyLock<DerivationPath> = Lazy
 
 /// Strata [`DerivationPath`] for operator's key.
 ///
-/// This corresponds to the path: `m/20000'/20'/101'`.
+/// This corresponds to the path: `m/20000'/20'/100'`.
 pub static STRATA_OP_MESSAGE_DERIVATION_PATH: LazyLock<DerivationPath> = LazyLock::new(|| {
     DerivationPath::master().extend([
         ChildNumber::from_hardened_idx(STRATA_BASE_IDX).expect("valid hardened child number"),

--- a/functional-tests/envs/testenv.py
+++ b/functional-tests/envs/testenv.py
@@ -236,7 +236,7 @@ class BasicEnvConfig(flexitest.EnvConfig):
         operator_message_interval = self.message_interval or settings.message_interval
         # Create all the bridge clients.
         for i in range(self.n_operators):
-            xpriv_path = params_gen_data["opseedpaths"][i]
+            xpriv_path = params_gen_data["op_msg_seedpaths"][i]
             xpriv = None
             with open(xpriv_path) as f:
                 xpriv = f.read().strip()
@@ -388,7 +388,7 @@ class HubNetworkEnvConfig(flexitest.EnvConfig):
 
         # Create all the bridge clients.
         for i in range(self.n_operators):
-            xpriv_path = params_gen_data["opseedpaths"][i]
+            xpriv_path = params_gen_data["op_msg_seedpaths"][i]
             xpriv = None
             with open(xpriv_path) as f:
                 xpriv = f.read().strip()


### PR DESCRIPTION
## Description

In #673, we made the operator's derived p2p messages and MuSig2 signing keys as full hardened paths.
This broke the `key-derivation` and `datatool` crates that expected them to be non-hardened paths, hence it also broke the functional tests with respect to the bridge.

### Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature/Enhancement (non-breaking change which adds functionality or enhances an existing one)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Refactor
- [x] New or updated tests
- [ ] Dependency Update

## Checklist

- [x] I have performed a self-review of my code.
- [x] I have commented my code where necessary.
- [x] I have updated the documentation if needed.
- [x] My changes do not introduce new warnings.
- [x] I have added (where necessary) tests that prove my changes are effective or that my feature works.
- [x] New and existing tests pass with my changes.

