### PR TITLE
Str 1111 fullnode sync finalization fix

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13848,6 +13848,7 @@ dependencies = [
  "strata-rpc-api",
  "strata-rpc-types",
  "strata-state",
+ "strata-status",
  "strata-storage",
  "thiserror 2.0.11",
  "tokio",

--- a/bin/strata-client/src/main.rs
+++ b/bin/strata-client/src/main.rs
@@ -167,18 +167,11 @@ fn main_inner(args: Args) -> anyhow::Result<()> {
 
         let rpc_client = sync_client(sync_endpoint);
         let sync_peer = RpcSyncPeer::new(rpc_client, 10);
-        let l2_sync_context = L2SyncContext::new(
-            sync_peer,
-            ctx.storage.l2().clone(),
-            ctx.sync_manager.clone(),
-        );
-        // NOTE: this might block for some time during first run with empty db until genesis
-        // block is generated
-        let mut l2_sync_state =
-            strata_sync::block_until_csm_ready_and_init_sync_state(&l2_sync_context)?;
+        let l2_sync_context =
+            L2SyncContext::new(sync_peer, ctx.storage.clone(), ctx.sync_manager.clone());
 
         executor.spawn_critical_async("l2-sync-manager", async move {
-            strata_sync::sync_worker(&mut l2_sync_state, &l2_sync_context)
+            strata_sync::sync_worker(&l2_sync_context)
                 .await
                 .map_err(Into::into)
         });

--- a/bin/strata-client/src/rpc_server.rs
+++ b/bin/strata-client/src/rpc_server.rs
@@ -486,7 +486,7 @@ impl StrataApiServer for StrataRpcImpl {
             .l2()
             .get_block_data_async(&block_id)
             .await
-            .map_err(|e| Error::Other(e.to_string()))?
+            .map_err(Error::Db)?
             .map(|block| {
                 borsh::to_vec(&block)
                     .map(HexBytes)

--- a/crates/btcio/src/reader/event.rs
+++ b/crates/btcio/src/reader/event.rs
@@ -1,0 +1,58 @@
+use bitcoin::Block;
+use strata_l1tx::messages::RelevantTxEntry;
+use strata_primitives::l1::{HeaderVerificationState, L1BlockCommitment};
+
+/// L1 events that we observe and want the persistence task to work on.
+#[derive(Clone, Debug)]
+#[allow(clippy::large_enum_variant)]
+pub enum L1Event {
+    /// Data that contains block number, block and relevant transactions, and also the epoch whose
+    /// rules are applied to. In most cases, the [`HeaderVerificationState`] is `None`, with a
+    /// meaningful state provided only under during genesis
+    // TODO: handle this properly: https://alpenlabs.atlassian.net/browse/STR-1104
+    BlockData(BlockData, u64, Option<HeaderVerificationState>),
+
+    /// Revert to the provided block height
+    RevertTo(L1BlockCommitment),
+}
+
+/// Stores the bitcoin block and interpretations of relevant transactions within
+/// the block.
+#[derive(Clone, Debug)]
+pub struct BlockData {
+    /// Block number.
+    block_num: u64,
+
+    /// Raw block data.
+    // TODO remove?
+    block: Block,
+
+    /// Transactions in the block that contain protocol operations
+    relevant_txs: Vec<RelevantTxEntry>,
+}
+
+impl BlockData {
+    pub fn new(block_num: u64, block: Block, relevant_txs: Vec<RelevantTxEntry>) -> Self {
+        Self {
+            block_num,
+            block,
+            relevant_txs,
+        }
+    }
+
+    pub fn block_num(&self) -> u64 {
+        self.block_num
+    }
+
+    pub fn block(&self) -> &Block {
+        &self.block
+    }
+
+    pub fn relevant_txs(&self) -> &[RelevantTxEntry] {
+        &self.relevant_txs
+    }
+
+    pub fn tx_idxs_iter(&self) -> impl Iterator<Item = u32> + '_ {
+        self.relevant_txs.iter().map(|v| v.index())
+    }
+}

--- a/crates/btcio/src/reader/handler.rs
+++ b/crates/btcio/src/reader/handler.rs
@@ -1,5 +1,4 @@
 use bitcoin::{consensus::serialize, hashes::Hash, Block};
-use strata_l1tx::messages::{BlockData, L1Event};
 use strata_primitives::{
     buf::Buf32,
     l1::{
@@ -10,7 +9,10 @@ use strata_primitives::{
 use strata_state::sync_event::{EventSubmitter, SyncEvent};
 use tracing::*;
 
-use super::query::ReaderContext;
+use super::{
+    event::{BlockData, L1Event},
+    query::ReaderContext,
+};
 use crate::rpc::traits::ReaderRpc;
 
 pub(crate) async fn handle_bitcoin_event<R: ReaderRpc>(

--- a/crates/btcio/src/reader/mod.rs
+++ b/crates/btcio/src/reader/mod.rs
@@ -1,3 +1,4 @@
+mod event;
 mod handler;
 pub mod query;
 mod state;

--- a/crates/btcio/src/reader/query.rs
+++ b/crates/btcio/src/reader/query.rs
@@ -10,7 +10,7 @@ use secp256k1::XOnlyPublicKey;
 use strata_config::btcio::ReaderConfig;
 use strata_l1tx::{
     filter::{indexer::index_block, TxFilterConfig},
-    messages::{BlockData, L1Event, RelevantTxEntry},
+    messages::RelevantTxEntry,
 };
 use strata_primitives::{
     block_credential::CredRule,
@@ -25,8 +25,10 @@ use strata_status::StatusChannel;
 use strata_storage::{L1BlockManager, NodeStorage};
 use tracing::*;
 
+use super::event::L1Event;
 use crate::{
     reader::{
+        event::BlockData,
         handler::handle_bitcoin_event,
         state::ReaderState,
         tx_indexer::ReaderTxVisitorImpl,

--- a/crates/btcio/src/reader/utils.rs
+++ b/crates/btcio/src/reader/utils.rs
@@ -1,7 +1,9 @@
-use strata_l1tx::messages::{L1Event, RelevantTxEntry};
+use strata_l1tx::messages::RelevantTxEntry;
 use strata_primitives::l1::ProtocolOperation;
 use strata_state::{batch::SignedCheckpoint, chain_state::Chainstate};
 use strata_storage::NodeStorage;
+
+use super::event::L1Event;
 
 /// Looks for checkpoints in given `RelevantTxEntry`s.
 pub(crate) fn find_checkpoint(entries: &[RelevantTxEntry]) -> Option<&SignedCheckpoint> {

--- a/crates/consensus-logic/src/fork_choice_manager.rs
+++ b/crates/consensus-logic/src/fork_choice_manager.rs
@@ -504,7 +504,7 @@ fn process_fc_message(
             let status = if ok {
                 // check if any pending blocks can be finalized
                 if let Err(err) = handle_epoch_finalization(fcm_state, engine) {
-                    error!(?err, "failed to finalize epoch");
+                    error!(%err, "failed to finalize epoch");
                 }
 
                 // Update status.
@@ -950,7 +950,7 @@ fn handle_new_client_state(
 
     let finalized_epoch_changed = match handle_epoch_finalization(fcm_state, engine) {
         Err(err) => {
-            error!(?err, "failed to finalize epoch");
+            error!(%err, "failed to finalize epoch");
             false
         }
         Ok(Some(finalized_epoch)) if finalized_epoch == new_fin_epoch => {

--- a/crates/consensus-logic/src/fork_choice_manager.rs
+++ b/crates/consensus-logic/src/fork_choice_manager.rs
@@ -338,6 +338,8 @@ pub fn tracker_task<E: ExecEngineCtl>(
 
     handle_unprocessed_blocks(&mut fcm, &storage, engine.as_ref(), &status_channel)?;
 
+    status_channel.set_fcm_initialized();
+
     if let Err(e) = forkchoice_manager_task_inner(
         &shutdown,
         handle,

--- a/crates/consensus-logic/src/fork_choice_manager.rs
+++ b/crates/consensus-logic/src/fork_choice_manager.rs
@@ -986,7 +986,16 @@ fn handle_new_client_state(
     Ok(())
 }
 
-/// Tries to finalize pending epochs
+/// Check if any pending epochs can be finalized.
+/// If multiple are available, finalize the latest epoch that can be finalized.
+/// Remove the finalized epoch and all earlier epochs from pending queue.
+///
+/// Note: Finalization in this context:
+///     1. Update chaintip tracker's base block
+///     2. Message execution engine to mark block corresponding to last block of this epoch as
+///        finalized in the EE.
+///
+/// Return commitment to epoch that was finalized, if any.
 fn handle_epoch_finalization(
     fcm_state: &mut ForkChoiceManager,
     engine: &impl ExecEngineCtl,

--- a/crates/consensus-logic/src/fork_choice_manager.rs
+++ b/crates/consensus-logic/src/fork_choice_manager.rs
@@ -428,9 +428,7 @@ fn forkchoice_manager_task_inner<E: ExecEngineCtl>(
             FcmEvent::NewFcmMsg(m) => {
                 process_fc_message(m, &mut fcm_state, engine, &status_channel)
             }
-            FcmEvent::NewStateUpdate(st) => {
-                handle_new_client_state(&mut fcm_state, st, engine, &status_channel)
-            }
+            FcmEvent::NewStateUpdate(st) => handle_new_client_state(&mut fcm_state, st, engine),
             FcmEvent::Abort => break,
         }?;
     }
@@ -935,7 +933,6 @@ fn handle_new_client_state(
     fcm_state: &mut ForkChoiceManager,
     cs: ClientState,
     engine: &impl ExecEngineCtl,
-    status_channel: &StatusChannel,
 ) -> anyhow::Result<()> {
     let Some(new_fin_epoch) = cs.get_declared_final_epoch().copied() else {
         debug!("got new CSM state, but finalized epoch still unset, ignoring");
@@ -948,40 +945,21 @@ fn handle_new_client_state(
     // Update the new state.
     fcm_state.cur_csm_state = Arc::new(cs);
 
-    let finalized_epoch_changed = match handle_epoch_finalization(fcm_state, engine) {
+    match handle_epoch_finalization(fcm_state, engine) {
         Err(err) => {
             error!(%err, "failed to finalize epoch");
-            false
         }
         Ok(Some(finalized_epoch)) if finalized_epoch == new_fin_epoch => {
             debug!(?finalized_epoch, "finalized latest epoch");
-            true
         }
         Ok(Some(finalized_epoch)) => {
             debug!(?finalized_epoch, "finalized earlier epoch");
-            true
         }
         Ok(None) => {
             // there were no epochs that could be finalized
             warn!("did not finalize epoch");
-            false
         }
     };
-
-    if finalized_epoch_changed {
-        // Update status.
-        let status = ChainSyncStatus {
-            tip: fcm_state.cur_best_block,
-            prev_epoch: *fcm_state.get_chainstate_prev_epoch(),
-            finalized_epoch: *fcm_state.chain_tracker.finalized_epoch(),
-            // FIXME this is a bit convoluted, could this be simpler?
-            safe_l1: fcm_state.cur_chainstate.l1_view().get_safe_block(),
-        };
-
-        let update = ChainSyncStatusUpdate::new(status, fcm_state.cur_chainstate.clone());
-        trace!("publishing new chainstate");
-        status_channel.update_chain_sync_status(update);
-    }
 
     Ok(())
 }

--- a/crates/l1tx/src/filter/indexer.rs
+++ b/crates/l1tx/src/filter/indexer.rs
@@ -9,7 +9,7 @@ use super::{
     parse_valid_checkpoint_envelopes, try_parse_tx_as_withdrawal_fulfillment, try_parse_tx_deposit,
     TxFilterConfig,
 };
-use crate::messages::IndexedTxEntry;
+use crate::messages::Indexed;
 
 /// Interface to handle storage of extracted information from a transaction.
 pub trait TxVisitor {
@@ -44,13 +44,13 @@ pub fn index_block<V: TxVisitor>(
     block: &Block,
     visitor_fn: impl Fn() -> V,
     config: &TxFilterConfig,
-) -> Vec<IndexedTxEntry<V::Output>> {
+) -> Vec<Indexed<V::Output>> {
     block
         .txdata
         .iter()
         .enumerate()
         .filter_map(|(i, tx)| {
-            index_tx(tx, visitor_fn(), config).map(|outp| IndexedTxEntry::new(i as u32, outp))
+            index_tx(tx, visitor_fn(), config).map(|outp| Indexed::new(i as u32, outp))
         })
         .collect::<Vec<_>>()
 }

--- a/crates/l1tx/src/messages.rs
+++ b/crates/l1tx/src/messages.rs
@@ -1,26 +1,9 @@
-use bitcoin::Block;
 use borsh::{BorshDeserialize, BorshSerialize};
-use strata_primitives::l1::{
-    DaCommitment, DepositRequestInfo, HeaderVerificationState, L1BlockCommitment, ProtocolOperation,
-};
-
-/// L1 events that we observe and want the persistence task to work on.
-#[derive(Clone, Debug)]
-#[allow(clippy::large_enum_variant)]
-pub enum L1Event {
-    /// Data that contains block number, block and relevant transactions, and also the epoch whose
-    /// rules are applied to. In most cases, the [`HeaderVerificationState`] is `None`, with a
-    /// meaningful state provided only under during genesis
-    // TODO: handle this properly: https://alpenlabs.atlassian.net/browse/STR-1104
-    BlockData(BlockData, u64, Option<HeaderVerificationState>),
-
-    /// Revert to the provided block height
-    RevertTo(L1BlockCommitment),
-}
+use strata_primitives::l1::{DaCommitment, DepositRequestInfo, ProtocolOperation};
 
 /// Indexed transaction entry taken from a block.
 #[derive(Clone, Debug, BorshDeserialize, BorshSerialize)]
-pub struct IndexedTxEntry<T> {
+pub struct Indexed<T> {
     /// Index of the transaction in the block
     index: u32,
 
@@ -30,7 +13,7 @@ pub struct IndexedTxEntry<T> {
     contents: T,
 }
 
-impl<T> IndexedTxEntry<T> {
+impl<T> Indexed<T> {
     /// Creates a new instance.
     pub fn new(index: u32, contents: T) -> Self {
         Self { index, contents }
@@ -155,45 +138,4 @@ impl DaEntry {
 }
 
 /// Indexed tx entry with some messages.
-pub type RelevantTxEntry = IndexedTxEntry<L1TxMessages>;
-
-/// Stores the bitcoin block and interpretations of relevant transactions within
-/// the block.
-#[derive(Clone, Debug)]
-pub struct BlockData {
-    /// Block number.
-    block_num: u64,
-
-    /// Raw block data.
-    // TODO remove?
-    block: Block,
-
-    /// Transactions in the block that contain protocol operations
-    relevant_txs: Vec<RelevantTxEntry>,
-}
-
-impl BlockData {
-    pub fn new(block_num: u64, block: Block, relevant_txs: Vec<RelevantTxEntry>) -> Self {
-        Self {
-            block_num,
-            block,
-            relevant_txs,
-        }
-    }
-
-    pub fn block_num(&self) -> u64 {
-        self.block_num
-    }
-
-    pub fn block(&self) -> &Block {
-        &self.block
-    }
-
-    pub fn relevant_txs(&self) -> &[RelevantTxEntry] {
-        &self.relevant_txs
-    }
-
-    pub fn tx_idxs_iter(&self) -> impl Iterator<Item = u32> + '_ {
-        self.relevant_txs.iter().map(|v| v.index)
-    }
-}
+pub type RelevantTxEntry = Indexed<L1TxMessages>;

--- a/crates/rpc/api/src/lib.rs
+++ b/crates/rpc/api/src/lib.rs
@@ -87,7 +87,7 @@ pub trait StrataApi {
     #[method(name = "syncStatus")]
     async fn sync_status(&self) -> RpcResult<RpcSyncStatus>;
 
-    /// Get blocks in range as raw bytes of borsh serailized `Vec<L2BlockBundle>`.
+    /// Get blocks in range as raw bytes of borsh serialized `Vec<L2BlockBundle>`.
     /// `start_height` and `end_height` are inclusive.
     #[method(name = "getRawBundles")]
     async fn get_raw_bundles(&self, start_height: u64, end_height: u64) -> RpcResult<HexBytes>;

--- a/crates/rpc/api/src/lib.rs
+++ b/crates/rpc/api/src/lib.rs
@@ -87,6 +87,8 @@ pub trait StrataApi {
     #[method(name = "syncStatus")]
     async fn sync_status(&self) -> RpcResult<RpcSyncStatus>;
 
+    /// Get blocks in range as raw bytes of borsh serailized `Vec<L2BlockBundle>`.
+    /// `start_height` and `end_height` are inclusive.
     #[method(name = "getRawBundles")]
     async fn get_raw_bundles(&self, start_height: u64, end_height: u64) -> RpcResult<HexBytes>;
 

--- a/crates/status/src/chain.rs
+++ b/crates/status/src/chain.rs
@@ -102,24 +102,3 @@ impl ChainSyncStatusUpdate {
         self.new_status().cur_epoch()
     }
 }
-
-/// Status of different services
-/// Currently only fcm, others can be added as per need.
-#[derive(Clone)]
-pub struct ServiceInitStatus {
-    fcm: bool,
-}
-
-impl ServiceInitStatus {
-    pub fn new_uninitialized() -> Self {
-        Self { fcm: false }
-    }
-
-    pub fn is_fcm_initialized(&self) -> bool {
-        self.fcm
-    }
-
-    pub fn set_fcm_initialized(&mut self) {
-        self.fcm = true;
-    }
-}

--- a/crates/status/src/chain.rs
+++ b/crates/status/src/chain.rs
@@ -102,3 +102,24 @@ impl ChainSyncStatusUpdate {
         self.new_status().cur_epoch()
     }
 }
+
+/// Status of different services
+/// Currently only fcm, others can be added as per need.
+#[derive(Clone)]
+pub struct ServiceInitStatus {
+    fcm: bool,
+}
+
+impl ServiceInitStatus {
+    pub fn new_uninitialized() -> Self {
+        Self { fcm: false }
+    }
+
+    pub fn is_fcm_initialized(&self) -> bool {
+        self.fcm
+    }
+
+    pub fn set_fcm_initialized(&mut self) {
+        self.fcm = true;
+    }
+}

--- a/crates/status/src/status_manager.rs
+++ b/crates/status/src/status_manager.rs
@@ -57,13 +57,11 @@ impl StatusChannel {
         let (cl_tx, cl_rx) = watch::channel(cl_state);
         let (l1_tx, l1_rx) = watch::channel(l1_status);
         let (chs_tx, chs_rx) = watch::channel(ch_state);
-        let (init_tx, _) = watch::channel(ServiceInitStatus::new_uninitialized());
 
         let sender = Arc::new(StatusSender {
             cl: cl_tx,
             l1: l1_tx,
             chs: chs_tx,
-            init_status: init_tx,
         });
         let receiver = Arc::new(StatusReceiver {
             cl: cl_rx,
@@ -202,21 +200,6 @@ impl StatusChannel {
             warn!("l1 status receiver dropped");
         }
     }
-
-    pub fn subscribe_service_init(&self) -> watch::Receiver<ServiceInitStatus> {
-        self.sender.init_status.subscribe()
-    }
-
-    pub fn set_fcm_initialized(&self) {
-        self.sender.init_status.send_if_modified(|value| {
-            if value.is_fcm_initialized() {
-                false
-            } else {
-                value.set_fcm_initialized();
-                true
-            }
-        });
-    }
 }
 
 /// Wrapper for watch status receivers
@@ -233,5 +216,4 @@ struct StatusSender {
     cl: watch::Sender<ClientState>,
     l1: watch::Sender<L1Status>,
     chs: watch::Sender<Option<ChainSyncStatusUpdate>>,
-    init_status: watch::Sender<ServiceInitStatus>,
 }

--- a/crates/status/src/status_manager.rs
+++ b/crates/status/src/status_manager.rs
@@ -57,11 +57,13 @@ impl StatusChannel {
         let (cl_tx, cl_rx) = watch::channel(cl_state);
         let (l1_tx, l1_rx) = watch::channel(l1_status);
         let (chs_tx, chs_rx) = watch::channel(ch_state);
+        let (init_tx, _) = watch::channel(ServiceInitStatus::new_uninitialized());
 
         let sender = Arc::new(StatusSender {
             cl: cl_tx,
             l1: l1_tx,
             chs: chs_tx,
+            init_status: init_tx,
         });
         let receiver = Arc::new(StatusReceiver {
             cl: cl_rx,
@@ -170,7 +172,7 @@ impl StatusChannel {
 
     /// Waits until genesis and returns the client state where genesis was triggered.
     pub async fn wait_until_genesis(&self) -> Result<ClientState, RecvError> {
-        let mut rx = self.receiver.cl.clone();
+        let mut rx = self.subscribe_client_state();
         let state = rx.wait_for(|state| state.has_genesis_occurred()).await?;
         Ok(state.clone())
     }
@@ -200,6 +202,21 @@ impl StatusChannel {
             warn!("l1 status receiver dropped");
         }
     }
+
+    pub fn subscribe_service_init(&self) -> watch::Receiver<ServiceInitStatus> {
+        self.sender.init_status.subscribe()
+    }
+
+    pub fn set_fcm_initialized(&self) {
+        self.sender.init_status.send_if_modified(|value| {
+            if value.is_fcm_initialized() {
+                false
+            } else {
+                value.set_fcm_initialized();
+                true
+            }
+        });
+    }
 }
 
 /// Wrapper for watch status receivers
@@ -216,4 +233,5 @@ struct StatusSender {
     cl: watch::Sender<ClientState>,
     l1: watch::Sender<L1Status>,
     chs: watch::Sender<Option<ChainSyncStatusUpdate>>,
+    init_status: watch::Sender<ServiceInitStatus>,
 }

--- a/crates/sync/Cargo.toml
+++ b/crates/sync/Cargo.toml
@@ -11,6 +11,7 @@ strata-primitives.workspace = true
 strata-rpc-api = { workspace = true, features = ["client"] }
 strata-rpc-types.workspace = true
 strata-state.workspace = true
+strata-status.workspace = true
 strata-storage.workspace = true
 
 anyhow.workspace = true

--- a/crates/sync/src/error.rs
+++ b/crates/sync/src/error.rs
@@ -25,6 +25,9 @@ pub enum L2SyncError {
     #[error("loading unfinalized blocks: {0}")]
     LoadUnfinalizedFailed(String),
 
+    #[error("channel closed")]
+    ChannelClosed,
+
     #[error("client: {0}")]
     Client(#[from] ClientError),
 

--- a/crates/sync/src/lib.rs
+++ b/crates/sync/src/lib.rs
@@ -5,4 +5,4 @@ mod worker;
 
 pub use client::{ClientError, RpcSyncPeer, SyncClient};
 pub use error::L2SyncError;
-pub use worker::{block_until_csm_ready_and_init_sync_state, sync_worker, L2SyncContext};
+pub use worker::{sync_worker, L2SyncContext};

--- a/crates/sync/src/state.rs
+++ b/crates/sync/src/state.rs
@@ -5,7 +5,7 @@ use strata_state::{
     header::{L2Header, SignedL2BlockHeader},
     id::L2BlockId,
 };
-use strata_storage::L2BlockManager;
+use strata_storage::NodeStorage;
 use tracing::{debug, warn};
 
 use crate::L2SyncError;
@@ -63,10 +63,11 @@ impl L2SyncState {
     }
 }
 
-pub fn initialize_from_db(
+pub(crate) async fn initialize_from_db(
     cstate: &ClientState,
-    l2man: &L2BlockManager,
+    storage: &NodeStorage,
 ) -> Result<L2SyncState, L2SyncError> {
+    let l2man = storage.l2().as_ref();
     let finalized_epoch = match cstate.get_apparent_finalized_epoch() {
         Some(epoch) => epoch,
         None => {

--- a/crates/sync/src/state.rs
+++ b/crates/sync/src/state.rs
@@ -75,13 +75,8 @@ pub(crate) async fn initialize_from_db(
     let csm_finalized_epoch = match cstate.get_declared_final_epoch() {
         Some(epoch) => *epoch,
         None => {
-            let genesis_blockid = *storage
-                .l2()
-                .get_blocks_at_height_async(0)
-                .await?
-                .first()
-                .expect("genesis block should exist");
-            EpochCommitment::new(0, 0, genesis_blockid)
+            let sync_state = cstate.sync().expect("csm state should be init");
+            EpochCommitment::new(0, 0, *sync_state.genesis_blkid())
         }
     };
 

--- a/crates/sync/src/state.rs
+++ b/crates/sync/src/state.rs
@@ -61,6 +61,10 @@ impl L2SyncState {
     pub(crate) fn tip_height(&self) -> u64 {
         self.tip_block.slot()
     }
+
+    pub(crate) fn finalized_epoch(&self) -> &EpochCommitment {
+        self.tracker.finalized_epoch()
+    }
 }
 
 pub(crate) async fn initialize_from_db(

--- a/crates/sync/src/state.rs
+++ b/crates/sync/src/state.rs
@@ -1,15 +1,17 @@
 use strata_consensus_logic::unfinalized_tracker::UnfinalizedBlockTracker;
 use strata_primitives::{epoch::EpochCommitment, l2::L2BlockCommitment};
 use strata_state::{
+    chain_state::Chainstate,
     client_state::ClientState,
     header::{L2Header, SignedL2BlockHeader},
     id::L2BlockId,
 };
 use strata_storage::NodeStorage;
-use tracing::{debug, warn};
+use tracing::debug;
 
 use crate::L2SyncError;
 
+#[derive(Debug)]
 pub struct L2SyncState {
     /// Height of highest unfinalized block in tracker
     tip_block: L2BlockCommitment,
@@ -65,43 +67,52 @@ impl L2SyncState {
 
 pub(crate) async fn initialize_from_db(
     cstate: &ClientState,
+    chainstate: &Chainstate,
     storage: &NodeStorage,
 ) -> Result<L2SyncState, L2SyncError> {
-    let l2man = storage.l2().as_ref();
-    let finalized_epoch = match cstate.get_apparent_finalized_epoch() {
-        Some(epoch) => epoch,
+    let chainstate_last_epoch = chainstate.prev_epoch();
+
+    let csm_finalized_epoch = match cstate.get_declared_final_epoch() {
+        Some(epoch) => *epoch,
         None => {
-            // TODO handle this in some more structured way
-            warn!("no finalized block yet, sync starting from dummy genesis");
-            let blocks = l2man.get_blocks_at_height_blocking(0)?;
-            let genesis_blkid = blocks[0];
-            EpochCommitment::new(0, 0, genesis_blkid)
+            let genesis_blockid = *storage
+                .l2()
+                .get_blocks_at_height_async(0)
+                .await?
+                .first()
+                .expect("genesis block should exist");
+            EpochCommitment::new(0, 0, genesis_blockid)
         }
     };
 
-    let finalized_blkid = *finalized_epoch.last_blkid();
-    let finalized_slot = finalized_epoch.last_slot();
-
-    let finalized_block = l2man.get_block_data_blocking(&finalized_blkid)?;
-
-    // Should we remove this since we don't do anything with it anymore?  It
-    // does serve as a sanity check so that we don't start on a block we don't
-    // actually have.
-    let Some(_) = finalized_block else {
-        return Err(L2SyncError::MissingBlock(*finalized_epoch.last_blkid()));
+    // pick whatever is the earliest
+    let finalized_epoch = if chainstate_last_epoch.epoch() < csm_finalized_epoch.epoch() {
+        *chainstate_last_epoch
+    } else {
+        csm_finalized_epoch
     };
 
-    debug!(?finalized_blkid, %finalized_slot, "loading unfinalized blocks");
+    debug!(?finalized_epoch, "loading unfinalized blocks");
 
-    let mut tracker = UnfinalizedBlockTracker::new_empty(finalized_epoch);
-    tracker
-        .load_unfinalized_blocks(l2man)
+    let l2man_tracker = storage.l2().clone();
+
+    let tracker = tokio::runtime::Handle::current()
+        .spawn_blocking(move || {
+            let mut tracker = UnfinalizedBlockTracker::new_empty(finalized_epoch);
+            tracker
+                .load_unfinalized_blocks(&l2man_tracker)
+                .map(|_| tracker)
+        })
+        .await
+        .map_err(|err| L2SyncError::LoadUnfinalizedFailed(err.to_string()))?
         .map_err(|err| L2SyncError::LoadUnfinalizedFailed(err.to_string()))?;
 
     let tip_block = tracker
         .chain_tip_blocks_iter()
         .max_by_key(|bc| bc.slot())
         .expect("sync: missing init chain tip");
+
+    debug!(?tip_block, "sync state initialized");
 
     let state = L2SyncState { tip_block, tracker };
 

--- a/crates/sync/src/worker.rs
+++ b/crates/sync/src/worker.rs
@@ -139,13 +139,13 @@ async fn do_tick<T: SyncClient>(
         return Ok(());
     };
 
-    if state.has_block(&status.tip_block_id) {
+    if state.has_block(status.tip_block_id()) {
         // in sync with client
         return Ok(());
     }
 
     let start_slot = state.tip_height() + 1;
-    let end_slot = status.tip_height; // remote tip height
+    let end_slot = status.tip_height(); // remote tip height
 
     let span = debug_span!("sync", %start_slot, %end_slot);
 

--- a/crates/sync/src/worker.rs
+++ b/crates/sync/src/worker.rs
@@ -60,18 +60,6 @@ async fn wait_for_clientsate(sync_man: &SyncManager) -> Result<ClientState, L2Sy
 }
 
 async fn wait_for_chainstate(sync_man: &SyncManager) -> Result<Chainstate, L2SyncError> {
-    let mut service_init_rx = sync_man.status_channel().subscribe_service_init();
-
-    // wait for FCM to be initialized. Dont want to start syncing from network while FCM is syncing
-    // up from db.
-    if service_init_rx
-        .wait_for(|s| s.is_fcm_initialized())
-        .await
-        .is_err()
-    {
-        return Err(L2SyncError::ChannelClosed);
-    }
-
     let mut chainstatus_rx = sync_man.status_channel().subscribe_chain_sync();
 
     let chainstate = chainstatus_rx

--- a/functional-tests/tests/sync/sync_fullnode_l2_lag.py
+++ b/functional-tests/tests/sync/sync_fullnode_l2_lag.py
@@ -55,7 +55,7 @@ class SyncFullNodeL2LagTest(testenv.StrataTester):
 
         # Get corresponding checkpoint block
         checkpt_info = seqrpc.strata_getCheckpointInfo(cur_epoch + 3)
-        checkpt_l1_blk_height = checkpt_info["l1_reference"]["block_height"]
+        checkpt_l1_blk_height = checkpt_info["l1_reference"]["l1_commitment"]["height"]
 
         # FN tip after fn catches upto the buried checkpoint, should be the same as before
         new_fn_tip = fnrpc.strata_syncStatus()["tip_height"]

--- a/functional-tests/tests/sync/sync_fullnode_l2_lag.py
+++ b/functional-tests/tests/sync/sync_fullnode_l2_lag.py
@@ -17,8 +17,6 @@ class SyncFullNodeL2LagTest(testenv.StrataTester):
         ctx.set_env(env)
 
     def main(self, ctx: flexitest.RunContext):
-        # TODO: re-enable this after full node sync is fixed
-        return True
         seq = ctx.get_service("seq_node")
         seqrpc = seq.create_rpc()
         fullnode = ctx.get_service("follower_1_node")

--- a/functional-tests/tests/sync/sync_fullnode_l2_lag_restart.py
+++ b/functional-tests/tests/sync/sync_fullnode_l2_lag_restart.py
@@ -1,0 +1,112 @@
+import logging
+
+import flexitest
+
+from envs import testenv
+from utils import *
+
+FOLLOW_DIST = 1
+
+
+@flexitest.register
+class SyncFullNodeL2LagRestartTest(testenv.StrataTester):
+    def __init__(self, ctx: flexitest.InitContext):
+        env = testenv.HubNetworkEnvConfig(
+            110, rollup_settings=RollupParamsSettings.new_default().fast_batch()
+        )
+        ctx.set_env(env)
+
+    def main(self, ctx: flexitest.RunContext):
+        seq = ctx.get_service("seq_node")
+        seqrpc = seq.create_rpc()
+        fullnode = ctx.get_service("follower_1_node")
+        fnrpc = fullnode.create_rpc()
+
+        # Wait until sequencer and fullnode start
+        wait_until(seqrpc.strata_protocolVersion, timeout=5)
+        wait_until(fnrpc.strata_protocolVersion, timeout=5)
+
+        # Pick a recent slot and make sure they're both the same.
+        seqss = seqrpc.strata_syncStatus()
+        check_slot = seqss["tip_height"] - FOLLOW_DIST
+        check_both_at_same_slot(seqrpc, fnrpc, check_slot)
+
+        # Now pause the sync worker so that we can have finalized epoch on L1,
+        # but not corresponding block on L2 in full node
+        paused = fnrpc.debug_pause_resume("SyncWorker", "PauseUntilResume")
+        assert paused, "Should pause the fullnode sync worker"
+
+        cur_epoch = seqss["cur_epoch"]
+        print(dict(cur_epoch=cur_epoch))
+
+        # wait for fn to sync up to end of current sequencer epoch
+        # L1 reader and csm should still be running and syncing with L2 sync paused/
+        wait_until_epoch_confirmed(fnrpc, cur_epoch, timeout=20)
+
+        # Wait until some more epochs are finalized in sequencer so we have plenty of blocks
+        # to sync up when we resume fn
+        wait_until_epoch_finalized(seqrpc, cur_epoch + 3, timeout=20)
+
+        # Full node tip after sync is paused
+        fn_ss = fnrpc.strata_syncStatus()
+        fn_tip = fn_ss["tip_height"]
+
+        # Get corresponding checkpoint block
+        checkpt_info = seqrpc.strata_getCheckpointInfo(cur_epoch + 3)
+        checkpt_l1_blk_height = checkpt_info["l1_reference"]["l1_commitment"]["height"]
+
+        # FN tip after fn catches upto the buried checkpoint, should be the same as before
+        new_fn_tip = fnrpc.strata_syncStatus()["tip_height"]
+        assert fn_tip == new_fn_tip, "Fn tip should not progress while syncing is paused"
+        seq_tip = seqrpc.strata_syncStatus()["tip_height"]
+        assert new_fn_tip < seq_tip, "Fn tip should be less than sequencer tip"
+
+        # stop and restart fullnode
+
+        fullnode.stop()
+
+        fullnode.start()
+
+        # Now check the epoch finalization, it should finalize since full node has resumed l2 sync
+        wait_until_with_value(
+            lambda: (
+                fnrpc.strata_clientStatus()["tip_l1_block"]["height"],
+                seqrpc.strata_clientStatus()["tip_l1_block"]["height"],
+            ),
+            lambda v: v[0] >= checkpt_l1_blk_height,
+            error_with="Fullnode L1 sync did not catch upto buried checkpoint",
+            timeout=10,
+            debug=True,
+        )
+
+        # Let's check that eventually the fullnode syncs with sequencer
+        wait_until(
+            fn_syncs_with_seq(fnrpc, seqrpc),
+            error_with="Full node could not sync with sequencer",
+            timeout=20,
+        )
+
+
+def fn_syncs_with_seq(fnrpc, seqrpc):
+    def _f():
+        fnss = fnrpc.strata_syncStatus()
+        seqss = seqrpc.strata_syncStatus()
+        seq_tip_slot = seqss["tip_height"]
+        fn_tip_slot = fnss["tip_height"]
+
+        logging.info(f"Seq tip slot {seq_tip_slot}, fn tip slot {fn_tip_slot}")
+        return fn_tip_slot == seq_tip_slot
+
+    return _f
+
+
+def check_both_at_same_slot(seqrpc, fnrpc, check_slot):
+    seq_headers = seqrpc.strata_getHeadersAtIdx(check_slot)
+    assert len(seq_headers) > 0, f"seq node missing headers at slot {check_slot}"
+
+    fn_headers = fnrpc.strata_getHeadersAtIdx(check_slot)
+    assert len(fn_headers) > 0, f"follower node missing headers at slot {check_slot}"
+
+    seq_hdr = seq_headers[0]
+    fn_hdr = fn_headers[0]
+    assert seq_hdr == fn_hdr, f"headers mismatched at slot {check_slot}"


### PR DESCRIPTION
## Description
Implementation of #706 invalidated the fix done in #703 regarding fullnode sync and finalization of L2 chain when L1 chain sync is multiple epochs ahead of L2 chain sync. 
This PR fixes the issue by only applying finalization on epochs which are known to be synced on both L1 and L2 chains.

- [X] finalize latest common epoch
- [X] init FCM state correctly
- [x] init L2 Sync worker state correctly

<!--
Provide a brief summary of the changes and the motivation behind them.
-->

### Type of Change

<!--
Select the type of change your PR introduces (put an `x` in all that apply):
-->

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature/Enhancement (non-breaking change which adds functionality or enhances an existing one)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactor
- [ ] New or updated tests
- [ ] Dependency Update

## Notes to Reviewers

<!--
Anything in particular you want to note that will help reviewers fulfill their role
in reviewing this PR?
-->

## Checklist

<!--
Ensure all the following are checked:
-->

- [ ] I have performed a self-review of my code.
- [ ] I have commented my code where necessary.
- [ ] I have updated the documentation if needed.
- [ ] My changes do not introduce new warnings.
- [ ] I have added (where necessary) tests that prove my changes are effective or that my feature works.
- [ ] New and existing tests pass with my changes.

## Related Issues

<!--
Link any related issues (e.g., `closes #123`, `fixes #456`).
-->

depends on checkpoints being correctly saved, fix made in #718
