### PR TITLE
Update RECOVER_DELAY per Testnet I requirements

### DIFF
--- a/bin/strata-cli/src/constants.rs
+++ b/bin/strata-cli/src/constants.rs
@@ -4,7 +4,7 @@ use alloy::consensus::constants::ETH_TO_WEI;
 use bdk_wallet::bitcoin::{Amount, Network};
 
 /// Number of blocks after bridge in transaction confirmation that the recovery path can be spent.
-pub const RECOVER_DELAY: u32 = 1008;
+pub const RECOVER_DELAY: u32 = 144;
 
 /// Number of blocks after which we'll actually attempt recovery. This is mostly to account for any
 /// reorgs that may happen at the recovery height.


### PR DESCRIPTION
## Description

<!--
Provide a brief summary of the changes and the motivation behind them.
-->

The timelock on the DRT for the user to take back their funds should be 144 blocks, as per the main requirements.
See also https://github.com/alpenlabs/docs/pull/1#discussion_r1987772614

**This should not be merged before we double check that in all other places we change this as well.**
