### PR TITLE
Str 1111 fix node sync

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13870,6 +13870,7 @@ dependencies = [
  "borsh",
  "futures",
  "futures-util",
+ "strata-common",
  "strata-consensus-logic",
  "strata-db",
  "strata-primitives",

--- a/bin/strata-client/Cargo.toml
+++ b/bin/strata-client/Cargo.toml
@@ -66,4 +66,5 @@ debug-utils = [
   "strata-common/debug-utils",
   "strata-consensus-logic/debug-utils",
   "strata-sequencer/debug-utils",
+  "strata-sync/debug-utils",
 ]

--- a/bin/strata-client/src/main.rs
+++ b/bin/strata-client/src/main.rs
@@ -345,7 +345,7 @@ fn start_core_tasks(
         "bitcoin_data_reader_task",
         bitcoin_data_reader_task(
             bitcoin_client.clone(),
-            storage.l1().clone(),
+            storage.clone(),
             Arc::new(config.btcio.reader.clone()),
             sync_manager.get_params(),
             status_channel.clone(),

--- a/bin/strata-client/src/rpc_server.rs
+++ b/bin/strata-client/src/rpc_server.rs
@@ -13,8 +13,8 @@ use jsonrpsee::core::RpcResult;
 use strata_bridge_relay::relayer::RelayerHandle;
 use strata_btcio::{broadcaster::L1BroadcastHandle, writer::EnvelopeHandle};
 #[cfg(feature = "debug-utils")]
-use strata_common::bail_manager::BAIL_SENDER;
-use strata_common::worker_pause_manager::{send_action_to_worker, Action, WorkerType};
+use strata_common::BAIL_SENDER;
+use strata_common::{send_action_to_worker, Action, WorkerType};
 use strata_consensus_logic::{checkpoint_verification::verify_proof, sync_manager::SyncManager};
 use strata_db::types::{CheckpointConfStatus, CheckpointProvingStatus, L1TxEntry, L1TxStatus};
 use strata_primitives::{

--- a/bin/strata-client/src/rpc_server.rs
+++ b/bin/strata-client/src/rpc_server.rs
@@ -14,6 +14,7 @@ use strata_bridge_relay::relayer::RelayerHandle;
 use strata_btcio::{broadcaster::L1BroadcastHandle, writer::EnvelopeHandle};
 #[cfg(feature = "debug-utils")]
 use strata_common::bail_manager::BAIL_SENDER;
+use strata_common::worker_pause_manager::{send_action_to_worker, Action, WorkerType};
 use strata_consensus_logic::{checkpoint_verification::verify_proof, sync_manager::SyncManager};
 use strata_db::types::{CheckpointConfStatus, CheckpointProvingStatus, L1TxEntry, L1TxStatus};
 use strata_primitives::{
@@ -994,5 +995,9 @@ impl StrataDebugApiServer for StrataDebugRpcImpl {
         #[cfg(feature = "debug-utils")]
         let _sender = BAIL_SENDER.send(Some(_ctx));
         Ok(())
+    }
+
+    async fn pause_resume_worker(&self, wtype: WorkerType, action: Action) -> RpcResult<bool> {
+        Ok(send_action_to_worker(wtype, action).await)
     }
 }

--- a/crates/btcio/src/reader/mod.rs
+++ b/crates/btcio/src/reader/mod.rs
@@ -2,3 +2,4 @@ mod handler;
 pub mod query;
 mod state;
 mod tx_indexer;
+mod utils;

--- a/crates/btcio/src/reader/state.rs
+++ b/crates/btcio/src/reader/state.rs
@@ -2,6 +2,7 @@ use std::collections::VecDeque;
 
 use bitcoin::BlockHash;
 use strata_l1tx::filter::TxFilterConfig;
+use strata_state::batch::SignedCheckpoint;
 
 /// State we use in various parts of the reader.
 #[derive(Debug)]
@@ -15,11 +16,14 @@ pub struct ReaderState {
     /// Depth at which we start pulling recent blocks out of the front of the queue.
     max_depth: usize,
 
-    /// Current transaction filtering config
+    /// Current transaction filtering config.
     filter_config: TxFilterConfig,
 
-    /// Current epoch
+    /// Current epoch.
     epoch: u64,
+
+    /// Checkpoint to wait until the corresponding l2 block is present in db.
+    checkpoint_to_wait_for: Option<SignedCheckpoint>,
 }
 
 impl ReaderState {
@@ -31,6 +35,7 @@ impl ReaderState {
         recent_blocks: VecDeque<BlockHash>,
         filter_config: TxFilterConfig,
         epoch: u64,
+        checkpoint_to_wait_for: Option<SignedCheckpoint>,
     ) -> Self {
         assert!(!recent_blocks.is_empty());
         Self {
@@ -39,6 +44,7 @@ impl ReaderState {
             recent_blocks,
             filter_config,
             epoch,
+            checkpoint_to_wait_for,
         }
     }
 
@@ -72,6 +78,14 @@ impl ReaderState {
 
     pub(crate) fn set_filter_config(&mut self, filter_config: TxFilterConfig) {
         self.filter_config = filter_config;
+    }
+
+    pub fn checkpoint_to_wait_for(&self) -> Option<&SignedCheckpoint> {
+        self.checkpoint_to_wait_for.as_ref()
+    }
+
+    pub(crate) fn set_checkpoint_to_wait_for(&mut self, ckpt: Option<SignedCheckpoint>) {
+        self.checkpoint_to_wait_for = ckpt;
     }
 
     /// Returns the idx of the deepest block in the reader state.

--- a/crates/btcio/src/reader/utils.rs
+++ b/crates/btcio/src/reader/utils.rs
@@ -1,0 +1,104 @@
+use strata_db::traits::BlockStatus;
+use strata_l1tx::messages::{L1Event, RelevantTxEntry};
+use strata_primitives::l1::ProtocolOperation;
+use strata_state::batch::SignedCheckpoint;
+use strata_storage::{L1BlockManager, NodeStorage};
+use tracing::*;
+
+/// Looks for checkpoints in given `RelevantTxEntry`s.
+pub(crate) fn find_checkpoint(entries: &[RelevantTxEntry]) -> Option<&SignedCheckpoint> {
+    let checkpts: Vec<&SignedCheckpoint> = entries
+        .iter()
+        .flat_map(|txentry| {
+            txentry
+                .contents()
+                .protocol_ops()
+                .iter()
+                .filter_map(|op| match op {
+                    ProtocolOperation::Checkpoint(c) => Some(c),
+                    _ => None,
+                })
+        })
+        .collect();
+    checkpts.last().map(|v| &**v)
+}
+
+pub(crate) async fn wait_for_terminal_block_in_db(
+    storage: &NodeStorage,
+    chkpt: &SignedCheckpoint,
+) -> anyhow::Result<()> {
+    let l2blk_comm = chkpt.checkpoint().batch_info().final_l2_block();
+    let exp_blkid = l2blk_comm.blkid();
+    let exp_height = l2blk_comm.slot();
+    let l2mgr = storage.l2();
+
+    if l2mgr.get_block_data_async(exp_blkid).await?.is_some() {
+        // Return if valid, else wait for valid block or some other block at the height is valid.
+        if let Some(BlockStatus::Valid) = l2mgr.get_block_status_async(exp_blkid).await? {
+            return Ok(());
+        }
+    }
+    debug!(
+        ?l2blk_comm,
+        "Found checkpoint in L1 block, waiting for corresponding processed terminal L2 block"
+    );
+
+    let mut rx = l2mgr.subscribe_to_valid_block_updates();
+
+    // FIXME: Ideally we would wait for the valid block until some timeout because that will
+    // never be seen if L2 reorgs.
+    // Or, Instead for waiting on particular block id, ideally we would wait for canonical block
+    // at given height and see if we get different blockid than we expect. That would
+    // handle for reorgs too.
+    loop {
+        match rx.recv().await? {
+            (h, blkid) if h >= exp_height || blkid == *exp_blkid => {
+                debug!(
+                    ?h,
+                    ?blkid,
+                    "Found a block at given height in db, continuing..."
+                );
+                return Ok(());
+            }
+            (h, blkid) => {
+                debug!(%h, %blkid, "Received valid block update");
+            }
+        }
+    }
+}
+
+/// Looks for checkpoints in given L1 events
+pub(crate) fn find_checkpoint_in_events(evs: &[L1Event]) -> Option<&SignedCheckpoint> {
+    for ev in evs {
+        if let L1Event::BlockData(blk_data, _, _) = ev {
+            if let Some(checkpt) = find_checkpoint(blk_data.relevant_txs()) {
+                return Some(checkpt);
+            }
+        }
+    }
+    None
+}
+
+/// Given a L1 height, fetches corresponding manifest and if manifest exists and it has checkpoint
+/// in it, returns the checkpoint.
+/// This is the checkpoint whose terminal l2 block will be waited to be present in the database.
+pub(crate) fn find_initial_checkpoint_to_wait_for(
+    l1mgr: &L1BlockManager,
+    last_block: u64,
+) -> anyhow::Result<Option<SignedCheckpoint>> {
+    let checkpt = l1mgr
+        .get_block_manifest_at_height(last_block)?
+        .map(|bmf| {
+            bmf.txs()
+                .iter()
+                .flat_map(|tx| {
+                    tx.protocol_ops().iter().filter_map(|op| match op {
+                        ProtocolOperation::Checkpoint(c) => Some(c.clone()),
+                        _ => None,
+                    })
+                })
+                .collect::<Vec<_>>()
+        })
+        .and_then(|v| v.last().cloned());
+    Ok(checkpt)
+}

--- a/crates/common/src/lib.rs
+++ b/crates/common/src/lib.rs
@@ -5,6 +5,8 @@ pub mod logging;
 
 #[cfg(feature = "debug-utils")]
 pub mod bail_manager;
+#[cfg(feature = "debug-utils")]
+pub mod worker_pause_manager;
 pub mod ws_client;
 
 /// Checks to see if we should bail out.

--- a/crates/common/src/lib.rs
+++ b/crates/common/src/lib.rs
@@ -43,15 +43,3 @@ pub async fn send_action_to_worker(_wtype: WorkerType, _action: Action) -> bool 
     // Noop
     true
 }
-
-#[cfg(not(feature = "debug-utils"))]
-#[inline(always)]
-pub async fn check_and_pause_if_needed_async(_wtype: WorkerType) {
-    // Noop
-}
-
-#[cfg(not(feature = "debug-utils"))]
-#[inline(always)]
-pub fn check_and_pause_if_needed(_wtype: WorkerType) {
-    // Noop
-}

--- a/crates/common/src/lib.rs
+++ b/crates/common/src/lib.rs
@@ -1,19 +1,19 @@
 //! Crate includes reusable utils for services that handle common behavior.
 //! Such as initializing the tracing framework and whatever else.
 
+use serde::{Deserialize, Serialize};
+
 pub mod logging;
 
 #[cfg(feature = "debug-utils")]
-pub mod bail_manager;
+mod bail_manager;
 #[cfg(feature = "debug-utils")]
-pub mod worker_pause_manager;
+pub use bail_manager::*;
+#[cfg(feature = "debug-utils")]
+mod worker_pause_manager;
+#[cfg(feature = "debug-utils")]
+pub use worker_pause_manager::*;
 pub mod ws_client;
-
-/// Checks to see if we should bail out.
-#[cfg(feature = "debug-utils")]
-pub fn check_bail_trigger(s: &str) {
-    bail_manager::check_bail_trigger(s);
-}
 
 /// Checks to see if we should bail out.
 // Stub for when we don't actually want to do anything.
@@ -21,4 +21,37 @@ pub fn check_bail_trigger(s: &str) {
 #[inline(always)]
 pub fn check_bail_trigger(_s: &str) {
     // nothing
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub enum WorkerType {
+    SyncWorker,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub enum Action {
+    // Pause for seconds
+    Pause(u64),
+    // Pause until asked to resume
+    PauseUntilResume,
+    Resume,
+}
+
+#[cfg(not(feature = "debug-utils"))]
+#[inline(always)]
+pub async fn send_action_to_worker(_wtype: WorkerType, _action: Action) -> bool {
+    // Noop
+    true
+}
+
+#[cfg(not(feature = "debug-utils"))]
+#[inline(always)]
+pub async fn check_and_pause_if_needed_async(_wtype: WorkerType) {
+    // Noop
+}
+
+#[cfg(not(feature = "debug-utils"))]
+#[inline(always)]
+pub fn check_and_pause_if_needed(_wtype: WorkerType) {
+    // Noop
 }

--- a/crates/common/src/worker_pause_manager.rs
+++ b/crates/common/src/worker_pause_manager.rs
@@ -44,7 +44,7 @@ pub async fn send_action_to_worker(wtype: WorkerType, action: Action) -> bool {
 }
 
 /// For the given worker type, checks if it has a Pause message, if so pauses it.
-pub async fn check_and_pause_if_needed_async(wtype: WorkerType) {
+pub async fn check_and_pause_debug_async(wtype: WorkerType) {
     let channel = PAUSE_CHANNELS.get(&wtype).unwrap();
     let mut receiver = channel.receiver.write().await;
 
@@ -61,7 +61,7 @@ pub async fn check_and_pause_if_needed_async(wtype: WorkerType) {
 }
 
 /// For the given worker type, checks if it has a Pause message, if so pauses it.
-pub fn check_and_pause_if_needed(wtype: WorkerType) {
+pub fn check_and_pause_debug(wtype: WorkerType) {
     let channel = PAUSE_CHANNELS.get(&wtype).unwrap();
     let mut receiver = channel.receiver.blocking_write();
 
@@ -84,7 +84,7 @@ fn check_and_handle_action(wtype: &WorkerType, act: Option<Action>) -> bool {
             true
         }
         None => {
-            debug!(?wtype, "Error receiveing msg for worker");
+            debug!(?wtype, "Error receiving msg for worker");
             true
         }
         Some(m) => {

--- a/crates/consensus-logic/src/csm/worker.rs
+++ b/crates/consensus-logic/src/csm/worker.rs
@@ -2,7 +2,7 @@
 
 use std::{sync::Arc, thread};
 
-use strata_db::types::{CheckpointConfStatus, CheckpointEntry};
+use strata_db::types::CheckpointConfStatus;
 use strata_eectl::engine::ExecEngineCtl;
 use strata_primitives::prelude::*;
 use strata_state::{
@@ -311,7 +311,7 @@ fn handle_sync_event(
     Ok(())
 }
 
-/// Apply send Update notificaiton to listeners.
+/// Apply send Update notification to listeners.
 fn post_handle_sync_event_hook(
     ev_idx: u64,
     new_state: Arc<ClientState>,
@@ -425,14 +425,14 @@ fn check_and_wait_for_valid_finalized_block_in_db(
         );
         let mut rx = l2.subscribe_to_valid_block_updates();
 
-        // FIXME: Ideally we would wait for the block until some timeout because that will never be
-        // seen if L2 reorgs.
+        // FIXME: Ideally we would wait for the valid block until some timeout because that will
+        // never be seen if L2 reorgs.
         // Or, Instead for waiting on particular block id, ideally we would wait for canonical block
         // at given height and see if we get different blockid than we expect. That would
         // handle for reorgs too.
         loop {
             match rx.blocking_recv()? {
-                (h, blkid) if h == exp_height || blkid == *exp_blkid => {
+                (h, blkid) if h >= exp_height || blkid == *exp_blkid => {
                     debug!(
                         ?h,
                         ?blkid,

--- a/crates/consensus-logic/src/csm/worker.rs
+++ b/crates/consensus-logic/src/csm/worker.rs
@@ -121,10 +121,7 @@ impl WorkerState {
     /// This is copied from the old `StateTracker` type which we removed to
     /// simplify things.
     // TODO maybe remove output return value
-    pub fn advance_consensus_state(
-        &mut self,
-        ev_idx: u64,
-    ) -> anyhow::Result<(ClientUpdateOutput, Arc<ClientState>)> {
+    pub fn advance_consensus_state(&mut self, ev_idx: u64) -> anyhow::Result<ClientUpdateOutput> {
         let prev_ev_idx = ev_idx - 1;
         if prev_ev_idx != self.cur_state_idx {
             return Err(Error::SkippedEventIdx(prev_ev_idx, self.cur_state_idx).into());
@@ -143,18 +140,13 @@ impl WorkerState {
         // Clone the state and apply the operations to it.
         let outp = state_mut.into_update();
 
-        // Store the outputs.
-        let state = self
-            .storage
-            .client_state()
-            .put_update_blocking(ev_idx, outp.clone())?;
+        Ok(outp)
+    }
 
-        // Update bookkeeping.
+    fn update_bookeeping(&mut self, ev_idx: u64, state: Arc<ClientState>) {
         debug!(%ev_idx, ?state, "computed new consensus state");
         self.cur_state = state;
         self.cur_state_idx = ev_idx;
-
-        Ok((outp, self.cur_state.clone()))
     }
 }
 
@@ -212,6 +204,13 @@ fn process_msg(
                     warn!(%ev_idx, "Applying missed sync event.");
                 }
                 handle_sync_event_with_retry(state, engine, ev_idx, status_channel, shutdown)?;
+                // Broadcast notifications and other stuffs
+                post_handle_sync_event_hook(
+                    ev_idx,
+                    state.cur_state().clone(),
+                    state,
+                    status_channel,
+                )?;
             }
 
             Ok(())
@@ -246,10 +245,13 @@ fn handle_sync_event_with_retry(
         // TODO demote to trace after we figure out the current issues
         debug!("trying sync event");
 
-        let Err(e) = handle_sync_event(state, engine, ev_idx, status_channel) else {
-            // Happy case, we want this to happen.
-            trace!("completed sync event");
-            break;
+        let e = match handle_sync_event(state, engine, ev_idx, status_channel) {
+            Err(e) => e,
+            Ok(v) => {
+                // Happy case, we want this to happen.
+                trace!("completed sync event");
+                return Ok(v);
+            }
         };
 
         // If we hit the try limit, abort.
@@ -281,11 +283,7 @@ fn handle_sync_event(
     status_channel: &StatusChannel,
 ) -> anyhow::Result<()> {
     // Perform the main step of deciding what the output we're operating on.
-    let (outp, new_state) = state.advance_consensus_state(ev_idx)?;
-    let outp = Arc::new(outp);
-
-    // Make sure that the new state index is set as expected.
-    assert_eq!(state.cur_event_idx(), ev_idx);
+    let outp = state.advance_consensus_state(ev_idx)?;
 
     // Apply the actions produced from the state transition before we publish
     // the new state, so that any database changes from them are available when
@@ -294,6 +292,28 @@ fn handle_sync_event(
         apply_action(action.clone(), state, engine, status_channel)?;
     }
 
+    // Store the outputs.
+    let clstate = state
+        .storage
+        .client_state()
+        .put_update_blocking(ev_idx, outp.clone())?;
+
+    // Now update worker state bookkeeping
+    state.update_bookeeping(ev_idx, clstate);
+
+    // Make sure that the new state index is set as expected.
+    assert_eq!(state.cur_event_idx(), ev_idx);
+
+    Ok(())
+}
+
+/// Apply send Update notificaiton to listeners.
+fn post_handle_sync_event_hook(
+    ev_idx: u64,
+    new_state: Arc<ClientState>,
+    state: &WorkerState,
+    status_channel: &StatusChannel,
+) -> anyhow::Result<()> {
     // FIXME clean this up and make them take Arcs
     let mut status = CsmStatus::default();
     status.set_last_sync_ev_idx(ev_idx);
@@ -307,13 +327,12 @@ fn handle_sync_event(
         // listeners?
         warn!("failed to send broadcast for new CSM update");
     }
-
     Ok(())
 }
 
 fn apply_action(
     action: SyncAction,
-    state: &mut WorkerState,
+    state: &WorkerState,
     engine: &impl ExecEngineCtl,
     _status_channel: &StatusChannel,
 ) -> anyhow::Result<()> {

--- a/crates/rpc/api/src/lib.rs
+++ b/crates/rpc/api/src/lib.rs
@@ -1,6 +1,7 @@
 //! Macro trait def for the `strata_` RPC namespace using jsonrpsee.
 use bitcoin::Txid;
 use jsonrpsee::{core::RpcResult, proc_macros::rpc};
+use strata_common::worker_pause_manager::{Action, WorkerType};
 use strata_db::types::{L1TxEntry, L1TxStatus};
 use strata_primitives::{
     batch::EpochSummary,
@@ -229,7 +230,12 @@ pub trait StrataDebugApi {
     /// Get the ClientState at a certain index
     #[method(name = "debug_getClientStateAtIdx")]
     async fn get_clientstate_at_idx(&self, idx: u64) -> RpcResult<Option<ClientState>>;
+
     /// for exiting the client based on context
     #[method(name = "debug_bail")]
     async fn set_bail_context(&self, ctx: String) -> RpcResult<()>;
+
+    /// Instructs a worker to pause or resume its working
+    #[method(name = "debug_pause_resume")]
+    async fn pause_resume_worker(&self, wtype: WorkerType, action: Action) -> RpcResult<bool>;
 }

--- a/crates/rpc/api/src/lib.rs
+++ b/crates/rpc/api/src/lib.rs
@@ -1,7 +1,7 @@
 //! Macro trait def for the `strata_` RPC namespace using jsonrpsee.
 use bitcoin::Txid;
 use jsonrpsee::{core::RpcResult, proc_macros::rpc};
-use strata_common::worker_pause_manager::{Action, WorkerType};
+use strata_common::{Action, WorkerType};
 use strata_db::types::{L1TxEntry, L1TxStatus};
 use strata_primitives::{
     batch::EpochSummary,

--- a/crates/sequencer/src/block_template/types.rs
+++ b/crates/sequencer/src/block_template/types.rs
@@ -1,6 +1,5 @@
 use serde::{Deserialize, Serialize};
-#[cfg(feature = "debug-utils")]
-use strata_common::bail_manager::{check_bail_trigger, BAIL_DUTY_SIGN_BLOCK};
+use strata_common::{check_bail_trigger, BAIL_DUTY_SIGN_BLOCK};
 use strata_primitives::{buf::Buf64, l2::L2BlockId};
 use strata_state::{
     block::{L2Block, L2BlockAccessory, L2BlockBody, L2BlockBundle},

--- a/crates/sequencer/src/block_template/types.rs
+++ b/crates/sequencer/src/block_template/types.rs
@@ -1,4 +1,5 @@
 use serde::{Deserialize, Serialize};
+#[cfg(feature = "debug-utils")]
 use strata_common::{check_bail_trigger, BAIL_DUTY_SIGN_BLOCK};
 use strata_primitives::{buf::Buf64, l2::L2BlockId};
 use strata_state::{

--- a/crates/storage/src/managers/l2.rs
+++ b/crates/storage/src/managers/l2.rs
@@ -16,14 +16,14 @@ pub struct L2BlockManager {
     ops: ops::l2::L2DataOps,
     block_cache: cache::CacheTable<L2BlockId, Option<L2BlockBundle>>,
     /// Broadcaster which broadcasts about new l2_block update in db.
-    l2_blk_tx: broadcast::Sender<L2BlockId>,
+    l2_blk_tx: broadcast::Sender<(u64, L2BlockId)>,
 }
 
 impl L2BlockManager {
     pub fn new<D: Database + Sync + Send + 'static>(pool: ThreadPool, db: Arc<D>) -> Self {
         let ops = ops::l2::Context::new(db.l2_db().clone()).into_ops(pool);
         let block_cache = cache::CacheTable::new(64.try_into().unwrap());
-        let (l2_blk_tx, _) = broadcast::channel::<L2BlockId>(1024);
+        let (l2_blk_tx, _) = broadcast::channel::<(u64, L2BlockId)>(1024);
         Self {
             ops,
             block_cache,
@@ -33,32 +33,34 @@ impl L2BlockManager {
 
     /// Puts a block in the database, purging cache entry.
     pub async fn put_block_data_async(&self, bundle: L2BlockBundle) -> DbResult<()> {
-        let id = bundle.block().header().get_blockid();
+        let header = bundle.block().header().clone();
+        let id = header.get_blockid();
         self.ops.put_block_data_async(bundle).await?;
         self.block_cache.purge(&id);
 
         // Broadcast
-        if let Err(e) = self.l2_blk_tx.send(id) {
-            warn!(?e, "Failed to broadcast l2 tx update");
+        if let Err(e) = self.l2_blk_tx.send((header.blockidx(), id)) {
+            warn!(?e, "No active listeners for l2 tx update");
         }
         Ok(())
     }
 
     /// Puts in a block in the database, purging cache entry.
     pub fn put_block_data_blocking(&self, bundle: L2BlockBundle) -> DbResult<()> {
-        let id = bundle.block().header().get_blockid();
+        let header = bundle.block().header().clone();
+        let id = header.get_blockid();
         self.ops.put_block_data_blocking(bundle)?;
         self.block_cache.purge(&id);
 
         // Broadcast
-        if let Err(e) = self.l2_blk_tx.send(id) {
-            warn!(?e, "Failed to broadcast l2 tx update");
+        if let Err(e) = self.l2_blk_tx.send((header.blockidx(), id)) {
+            warn!(?e, "No active listeners for l2 tx update");
         }
         Ok(())
     }
 
     /// Subscribe to block updates
-    pub fn subscribe_to_block_updates(&self) -> broadcast::Receiver<L2BlockId> {
+    pub fn subscribe_to_block_updates(&self) -> broadcast::Receiver<(u64, L2BlockId)> {
         self.l2_blk_tx.subscribe()
     }
 

--- a/crates/storage/src/managers/l2.rs
+++ b/crates/storage/src/managers/l2.rs
@@ -6,6 +6,8 @@ use strata_db::{
 };
 use strata_state::{block::L2BlockBundle, header::L2Header, id::L2BlockId};
 use threadpool::ThreadPool;
+use tokio::sync::broadcast;
+use tracing::warn;
 
 use crate::{cache, ops};
 
@@ -13,13 +15,20 @@ use crate::{cache, ops};
 pub struct L2BlockManager {
     ops: ops::l2::L2DataOps,
     block_cache: cache::CacheTable<L2BlockId, Option<L2BlockBundle>>,
+    /// Broadcaster which broadcasts about new l2_block update in db.
+    l2_blk_tx: broadcast::Sender<L2BlockId>,
 }
 
 impl L2BlockManager {
     pub fn new<D: Database + Sync + Send + 'static>(pool: ThreadPool, db: Arc<D>) -> Self {
         let ops = ops::l2::Context::new(db.l2_db().clone()).into_ops(pool);
         let block_cache = cache::CacheTable::new(64.try_into().unwrap());
-        Self { ops, block_cache }
+        let (l2_blk_tx, _) = broadcast::channel::<L2BlockId>(1024);
+        Self {
+            ops,
+            block_cache,
+            l2_blk_tx,
+        }
     }
 
     /// Puts a block in the database, purging cache entry.
@@ -27,6 +36,11 @@ impl L2BlockManager {
         let id = bundle.block().header().get_blockid();
         self.ops.put_block_data_async(bundle).await?;
         self.block_cache.purge(&id);
+
+        // Broadcast
+        if let Err(e) = self.l2_blk_tx.send(id) {
+            warn!(?e, "Failed to broadcast l2 tx update");
+        }
         Ok(())
     }
 
@@ -35,7 +49,17 @@ impl L2BlockManager {
         let id = bundle.block().header().get_blockid();
         self.ops.put_block_data_blocking(bundle)?;
         self.block_cache.purge(&id);
+
+        // Broadcast
+        if let Err(e) = self.l2_blk_tx.send(id) {
+            warn!(?e, "Failed to broadcast l2 tx update");
+        }
         Ok(())
+    }
+
+    /// Subscribe to block updates
+    pub fn subscribe_to_block_updates(&self) -> broadcast::Receiver<L2BlockId> {
+        self.l2_blk_tx.subscribe()
     }
 
     /// Gets a block either in the cache or from the underlying database.

--- a/crates/sync/Cargo.toml
+++ b/crates/sync/Cargo.toml
@@ -4,6 +4,7 @@ name = "strata-sync"
 version = "0.1.0"
 
 [dependencies]
+strata-common.workspace = true
 strata-consensus-logic.workspace = true
 strata-db.workspace = true
 strata-primitives.workspace = true

--- a/crates/sync/Cargo.toml
+++ b/crates/sync/Cargo.toml
@@ -25,3 +25,6 @@ tracing.workspace = true
 
 [dev-dependencies]
 arbitrary.workspace = true
+
+[features]
+debug-utils = ["strata-common/debug-utils"]

--- a/crates/sync/src/worker.rs
+++ b/crates/sync/src/worker.rs
@@ -3,7 +3,7 @@
 use std::sync::Arc;
 
 use futures::StreamExt;
-use strata_common::worker_pause_manager::{check_and_pause_if_needed_async, WorkerType};
+use strata_common::{check_and_pause_if_needed_async, WorkerType};
 use strata_consensus_logic::{
     csm::message::{ClientUpdateNotif, ForkChoiceMessage},
     sync_manager::SyncManager,

--- a/crates/sync/src/worker.rs
+++ b/crates/sync/src/worker.rs
@@ -3,7 +3,8 @@
 use std::sync::Arc;
 
 use futures::StreamExt;
-use strata_common::{check_and_pause_if_needed_async, WorkerType};
+#[cfg(feature = "debug-utils")]
+use strata_common::{check_and_pause_debug_async, WorkerType};
 use strata_consensus_logic::{
     csm::message::{ClientUpdateNotif, ForkChoiceMessage},
     sync_manager::SyncManager,
@@ -153,7 +154,8 @@ async fn sync_blocks_by_range<T: SyncClient>(
 
     while let Some(block) = block_stream.next().await {
         // NOTE: This is a noop if "debug-utils" flag is not turned on.
-        check_and_pause_if_needed_async(WorkerType::SyncWorker).await;
+        #[cfg(feature = "debug-utils")]
+        check_and_pause_debug_async(WorkerType::SyncWorker).await;
 
         handle_new_block(state, context, block).await?;
     }

--- a/crates/sync/src/worker.rs
+++ b/crates/sync/src/worker.rs
@@ -130,12 +130,6 @@ async fn do_tick<T: SyncClient>(
 
     let span = debug_span!("sync", %start_slot, %end_slot);
 
-    /*debug!(
-        current_height = state.tip_height(),
-        target_height = status.tip_height,
-        "syncing to target height"
-    );*/
-
     if let Err(e) = sync_blocks_by_range(start_slot, end_slot, state, context)
         .instrument(span)
         .await

--- a/crates/sync/src/worker.rs
+++ b/crates/sync/src/worker.rs
@@ -3,6 +3,7 @@
 use std::sync::Arc;
 
 use futures::StreamExt;
+use strata_common::worker_pause_manager::{check_and_pause_if_needed_async, WorkerType};
 use strata_consensus_logic::{
     csm::message::{ClientUpdateNotif, ForkChoiceMessage},
     sync_manager::SyncManager,
@@ -157,6 +158,9 @@ async fn sync_blocks_by_range<T: SyncClient>(
     let mut block_stream = Box::pin(block_stream);
 
     while let Some(block) = block_stream.next().await {
+        // NOTE: This is a noop if "debug-utils" flag is not turned on.
+        check_and_pause_if_needed_async(WorkerType::SyncWorker).await;
+
         handle_new_block(state, context, block).await?;
     }
 

--- a/functional-tests/run_test.sh
+++ b/functional-tests/run_test.sh
@@ -15,7 +15,7 @@ if [ ! -z $PROVER_TEST ]; then
     cargo build --release -F sp1-mock-builder
 	export PATH=$(realpath ../target/release/):$PATH
 else
-    echo "Running on seq mode"
+    echo "Running strata client"
     cargo build -F debug-utils
 fi
 

--- a/functional-tests/tests/sync/sync_fullnode_l2_lag.py
+++ b/functional-tests/tests/sync/sync_fullnode_l2_lag.py
@@ -49,13 +49,13 @@ class SyncFullNodeL2LagTest(testenv.StrataTester):
         checkpt_info = seqrpc.strata_getCheckpointInfo(cur_epoch)
         checkpt_l1_blk_height = checkpt_info["l1_reference"]["block_height"]
 
-        # Wait until full node's CSM reads the buried checkpoint height - 1. At this
+        # Wait until full node's CSM reads upto checkpoint height - 1. At this
         # point it won't have fully processed L1 block at checkpoint height
         # because corresponding finalized l2 block is not present in db yet.
         wait_until_with_value(
             lambda: (
-                fnrpc.strata_clientStatus()["buried_l1_block"]["height"],
-                seqrpc.strata_clientStatus()["buried_l1_block"]["height"],
+                fnrpc.strata_clientStatus()["tip_l1_block"]["height"],
+                seqrpc.strata_clientStatus()["tip_l1_block"]["height"],
             ),
             lambda v: v[0] >= checkpt_l1_blk_height - 1,
             error_with="Fullnode L1 sync did not catch upto buried checkpoint height - 1",
@@ -76,8 +76,8 @@ class SyncFullNodeL2LagTest(testenv.StrataTester):
         # Now check the epoch finalization, it should finalize since full node has resumed l2 sync
         wait_until_with_value(
             lambda: (
-                fnrpc.strata_clientStatus()["buried_l1_block"]["height"],
-                seqrpc.strata_clientStatus()["buried_l1_block"]["height"],
+                fnrpc.strata_clientStatus()["tip_l1_block"]["height"],
+                seqrpc.strata_clientStatus()["tip_l1_block"]["height"],
             ),
             lambda v: v[0] >= checkpt_l1_blk_height,
             error_with="Fullnode L1 sync did not catch upto buried checkpoint",

--- a/functional-tests/tests/sync/sync_fullnode_l2_lag.py
+++ b/functional-tests/tests/sync/sync_fullnode_l2_lag.py
@@ -1,0 +1,118 @@
+import logging
+
+import flexitest
+
+from envs import testenv
+from utils import *
+
+FOLLOW_DIST = 1
+
+
+@flexitest.register
+class SyncFullNodeL2LagTest(testenv.StrataTester):
+    def __init__(self, ctx: flexitest.InitContext):
+        env = testenv.HubNetworkEnvConfig(
+            110, rollup_settings=RollupParamsSettings.new_default().fast_batch()
+        )
+        ctx.set_env(env)
+
+    def main(self, ctx: flexitest.RunContext):
+        seq = ctx.get_service("seq_node")
+        seqrpc = seq.create_rpc()
+        fullnode = ctx.get_service("follower_1_node")
+        fnrpc = fullnode.create_rpc()
+
+        # Wait until sequencer and fullnode start
+        wait_until(seqrpc.strata_protocolVersion, timeout=5)
+        wait_until(fnrpc.strata_protocolVersion, timeout=5)
+
+        # Pick a recent slot and make sure they're both the same.
+        seqss = seqrpc.strata_syncStatus()
+        check_slot = seqss["tip_height"] - FOLLOW_DIST
+        check_both_at_same_slot(seqrpc, fnrpc, check_slot)
+
+        # Now pause the sync worker so that we can have finalized epoch on L1,
+        # but not corresponding block on L2 in full node
+        paused = fnrpc.debug_pause_resume("SyncWorker", "PauseUntilResume")
+        assert paused, "Should pause the fullnode sync worker"
+
+        cur_epoch = seqss["cur_epoch"]
+
+        # Wait until current epoch is finalized. By this time some blocks will
+        # have been produced in l2 as well as the checkpoint will be posted to L1.
+        wait_until_epoch_finalized(seqrpc, cur_epoch, timeout=10)
+
+        # Full node tip after sync is paused
+        fn_tip = fnrpc.strata_syncStatus()["tip_height"]
+
+        # Get corresponding checkpoint block
+        checkpt_info = seqrpc.strata_getCheckpointInfo(cur_epoch)
+        checkpt_l1_blk_height = checkpt_info["l1_reference"]["block_height"]
+
+        # Wait until full node's CSM reads the buried checkpoint height - 1. At this
+        # point it won't have fully processed L1 block at checkpoint height
+        # because corresponding finalized l2 block is not present in db yet.
+        wait_until_with_value(
+            lambda: (
+                fnrpc.strata_clientStatus()["buried_l1_block"]["height"],
+                seqrpc.strata_clientStatus()["buried_l1_block"]["height"],
+            ),
+            lambda v: v[0] >= checkpt_l1_blk_height - 1,
+            error_with="Fullnode L1 sync did not catch upto buried checkpoint height - 1",
+            timeout=10,
+            debug=True,
+        )
+
+        # FN tip after fn catches upto the buried checkpoint, should be the same as before
+        new_fn_tip = fnrpc.strata_syncStatus()["tip_height"]
+        assert fn_tip == new_fn_tip, "Fn tip should not progress while syncing is paused"
+        seq_tip = seqrpc.strata_syncStatus()["tip_height"]
+        assert new_fn_tip < seq_tip, "Fn tip should be less than sequencer tip"
+
+        # Now resume
+        resumed = fnrpc.debug_pause_resume("SyncWorker", "Resume")
+        assert resumed, "Should resume the fullnode sync worker"
+
+        # Now check the epoch finalization, it should finalize since full node has resumed l2 sync
+        wait_until_with_value(
+            lambda: (
+                fnrpc.strata_clientStatus()["buried_l1_block"]["height"],
+                seqrpc.strata_clientStatus()["buried_l1_block"]["height"],
+            ),
+            lambda v: v[0] >= checkpt_l1_blk_height,
+            error_with="Fullnode L1 sync did not catch upto buried checkpoint",
+            timeout=10,
+            debug=True,
+        )
+
+        # Let's check that eventually the fullnode syncs with sequencer
+        wait_until(
+            fn_syncs_with_seq(fnrpc, seqrpc),
+            error_with="Full node could not sync with sequencer",
+            timeout=20,
+        )
+
+
+def fn_syncs_with_seq(fnrpc, seqrpc):
+    def _f():
+        fnss = fnrpc.strata_syncStatus()
+        seqss = seqrpc.strata_syncStatus()
+        seq_tip_slot = seqss["tip_height"]
+        fn_tip_slot = fnss["tip_height"]
+
+        logging.info(f"Seq tip slot {seq_tip_slot}, fn tip slot {fn_tip_slot}")
+        return fn_tip_slot == seq_tip_slot
+
+    return _f
+
+
+def check_both_at_same_slot(seqrpc, fnrpc, check_slot):
+    seq_headers = seqrpc.strata_getHeadersAtIdx(check_slot)
+    assert len(seq_headers) > 0, f"seq node missing headers at slot {check_slot}"
+
+    fn_headers = fnrpc.strata_getHeadersAtIdx(check_slot)
+    assert len(fn_headers) > 0, f"follower node missing headers at slot {check_slot}"
+
+    seq_hdr = seq_headers[0]
+    fn_hdr = fn_headers[0]
+    assert seq_hdr == fn_hdr, f"headers mismatched at slot {check_slot}"

--- a/functional-tests/utils/utils.py
+++ b/functional-tests/utils/utils.py
@@ -263,7 +263,7 @@ def wait_until_csm_l1_tip_observed(rpc, **kwargs):
     wait_until_l1_observed(init_l1_height, **kwargs)
 
 
-def wait_until_cur_l1_tip_observed(btcrpc, seqrpc, **kwargs) -> int:
+def wait_until_cur_l1_tip_observed(btcrpc, seqrpc, **kwargs):
     """
     Waits until the current L1 tip block as requested from the L1 RPC has been
     observed by the CSM.


### PR DESCRIPTION
## Description

This PR does the following:
1. Adds a debug util that allows a worker task to pause by calling an RPC. The module is `strata_common::worker_pause_manager`.
2. Adds a functional test that tests correct operation if a fullnode's l2 sync is lagging behind its l1 sync.
3. In L1 reader, when a checkpoint is received, it checks if the l2 block referred by the checkpoint is actually present in L2 database, waits otherwise. In doing so, moves `engine.finalize_block` call from csm worker to fcm worker as it makes more sense for EE finalization to be in FCM
4. Adds `safe_block_hash` and `finalized_block_hash` to ExecEngine's state case, because if not there's a chance that stale `finalized_block_hash` is passed during `forkChoiceUpdatedV2` call. 

### Type of Change

<!--
Select the type of change your PR introduces (put an `x` in all that apply):
-->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature/Enhancement (non-breaking change which adds functionality or enhances an existing one)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactor
- [ ] New or updated tests
- [ ] Dependency Update

## Notes to Reviewers

<!--
Anything in particular you want to note that will help reviewers fulfill their role
in reviewing this PR?
-->

## Checklist

<!--
Ensure all the following are checked:
-->

- [ ] I have performed a self-review of my code.
- [ ] I have commented my code where necessary.
- [ ] I have updated the documentation if needed.
- [ ] My changes do not introduce new warnings.
- [ ] I have added (where necessary) tests that prove my changes are effective or that my feature works.
- [ ] New and existing tests pass with my changes.

## Related Issues

<!--
Link any related issues (e.g., `closes #123`, `fixes #456`).
-->
