### PR TITLE
revert: operator keys non-hardened derivations

### DIFF
--- a/crates/primitives/src/constants.rs
+++ b/crates/primitives/src/constants.rs
@@ -76,24 +76,32 @@ pub static STRATA_OPERATOR_BASE_DERIVATION_PATH: LazyLock<DerivationPath> = Lazy
 
 /// Strata [`DerivationPath`] for operator's key.
 ///
-/// This corresponds to the path: `m/20000'/20'/101'`.
+/// This corresponds to the path: `m/20000'/20'/100`.
+///
+/// # Warning
+///
+/// The last path should be hardened as in `m/20000'/20'/100'`.
 pub static STRATA_OP_MESSAGE_DERIVATION_PATH: LazyLock<DerivationPath> = LazyLock::new(|| {
     DerivationPath::master().extend([
         ChildNumber::from_hardened_idx(STRATA_BASE_IDX).expect("valid hardened child number"),
         ChildNumber::from_hardened_idx(STRATA_OPERATOR_IDX).expect("valid hardened child number"),
-        ChildNumber::from_hardened_idx(STRATA_OPERATOR_MESSAGE_IDX)
-            .expect("valid hardened child number"),
+        ChildNumber::from_normal_idx(STRATA_OPERATOR_MESSAGE_IDX)
+            .expect("valid normal child number"),
     ])
 });
 /// Strata [`DerivationPath`] for operator's wallet key.
 ///
-/// This corresponds to the path: `m/20000'/20'/101'`.
+/// This corresponds to the path: `m/20000'/20'/101`.
+///
+/// # Warning
+///
+/// The last path should be hardened as in `m/20000'/20'/101'`.
 pub static STRATA_OP_WALLET_DERIVATION_PATH: LazyLock<DerivationPath> = LazyLock::new(|| {
     DerivationPath::master().extend([
         ChildNumber::from_hardened_idx(STRATA_BASE_IDX).expect("valid hardened child number"),
         ChildNumber::from_hardened_idx(STRATA_OPERATOR_IDX).expect("valid hardened child number"),
-        ChildNumber::from_hardened_idx(STRATA_OPERATOR_WALLET_IDX)
-            .expect("valid hardened child number"),
+        ChildNumber::from_normal_idx(STRATA_OPERATOR_WALLET_IDX)
+            .expect("valid normal child number"),
     ])
 });
 /// A verifiably unspendable public key, produced by hashing a fixed string to a curve group


### PR DESCRIPTION
## Description

In https://github.com/alpenlabs/strata/pull/673, we made the operator's derived p2p messages and MuSig2 signing keys as full hardened paths.
This broke the key-derivation and datatool crates that expected them to be non-hardened paths, hence it also broke the functional tests with respect to the bridge.

This reverts the change.

### Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature/Enhancement (non-breaking change which adds functionality or enhances an existing one)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Refactor
- [ ] New or updated tests
- [ ] Dependency Update

## Notes to Reviewers

Ideally we wouldn't revert. But it would need to do changes in the `bridge-client`, and a bunch of other things.
Since the Secret Service crate in the `strata-bridge` already has the correct spec with the hardened paths, eventually we'll remove the bridge code from `strata`.

## Checklist

- [x] I have performed a self-review of my code.
- [x] I have commented my code where necessary.
- [x] I have updated the documentation if needed.
- [x] My changes do not introduce new warnings.
- [x] I have added (where necessary) tests that prove my changes are effective or that my feature works.
- [x] New and existing tests pass with my changes.

