### PR TITLE
Fix STR-1149: Incorrect state root in L2 block header

### DIFF
--- a/crates/consensus-logic/src/fork_choice_manager.rs
+++ b/crates/consensus-logic/src/fork_choice_manager.rs
@@ -744,7 +744,8 @@ fn apply_blocks(
         debug!(%slot, %blkid, "processing block");
         process_block(&mut prestate_cache, header, body, &rparams)
             .map_err(|e| Error::InvalidStateTsn(blkid, e))?;
-        let (post_state, wb) = prestate_cache.finalize();
+        let wb = prestate_cache.finalize();
+        let post_state = wb.new_toplevel_state();
 
         let post_state_epoch = post_state.cur_epoch();
 
@@ -760,7 +761,7 @@ fn apply_blocks(
             handle_finish_epoch(&blkid, &bundle, prev_epoch_terminal, &post_state, fcm_state)?;
         }
 
-        cur_state = post_state;
+        cur_state = post_state.clone();
 
         // After each application we update the fork choice tip data in case we fail
         // to apply an update.

--- a/crates/state/src/state_op.rs
+++ b/crates/state/src/state_op.rs
@@ -132,14 +132,11 @@ impl StateCache {
         self.write_ops.is_empty()
     }
 
-    /// Finalizes the changes made to the state, exporting it and a write batch
+    /// Finalizes the changes made to the state, exporting it as a write batch
     /// that can be applied to the previous state to produce it.
     // TODO remove extra `Chainstate` return value
-    pub fn finalize(self) -> (Chainstate, WriteBatch) {
-        (
-            self.new_state.clone(),
-            WriteBatch::new(self.new_state, self.write_ops),
-        )
+    pub fn finalize(self) -> WriteBatch {
+        WriteBatch::new(self.new_state, self.write_ops)
     }
 
     // Primitive manipulation functions.


### PR DESCRIPTION
## Description

This attempts to fix the ticket by updating how services listen to new blocks in the update notifications from the status channel.  This also will make the state transition function have access to the previous block's full header.

### Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature/Enhancement (non-breaking change which adds functionality or enhances an existing one)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactor
- [ ] New or updated tests
- [ ] Dependency Update

## Notes to Reviewers

<!--
Anything in particular you want to note that will help reviewers fulfill their role
in reviewing this PR?
-->

## Checklist

<!--
Ensure all the following are checked:
-->

- [ ] I have performed a self-review of my code.
- [ ] I have commented my code where necessary.
- [ ] I have updated the documentation if needed.
- [ ] My changes do not introduce new warnings.
- [ ] I have added (where necessary) tests that prove my changes are effective or that my feature works.
- [ ] New and existing tests pass with my changes.

## Related Issues

- [STR-1149](https://alpenlabs.atlassian.net/browse/STR-1149)