### PR TITLE
Flatten checkpoint l1 ref in rpc and fix txid bytes reversal

### DIFF
--- a/functional-tests/tests/sync/sync_from_rpc.py
+++ b/functional-tests/tests/sync/sync_from_rpc.py
@@ -16,6 +16,7 @@ class SyncFromRpcTest(testenv.StrataTester):
 
     def main(self, ctx: flexitest.RunContext):
         seqrpc = ctx.get_service("seq_node").create_rpc()
+        btcrpc = ctx.get_service("bitcoin").create_rpc()
         fnrpc = ctx.get_service("follower_1_node").create_rpc()
         seq_reth_rpc = ctx.get_service("seq_reth").create_rpc()
         fullnode_reth_rpc = ctx.get_service("follower_1_reth").create_rpc()
@@ -73,3 +74,14 @@ class SyncFromRpcTest(testenv.StrataTester):
 
         assert fn_checkpt_info["l1_reference"] == sq_checkpt_info["l1_reference"]
         assert fn_checkpt_info["confirmation_status"] == sq_checkpt_info["confirmation_status"]
+
+        # Check l1_reference txid and blockids are actually present in bitcoin
+        txid = fn_checkpt_info["l1_reference"]["txid"]
+        txdata = btcrpc.proxy.gettransaction(txid)
+        assert txdata["confirmations"] > 0
+
+        blkid = fn_checkpt_info["l1_reference"]["block_id"]
+        blkheight = fn_checkpt_info["l1_reference"]["block_height"]
+        blkdata = btcrpc.proxy.getblock(blkid)
+        assert blkdata["confirmations"] > 0
+        assert blkheight > 0

--- a/functional-tests/tests/sync/sync_fullnode_l2_lag.py
+++ b/functional-tests/tests/sync/sync_fullnode_l2_lag.py
@@ -53,7 +53,7 @@ class SyncFullNodeL2LagTest(testenv.StrataTester):
 
         # Get corresponding checkpoint block
         checkpt_info = seqrpc.strata_getCheckpointInfo(cur_epoch + 3)
-        checkpt_l1_blk_height = checkpt_info["l1_reference"]["l1_commitment"]["height"]
+        checkpt_l1_blk_height = checkpt_info["l1_reference"]["block_height"]
 
         # FN tip after fn catches upto the buried checkpoint, should be the same as before
         new_fn_tip = fnrpc.strata_syncStatus()["tip_height"]

--- a/functional-tests/tests/sync/sync_fullnode_l2_lag_restart.py
+++ b/functional-tests/tests/sync/sync_fullnode_l2_lag_restart.py
@@ -53,7 +53,7 @@ class SyncFullNodeL2LagRestartTest(testenv.StrataTester):
 
         # Get corresponding checkpoint block
         checkpt_info = seqrpc.strata_getCheckpointInfo(cur_epoch + 3)
-        checkpt_l1_blk_height = checkpt_info["l1_reference"]["l1_commitment"]["height"]
+        checkpt_l1_blk_height = checkpt_info["l1_reference"]["block_height"]
 
         # FN tip after fn catches upto the buried checkpoint, should be the same as before
         new_fn_tip = fnrpc.strata_syncStatus()["tip_height"]


### PR DESCRIPTION
## Description

This PR adds a new `RpcCheckpointL1Ref` type that flattens the values in the actual `CheckpointL1Ref` type and also uses `Txid`, `Wtxid` and `BlockHash` instead of `Buf32` in the actual type so that those are properly represented as string by rpc clients.

### Type of Change

<!--
Select the type of change your PR introduces (put an `x` in all that apply):
-->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature/Enhancement (non-breaking change which adds functionality or enhances an existing one)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactor
- [ ] New or updated tests
- [ ] Dependency Update

## Notes to Reviewers

<!--
Anything in particular you want to note that will help reviewers fulfill their role
in reviewing this PR?
-->

## Checklist

<!--
Ensure all the following are checked:
-->

- [ ] I have performed a self-review of my code.
- [ ] I have commented my code where necessary.
- [ ] I have updated the documentation if needed.
- [ ] My changes do not introduce new warnings.
- [ ] I have added (where necessary) tests that prove my changes are effective or that my feature works.
- [ ] New and existing tests pass with my changes.

## Related Issues

<!--
Link any related issues (e.g., `closes #123`, `fixes #456`).
-->
