### PR TITLE
fix: sp1 key not found for programs other than provers

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -93,7 +93,7 @@ jobs:
 
             # Extract sp1 value using jq
             SP1_VALUE=$(echo "$PARAMS_OUTPUT" | jq -r '.rollup_vk.sp1')
-            echo "sp1_value=\"$SP1_VALUE\"" >> "$GITHUB_OUTPUT"
+            echo "sp1_value=$SP1_VALUE" >> "$GITHUB_OUTPUT"
             echo "SP1 verification key: $SP1_VALUE"
 
             # Build prover with sp1 features
@@ -110,13 +110,20 @@ jobs:
           docker push "${ECR_REGISTRY}/${ECR_REPOSITORY}:${SHORT_TAG}"
       - name: Extract SP1 Value
         id: extract-sp1-value
+        env:
+          SP1_VALUE: ${{ steps.build-and-push.outputs.sp1_value }}
         run: |
-          if [ -n "$SP1_VALUE" ]; then
-            echo "sp1_value=$SP1_VALUE" >> "$GITHUB_OUTPUT"
-          else
-            echo "Error: Failed to extract SP1 value from parameters"
-            exit 1
+          # store sp1 value only if the matrix program is prover-client
+          if [ "${{ matrix.program }}" == "prover-client" ]; then
+            if [ -n "$SP1_VALUE" ]; then
+              echo "sp1_value=$SP1_VALUE" >> "$GITHUB_OUTPUT"
+            else
+              # the process must exit if we do not have the verification key when prover is built
+              echo "Error: Failed to extract SP1 value from parameters"
+              exit 1
+            fi
           fi
+
   update-helm-values:
     name: Update Helm Values
     needs: [build-and-push]


### PR DESCRIPTION
## Description

<!--
Provide a brief summary of the changes and the motivation behind them.
-->
This pr tries to fix issue seen with non-existent sp1 key when the programs built are other than prover. A check is added to avoid the condition.
### Type of Change

<!--
Select the type of change your PR introduces (put an `x` in all that apply):
-->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature/Enhancement (non-breaking change which adds functionality or enhances an existing one)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactor
- [ ] New or updated tests
- [ ] Dependency Update

## Notes to Reviewers

<!--
Anything in particular you want to note that will help reviewers fulfill their role
in reviewing this PR?
-->

## Checklist

<!--
Ensure all the following are checked:
-->

- [x] I have performed a self-review of my code.
- [x] I have commented my code where necessary.
- [x] I have updated the documentation if needed.
- [x] My changes do not introduce new warnings.
- [ ] I have added (where necessary) tests that prove my changes are effective or that my feature works.
- [x] New and existing tests pass with my changes.

## Related Issues
1143
<!--
Link any related issues (e.g., `closes #123`, `fixes #456`).
-->
