### PR TITLE
STR-1149 fix stateroot in l2 block

### DIFF
--- a/bin/strata-client/src/el_sync.rs
+++ b/bin/strata-client/src/el_sync.rs
@@ -33,13 +33,13 @@ pub fn sync_chainstate_to_el(
 
     // last idx of chainstate whose corresponding block is present in el
     let sync_from_idx = find_last_match((earliest_idx, latest_idx), |idx| {
-        let Some(chain_state) = chainstate_manager.get_toplevel_chainstate_blocking(idx)? else {
+        let Some((_chain_state, tip_blockid)) =
+            chainstate_manager.get_toplevel_chainstate_blocking(idx)?
+        else {
             return Err(Error::MissingChainstate(idx));
         };
 
-        let block_id = chain_state.chain_tip_blkid();
-
-        Ok(engine.check_block_exists(*block_id)?)
+        Ok(engine.check_block_exists(tip_blockid)?)
     })?
     .map(|idx| idx + 1) // sync from next index
     .unwrap_or(0); // sync from genesis
@@ -48,20 +48,20 @@ pub fn sync_chainstate_to_el(
 
     for idx in sync_from_idx..=latest_idx {
         debug!(?idx, "Syncing chainstate");
-        let Some(chain_state) = chainstate_manager.get_toplevel_chainstate_blocking(idx)? else {
+        let Some((_chain_state, tip_blockid)) =
+            chainstate_manager.get_toplevel_chainstate_blocking(idx)?
+        else {
             return Err(Error::MissingChainstate(idx));
         };
 
-        let block_id = chain_state.chain_tip_blkid();
-
-        let Some(l2block) = l2_block_manager.get_block_data_blocking(block_id)? else {
-            return Err(Error::MissingL2Block(*block_id));
+        let Some(l2block) = l2_block_manager.get_block_data_blocking(&tip_blockid)? else {
+            return Err(Error::MissingL2Block(tip_blockid));
         };
 
         let payload = ExecPayloadData::from_l2_block_bundle(&l2block);
 
         engine.submit_payload(payload)?;
-        engine.update_safe_block(*block_id)?;
+        engine.update_safe_block(tip_blockid)?;
     }
 
     Ok(())

--- a/bin/strata-client/src/el_sync.rs
+++ b/bin/strata-client/src/el_sync.rs
@@ -33,13 +33,11 @@ pub fn sync_chainstate_to_el(
 
     // last idx of chainstate whose corresponding block is present in el
     let sync_from_idx = find_last_match((earliest_idx, latest_idx), |idx| {
-        let Some((_chain_state, tip_blockid)) =
-            chainstate_manager.get_toplevel_chainstate_blocking(idx)?
-        else {
+        let Some(entry) = chainstate_manager.get_toplevel_chainstate_blocking(idx)? else {
             return Err(Error::MissingChainstate(idx));
         };
 
-        Ok(engine.check_block_exists(tip_blockid)?)
+        Ok(engine.check_block_exists(*entry.tip_blockid())?)
     })?
     .map(|idx| idx + 1) // sync from next index
     .unwrap_or(0); // sync from genesis
@@ -48,20 +46,21 @@ pub fn sync_chainstate_to_el(
 
     for idx in sync_from_idx..=latest_idx {
         debug!(?idx, "Syncing chainstate");
-        let Some((_chain_state, tip_blockid)) =
-            chainstate_manager.get_toplevel_chainstate_blocking(idx)?
+        let Some(chainstate_entry) = chainstate_manager.get_toplevel_chainstate_blocking(idx)?
         else {
             return Err(Error::MissingChainstate(idx));
         };
 
-        let Some(l2block) = l2_block_manager.get_block_data_blocking(&tip_blockid)? else {
-            return Err(Error::MissingL2Block(tip_blockid));
+        let tip_blockid = chainstate_entry.tip_blockid();
+
+        let Some(l2block) = l2_block_manager.get_block_data_blocking(tip_blockid)? else {
+            return Err(Error::MissingL2Block(*tip_blockid));
         };
 
         let payload = ExecPayloadData::from_l2_block_bundle(&l2block);
 
         engine.submit_payload(payload)?;
-        engine.update_safe_block(tip_blockid)?;
+        engine.update_safe_block(*tip_blockid)?;
     }
 
     Ok(())

--- a/bin/strata-client/src/extractor.rs
+++ b/bin/strata-client/src/extractor.rs
@@ -601,8 +601,7 @@ mod tests {
         let base_input = UpdateInput::new(0, vec![], Buf32::zero(), vec![]);
         let exec_state = ExecEnvState::from_base_input(base_input, Buf32::zero());
 
-        let l2_block_id = L2BlockId::from(Buf32::zero());
-        let gdata = GenesisStateData::new(l2_block_id, l1_state, operator_table, exec_state);
+        let gdata = GenesisStateData::new(l1_state, operator_table, exec_state);
 
         let mut empty_chain_state = Chainstate::from_genesis(&gdata);
 

--- a/bin/strata-client/src/extractor.rs
+++ b/bin/strata-client/src/extractor.rs
@@ -238,7 +238,6 @@ mod tests {
             BitcoinAmount, DepositRequestInfo, HeaderVerificationState, L1BlockId, L1BlockManifest,
             L1HeaderRecord, L1Tx, L1TxProof, OutputRef, RawBitcoinTx, XOnlyPk,
         },
-        l2::L2BlockId,
     };
     use strata_rocksdb::{test_utils::get_rocksdb_tmp_instance, L1Db};
     use strata_state::{

--- a/bin/strata-client/src/main.rs
+++ b/bin/strata-client/src/main.rs
@@ -250,7 +250,7 @@ fn do_startup_checks(
         err => err?,
     };
 
-    let Some(last_chain_state) = storage
+    let Some((last_chain_state, tip_blockid)) = storage
         .chainstate()
         .get_toplevel_chainstate_blocking(last_state_idx)?
     else {
@@ -275,8 +275,8 @@ fn do_startup_checks(
     }
 
     // Check that tip L2 block exists (and engine can be connected to)
-    let chain_tip = last_chain_state.chain_tip_blkid();
-    match engine.check_block_exists(*chain_tip) {
+    let chain_tip = tip_blockid;
+    match engine.check_block_exists(chain_tip) {
         Ok(true) => {
             info!("startup: last l2 block is synced")
         }

--- a/bin/strata-client/src/main.rs
+++ b/bin/strata-client/src/main.rs
@@ -250,13 +250,14 @@ fn do_startup_checks(
         err => err?,
     };
 
-    let Some((last_chain_state, tip_blockid)) = storage
+    let Some(last_chain_state_entry) = storage
         .chainstate()
         .get_toplevel_chainstate_blocking(last_state_idx)?
     else {
         anyhow::bail!("Missing chain state idx: {last_state_idx}");
     };
 
+    let (last_chain_state, tip_blockid) = last_chain_state_entry.to_parts();
     // Check that we can connect to bitcoin client and block we believe to be matured in L1 is
     // actually present
     let safe_l1blockid = last_chain_state.l1_view().safe_block().blkid();

--- a/bin/strata-client/src/rpc_server.rs
+++ b/bin/strata-client/src/rpc_server.rs
@@ -146,7 +146,7 @@ impl StrataRpcImpl {
 
 fn conv_blk_header_to_rpc(blk_header: &impl L2Header) -> RpcBlockHeader {
     RpcBlockHeader {
-        block_idx: blk_header.blockidx(),
+        block_idx: blk_header.slot(),
         timestamp: blk_header.timestamp(),
         block_id: *blk_header.get_blockid().as_ref(),
         prev_block: *blk_header.parent().as_ref(),
@@ -281,7 +281,7 @@ impl StrataApiServer for StrataRpcImpl {
             let l2_blk = self.fetch_l2_block_ok(&cur_blkid).await?;
             output.push(conv_blk_header_to_rpc(l2_blk.header()));
             cur_blkid = *l2_blk.header().parent();
-            if l2_blk.header().blockidx() == 0 || Buf32::from(cur_blkid).is_zero() {
+            if l2_blk.header().slot() == 0 || Buf32::from(cur_blkid).is_zero() {
                 break;
             }
         }
@@ -298,7 +298,7 @@ impl StrataApiServer for StrataRpcImpl {
 
         // check the tip idx
         let tip_block = self.fetch_l2_block_ok(tip_blkid).await?;
-        let tip_idx = tip_block.header().blockidx();
+        let tip_idx = tip_block.header().slot();
 
         if idx > tip_idx {
             return Ok(None);
@@ -410,7 +410,7 @@ impl StrataApiServer for StrataRpcImpl {
     async fn get_cl_block_witness_raw(&self, blkid: L2BlockId) -> RpcResult<Vec<u8>> {
         let l2_blk_bundle = self.fetch_l2_block_ok(&blkid).await?;
 
-        let prev_slot = l2_blk_bundle.block().header().header().blockidx() - 1;
+        let prev_slot = l2_blk_bundle.block().header().header().slot() - 1;
 
         let chain_state = self
             .storage

--- a/crates/btcio/src/reader/query.rs
+++ b/crates/btcio/src/reader/query.rs
@@ -502,28 +502,28 @@ mod test {
     /// Used to populate recent blocks in reader state.
     const N_RECENT_BLOCKS: usize = 10;
 
-    fn get_reader_ctx(chs: Chainstate, cls: ClientState) -> ReaderContext<TestBitcoinClient> {
-        let mut gen = ArbitraryGenerator::new();
-        let l1status: L1Status = gen.generate();
-        let css = ChainSyncStatusUpdate::new_transitional(Arc::new(chs.clone()));
-        let status_channel = StatusChannel::new(cls, l1status, Some(css));
-        let params = Arc::new(gen_params());
-        let config = Arc::new(ReaderConfig::default());
-        let client = Arc::new(TestBitcoinClient::new(1));
+    // fn get_reader_ctx(chs: Chainstate, cls: ClientState) -> ReaderContext<TestBitcoinClient> {
+    //     let mut gen = ArbitraryGenerator::new();
+    //     let l1status: L1Status = gen.generate();
+    //     let css = ChainSyncStatusUpdate::new(Arc::new(chs.clone()));
+    //     let status_channel = StatusChannel::new(cls, l1status, Some(css));
+    //     let params = Arc::new(gen_params());
+    //     let config = Arc::new(ReaderConfig::default());
+    //     let client = Arc::new(TestBitcoinClient::new(1));
 
-        let (rbdb, db_ops) = get_rocksdb_tmp_instance().unwrap();
-        let db = init_core_dbs(rbdb, db_ops);
-        let pool = ThreadPool::new(1);
-        let storage = Arc::new(create_node_storage(db, pool).unwrap());
-        ReaderContext {
-            storage,
-            config,
-            status_channel,
-            params,
-            client,
-            seq_pubkey: None,
-        }
-    }
+    //     let (rbdb, db_ops) = get_rocksdb_tmp_instance().unwrap();
+    //     let db = init_core_dbs(rbdb, db_ops);
+    //     let pool = ThreadPool::new(1);
+    //     let storage = Arc::new(create_node_storage(db, pool).unwrap());
+    //     ReaderContext {
+    //         storage,
+    //         config,
+    //         status_channel,
+    //         params,
+    //         client,
+    //         seq_pubkey: None,
+    //     }
+    // }
 
     // Get reader state with provided recent blocks
     fn get_reader_state(

--- a/crates/btcio/src/reader/query.rs
+++ b/crates/btcio/src/reader/query.rs
@@ -485,45 +485,14 @@ pub async fn fetch_verification_state(
 #[cfg(test)]
 mod test {
     use bitcoin::{hashes::Hash, params::REGTEST};
-    use strata_primitives::{buf::Buf32, l1::L1Status};
-    use strata_rocksdb::{init_core_dbs, test_utils::get_rocksdb_tmp_instance};
-    use strata_state::{chain_state::Chainstate, client_state::ClientState};
-    use strata_status::ChainSyncStatusUpdate;
-    use strata_storage::create_node_storage;
-    use strata_test_utils::{l2::gen_params, ArbitraryGenerator};
-    use threadpool::ThreadPool;
+    use strata_primitives::buf::Buf32;
+    use strata_test_utils::ArbitraryGenerator;
 
     use super::*;
     use crate::test_utils::{
         corepc_node_helpers::{get_bitcoind_and_client, mine_blocks},
         TestBitcoinClient,
     };
-
-    /// Used to populate recent blocks in reader state.
-    const N_RECENT_BLOCKS: usize = 10;
-
-    // fn get_reader_ctx(chs: Chainstate, cls: ClientState) -> ReaderContext<TestBitcoinClient> {
-    //     let mut gen = ArbitraryGenerator::new();
-    //     let l1status: L1Status = gen.generate();
-    //     let css = ChainSyncStatusUpdate::new(Arc::new(chs.clone()));
-    //     let status_channel = StatusChannel::new(cls, l1status, Some(css));
-    //     let params = Arc::new(gen_params());
-    //     let config = Arc::new(ReaderConfig::default());
-    //     let client = Arc::new(TestBitcoinClient::new(1));
-
-    //     let (rbdb, db_ops) = get_rocksdb_tmp_instance().unwrap();
-    //     let db = init_core_dbs(rbdb, db_ops);
-    //     let pool = ThreadPool::new(1);
-    //     let storage = Arc::new(create_node_storage(db, pool).unwrap());
-    //     ReaderContext {
-    //         storage,
-    //         config,
-    //         status_channel,
-    //         params,
-    //         client,
-    //         seq_pubkey: None,
-    //     }
-    // }
 
     // Get reader state with provided recent blocks
     fn get_reader_state(

--- a/crates/chaintsn/src/context.rs
+++ b/crates/chaintsn/src/context.rs
@@ -1,0 +1,21 @@
+//! Interfaces to expose the context in which a block is being validated.
+
+use strata_state::{header::L2BlockHeader, id::L2BlockId};
+
+/// Provider for context about the block in the chain.
+///
+/// Does NOT provide access to chainstate information.  This is primarily
+/// involving block headers.  It will probably also provide L1 manifests.
+pub trait BlockContext {
+    /// Returns the slot that we're checking.
+    fn slot(&self) -> u64;
+
+    /// Returns the unix millis timestamp of the block.
+    fn timestamp(&self) -> u64;
+
+    /// Returns the parent block's ID.
+    fn parent_blkid(&self) -> &L2BlockId;
+
+    /// Returns the parent block's header.
+    fn parent_header(&self) -> &L2BlockHeader;
+}

--- a/crates/chaintsn/src/errors.rs
+++ b/crates/chaintsn/src/errors.rs
@@ -11,6 +11,9 @@ pub enum TsnError {
     #[error("mismatch parent (head {0:?}, parent {1:?}")]
     MismatchParent(L2BlockId, L2BlockId),
 
+    #[error("mismatch epoch (block {0}, expected {1}")]
+    MismatchEpoch(u64, u64),
+
     #[error("attested mismatched ID for {0} (set {1}, computed {2})")]
     L1BlockIdMismatch(u64, L1BlockId, L1BlockId),
 

--- a/crates/chaintsn/src/lib.rs
+++ b/crates/chaintsn/src/lib.rs
@@ -1,5 +1,6 @@
 //! Rollup chain state transition.
 
+pub mod context;
 pub mod errors;
 pub mod slot_rng;
 pub mod transition;

--- a/crates/chaintsn/src/transition.rs
+++ b/crates/chaintsn/src/transition.rs
@@ -52,7 +52,7 @@ pub fn process_block(
 ) -> Result<(), TsnError> {
     // We want to fail quickly here because otherwise we don't know what's
     // happening.
-    if !state.is_empty() {
+    if !state.is_empty() && state.original_state() == state.state() {
         panic!("transition: state cache not fresh");
     }
 
@@ -63,6 +63,7 @@ pub fn process_block(
     let tip_slot = state.state().chain_tip_slot();
     state.set_slot(header.slot());
     state.set_prev_block(L2BlockCommitment::new(tip_slot, *header.parent()));
+    advance_epoch_tracking(state)?;
 
     // Go through each stage and play out the operations it has.
     let has_new_epoch = process_l1_view_update(state, body.l1_segment(), params)?;
@@ -71,7 +72,7 @@ pub fn process_block(
 
     // If we checked in with L1, then advance the epoch.
     if has_new_epoch {
-        advance_epoch_tracking(state, header)?;
+        state.mark_epoch_finishing(true);
     }
 
     Ok(())
@@ -224,12 +225,18 @@ fn process_deposit_spent(state: &mut StateCache, info: &DepositSpendInfo) -> Res
     Ok(())
 }
 
-/// Advances the epoch bookkeeping, using the provided header as the terminal.
-fn advance_epoch_tracking(state: &mut StateCache, header: &impl L2Header) -> Result<(), TsnError> {
+/// Advances the epoch bookkeeping, if this is first slot of new epoch.
+fn advance_epoch_tracking(state: &mut StateCache) -> Result<(), TsnError> {
+    if !state.should_finish_epoch() {
+        return Ok(());
+    }
+
+    let prev_block = state.state().prev_block();
     let cur_epoch = state.state().cur_epoch();
-    let this_epoch = EpochCommitment::new(cur_epoch, header.slot(), header.get_blockid());
-    state.set_prev_epoch(this_epoch);
+    let ended_epoch = EpochCommitment::new(cur_epoch, prev_block.slot(), *prev_block.blkid());
+    state.set_prev_epoch(ended_epoch);
     state.set_cur_epoch(cur_epoch + 1);
+    state.mark_epoch_finishing(false);
     Ok(())
 }
 

--- a/crates/chaintsn/src/transition.rs
+++ b/crates/chaintsn/src/transition.rs
@@ -64,6 +64,12 @@ pub fn process_block(
     state.set_slot(header.slot());
     state.set_prev_block(L2BlockCommitment::new(tip_slot, *header.parent()));
     advance_epoch_tracking(state)?;
+    if state.state().cur_epoch() != header.epoch() {
+        return Err(TsnError::MismatchEpoch(
+            header.epoch(),
+            state.state().cur_epoch(),
+        ));
+    }
 
     // Go through each stage and play out the operations it has.
     let has_new_epoch = process_l1_view_update(state, body.l1_segment(), params)?;

--- a/crates/consensus-logic/src/csm/client_transition.rs
+++ b/crates/consensus-logic/src/csm/client_transition.rs
@@ -12,7 +12,7 @@ use strata_primitives::{
 };
 use strata_state::{
     block::{self, L2BlockBundle},
-    chain_state::Chainstate,
+    chain_state::{Chainstate, ChainstateEntry},
     client_state::*,
     header::L2Header,
     id::L2BlockId,
@@ -69,7 +69,7 @@ impl EventContext for StorageEventContext<'_> {
         self.storage
             .chainstate()
             .get_toplevel_chainstate_blocking(slot)?
-            .map(|(chainstate, _)| chainstate)
+            .map(Into::into)
             .ok_or(Error::MissingIdxChainstate(slot))
     }
 }

--- a/crates/consensus-logic/src/csm/client_transition.rs
+++ b/crates/consensus-logic/src/csm/client_transition.rs
@@ -69,6 +69,7 @@ impl EventContext for StorageEventContext<'_> {
         self.storage
             .chainstate()
             .get_toplevel_chainstate_blocking(slot)?
+            .map(|(chainstate, _)| chainstate)
             .ok_or(Error::MissingIdxChainstate(slot))
     }
 }

--- a/crates/consensus-logic/src/csm/client_transition.rs
+++ b/crates/consensus-logic/src/csm/client_transition.rs
@@ -23,7 +23,7 @@ use strata_storage::NodeStorage;
 use tracing::*;
 use zkaleido::ProofReceipt;
 
-use crate::{checkpoint_verification::verify_checkpoint, errors::*, genesis::make_genesis_block};
+use crate::{checkpoint_verification::verify_checkpoint, errors::*, genesis::make_l2_genesis};
 
 /// Interface for external context necessary specifically for event validation.
 pub trait EventContext {
@@ -137,9 +137,10 @@ fn handle_block(
         state.activate_chain();
 
         // Also have to set this.
-        let genesis_block = make_genesis_block(params);
+        let pregenesis_mfs = vec![block_mf.clone()];
+        let (genesis_block, _) = make_l2_genesis(params, pregenesis_mfs);
         state.set_sync_state(SyncState::from_genesis_blkid(
-            genesis_block.header().get_blockid(),
+            genesis_block.block().header().get_blockid(),
         ));
 
         state.push_action(SyncAction::L2Genesis(*block.blkid()));
@@ -410,9 +411,11 @@ mod tests {
             .get_verification_state(genesis + 1, reorg_safe_depth)
             .unwrap();
 
-        let genesis_block = genesis::make_genesis_block(&params);
-        let genesis_blockid = genesis_block.header().get_blockid();
         let l1_chain = chain.get_header_records(horizon, 10).unwrap();
+
+        let pregenesis_mfs = chain.get_block_manifests(genesis, 1).unwrap();
+        let (genesis_block, _) = genesis::make_l2_genesis(&params, pregenesis_mfs);
+        let genesis_blockid = genesis_block.header().get_blockid();
 
         let l1_blocks = l1_chain
             .iter()

--- a/crates/consensus-logic/src/errors.rs
+++ b/crates/consensus-logic/src/errors.rs
@@ -75,6 +75,9 @@ pub enum Error {
     #[error("checkpoint invalid: {0}")]
     InvalidCheckpoint(#[from] CheckpointError),
 
+    #[error("stateroot mismatch")]
+    StaterootMismatch,
+
     #[error("chaintip: {0}")]
     ChainTip(#[from] ChainTipError),
 

--- a/crates/consensus-logic/src/fork_choice_manager.rs
+++ b/crates/consensus-logic/src/fork_choice_manager.rs
@@ -832,11 +832,11 @@ fn apply_blocks(
             "fcm: nonsensical post-state epoch (pre={pre_state_epoch}, post={post_state_epoch})"
         );
 
-        assert_eq!(
-            &post_state.compute_state_root(),
-            header.state_root(),
-            "state root mismatch"
-        );
+        let post_stateroot = post_state.compute_state_root();
+        if header.state_root() != &post_stateroot {
+            warn!(block = %header.state_root(), chain = %post_stateroot, "stateroot mismatch");
+            Err(Error::StaterootMismatch)?
+        }
 
         // If we advanced the epoch then we have to finish it.
         let is_terminal = post_state.is_epoch_finishing();

--- a/crates/consensus-logic/src/fork_choice_manager.rs
+++ b/crates/consensus-logic/src/fork_choice_manager.rs
@@ -861,7 +861,7 @@ fn apply_blocks(
     // Apply all the write batches.
     let chsman = fcm_state.storage.chainstate();
     for (block, wb) in updates {
-        chsman.put_write_batch_blocking(block.slot(), wb, *last_block.blkid())?;
+        chsman.put_write_batch_blocking(block.slot(), wb, *block.blkid())?;
     }
 
     // Update the tip block in the FCM state.

--- a/crates/consensus-logic/src/fork_choice_manager.rs
+++ b/crates/consensus-logic/src/fork_choice_manager.rs
@@ -105,7 +105,7 @@ impl ForkChoiceManager {
         let block = self
             .get_block_data(blkid)?
             .ok_or(Error::MissingL2Block(*blkid))?;
-        Ok(block.header().blockidx())
+        Ok(block.header().slot())
     }
 
     fn get_block_chainstate(
@@ -286,7 +286,7 @@ fn determine_start_tip(
         .get_block_data_blocking(best)?
         .ok_or(Error::MissingL2Block(*best))?
         .header()
-        .blockidx();
+        .slot();
 
     // Iterate through the remaining elements and choose.
     for blkid in iter {
@@ -294,7 +294,7 @@ fn determine_start_tip(
             .get_block_data_blocking(blkid)?
             .ok_or(Error::MissingL2Block(*best))?
             .header()
-            .blockidx();
+            .slot();
 
         if blkid_slot == best_slot && blkid < best {
             best = blkid;
@@ -484,7 +484,7 @@ fn process_fc_message(
                 .get_block_data(&blkid)?
                 .ok_or(Error::MissingL2Block(blkid))?;
 
-            let slot = block_bundle.header().blockidx();
+            let slot = block_bundle.header().slot();
             info!(%slot, %blkid, "processing new block");
 
             let ok = match handle_new_block(fcm_state, &blkid, &block_bundle, engine) {
@@ -538,7 +538,7 @@ fn handle_new_block(
     bundle: &L2BlockBundle,
     engine: &impl ExecEngineCtl,
 ) -> anyhow::Result<bool> {
-    let slot = bundle.header().blockidx();
+    let slot = bundle.header().slot();
 
     // First, decide if the block seems correctly signed and we haven't
     // already marked it as invalid.
@@ -644,7 +644,7 @@ fn check_new_block(
     let params = state.params.as_ref();
 
     // If it's not the genesis block, check that the block is correctly signed.
-    if block.header().blockidx() > 0 {
+    if block.header().slot() > 0 {
         let cred_ok =
             strata_state::block_validation::check_block_credential(block.header(), params.rollup());
         if !cred_ok {
@@ -696,7 +696,7 @@ fn pick_best_block<'t>(
         let best_header = best_block.header();
         let other_header = other_block.header();
 
-        if other_header.blockidx() > best_header.blockidx() {
+        if other_header.slot() > best_header.slot() {
             best_tip = other_tip;
             best_block = other_block;
         }
@@ -804,7 +804,7 @@ fn apply_blocks(
             .get_block_data(&blkid)?
             .ok_or(Error::MissingL2Block(blkid))?;
 
-        let slot = bundle.header().blockidx();
+        let slot = bundle.header().slot();
         let header = bundle.header();
         let body = bundle.body();
         let block = L2BlockCommitment::new(slot, blkid);
@@ -820,7 +820,8 @@ fn apply_blocks(
         debug!(%slot, %blkid, "processing block");
         process_block(&mut prestate_cache, header, body, &rparams)
             .map_err(|e| Error::InvalidStateTsn(blkid, e))?;
-        let (post_state, wb) = prestate_cache.finalize();
+        let wb = prestate_cache.finalize();
+        let post_state = wb.new_toplevel_state();
 
         let post_state_epoch = post_state.cur_epoch();
 
@@ -836,7 +837,7 @@ fn apply_blocks(
             handle_finish_epoch(&blkid, &bundle, prev_epoch_terminal, &post_state, fcm_state)?;
         }
 
-        cur_state = post_state;
+        cur_state = post_state.clone();
 
         // After each application we update the fork choice tip data in case we fail
         // to apply an update.
@@ -884,7 +885,7 @@ fn handle_finish_epoch(
     let new_epoch = post_state.cur_epoch();
     let prev_epoch_idx = new_epoch - 1;
 
-    let slot = bundle.header().blockidx();
+    let slot = bundle.header().slot();
     let terminal = L2BlockCommitment::new(slot, *blkid);
 
     // Sanity checks.

--- a/crates/consensus-logic/src/fork_choice_manager.rs
+++ b/crates/consensus-logic/src/fork_choice_manager.rs
@@ -543,7 +543,7 @@ fn handle_new_block(
     // First, decide if the block seems correctly signed and we haven't
     // already marked it as invalid.
     let chstate = fcm_state.cur_chainstate.as_ref();
-    let correctly_signed = check_new_block(blkid, bundle, chstate, fcm_state)?;
+    let correctly_signed = check_new_block(blkid, bundle.block(), chstate, fcm_state)?;
     if !correctly_signed {
         // It's invalid, write that and return.
         return Ok(false);
@@ -834,7 +834,7 @@ fn apply_blocks(
         // If we advanced the epoch then we have to finish it.
         let is_terminal = post_state_epoch == pre_state_epoch + 1;
         if is_terminal {
-            handle_finish_epoch(&blkid, &bundle, prev_epoch_terminal, &post_state, fcm_state)?;
+            handle_finish_epoch(&blkid, &bundle, prev_epoch_terminal, post_state, fcm_state)?;
         }
 
         cur_state = post_state.clone();

--- a/crates/consensus-logic/src/genesis.rs
+++ b/crates/consensus-logic/src/genesis.rs
@@ -63,7 +63,9 @@ pub fn init_genesis_chainstate(
     let gchstate = make_genesis_chainstate(&gblock, pregenesis_mfs, params);
 
     // Now insert things into the database.
-    storage.chainstate().write_genesis_state(gchstate.clone())?;
+    storage
+        .chainstate()
+        .write_genesis_state(gchstate.clone(), gblock.header().get_blockid())?;
     storage.l2().put_block_data_blocking(gblock)?;
     // TODO: Status channel should probably be updated.
 
@@ -142,8 +144,6 @@ pub fn make_genesis_chainstate(
     pregenesis_mfs: Vec<L1BlockManifest>,
     params: &Params,
 ) -> Chainstate {
-    let genesis_blkid = gblock.header().get_blockid();
-
     let geui = gblock.exec_segment().update().input();
     let gees =
         ExecEnvState::from_base_input(geui.clone(), params.rollup.evm_genesis_block_state_root);
@@ -168,7 +168,7 @@ pub fn make_genesis_chainstate(
     );
 
     let optbl = construct_operator_table(&params.rollup().operator_config);
-    let gdata = GenesisStateData::new(genesis_blkid, l1vs, optbl, gees);
+    let gdata = GenesisStateData::new(l1vs, optbl, gees);
     Chainstate::from_genesis(&gdata)
 }
 

--- a/crates/consensus-logic/src/genesis.rs
+++ b/crates/consensus-logic/src/genesis.rs
@@ -166,17 +166,6 @@ fn make_genesis_block(params: &Params) -> L2BlockBundle {
     L2BlockBundle::new(block, accessory)
 }
 
-fn make_block_from_parts(
-    header: L2BlockHeader,
-    sig: Buf64,
-    body: L2BlockBody,
-    accessory: L2BlockAccessory,
-) -> L2BlockBundle {
-    let signed_genesis_header = SignedL2BlockHeader::new(header, sig);
-    let block = L2Block::new(signed_genesis_header, body);
-    L2BlockBundle::new(block, accessory)
-}
-
 fn make_genesis_chainstate(
     gblock: &L2BlockBundle,
     pregenesis_mfs: Vec<L1BlockManifest>,

--- a/crates/consensus-logic/src/unfinalized_tracker.rs
+++ b/crates/consensus-logic/src/unfinalized_tracker.rs
@@ -133,9 +133,9 @@ impl UnfinalizedBlockTracker {
         let parent_blkid = header.parent();
 
         if let Some(parent_ent) = self.pending_table.get_mut(parent_blkid) {
-            if header.blockidx() <= parent_ent.slot {
+            if header.slot() <= parent_ent.slot {
                 return Err(ChainTipError::ChildBeforeParent(
-                    header.blockidx(),
+                    header.slot(),
                     parent_ent.slot,
                 ));
             }
@@ -146,7 +146,7 @@ impl UnfinalizedBlockTracker {
         }
 
         let ent = BlockEntry {
-            slot: header.blockidx(),
+            slot: header.slot(),
             parent: *header.parent(),
             children: HashSet::new(),
         };
@@ -472,7 +472,7 @@ mod tests {
             .get_block_data_blocking(&prev_finalized_tip)
             .expect("test: load block")
             .expect("test: missing block");
-        let prev_tip_slot = prev_tip.header().blockidx();
+        let prev_tip_slot = prev_tip.header().slot();
 
         let epoch = EpochCommitment::new(0, prev_tip_slot, prev_finalized_tip);
         let mut chain_tracker = unfinalized_tracker::UnfinalizedBlockTracker::new_empty(epoch);
@@ -483,7 +483,7 @@ mod tests {
             .get_block_data_blocking(&new_finalized_tip)
             .expect("test: load block")
             .expect("test: missing block");
-        let new_tip_slot = new_tip.header().blockidx();
+        let new_tip_slot = new_tip.header().slot();
 
         let new_epoch = EpochCommitment::new(1, new_tip_slot, new_finalized_tip);
         let report = chain_tracker.update_finalized_epoch(&new_epoch).unwrap();

--- a/crates/db/src/stubs/chain_state.rs
+++ b/crates/db/src/stubs/chain_state.rs
@@ -1,15 +1,14 @@
 use std::collections::*;
 
 use parking_lot::Mutex;
-use strata_state::{chain_state::Chainstate, id::L2BlockId, state_op::WriteBatch};
+use strata_state::{chain_state::Chainstate, id::L2BlockId, state_op::WriteBatchEntry};
 use tracing::*;
 
 use crate::{errors::DbError, traits::*, DbResult};
 
 struct InnerState {
-    write_batches: BTreeMap<u64, WriteBatch>,
+    write_batches: BTreeMap<u64, WriteBatchEntry>,
     toplevels: BTreeMap<u64, Chainstate>,
-    blocks: BTreeMap<u64, L2BlockId>,
 }
 
 impl InnerState {
@@ -17,7 +16,6 @@ impl InnerState {
         Self {
             write_batches: BTreeMap::new(),
             toplevels: BTreeMap::new(),
-            blocks: BTreeMap::new(),
         }
     }
 
@@ -48,14 +46,13 @@ impl StubChainstateDb {
 }
 
 impl ChainstateDatabase for StubChainstateDb {
-    fn write_genesis_state(&self, toplevel: Chainstate, blockid: L2BlockId) -> DbResult<()> {
+    fn write_genesis_state(&self, toplevel: Chainstate, _blockid: L2BlockId) -> DbResult<()> {
         let mut st = self.state.lock();
         st.toplevels.insert(0, toplevel.clone());
-        st.blocks.insert(0, blockid);
         Ok(())
     }
 
-    fn put_write_batch(&self, idx: u64, batch: WriteBatch, blockid: L2BlockId) -> DbResult<()> {
+    fn put_write_batch(&self, idx: u64, batch: WriteBatchEntry) -> DbResult<()> {
         let mut st = self.state.lock();
 
         let last_idx = st.find_last_write_batch();
@@ -71,8 +68,8 @@ impl ChainstateDatabase for StubChainstateDb {
 
         // Compute new state and insert things.
         st.write_batches.insert(idx, batch.clone());
-        st.toplevels.insert(idx, batch.into_toplevel());
-        st.blocks.insert(idx, blockid);
+        let (wb, _blockid) = batch.to_parts();
+        st.toplevels.insert(idx, wb.into_toplevel());
 
         Ok(())
     }
@@ -151,12 +148,8 @@ impl ChainstateDatabase for StubChainstateDb {
         Ok(idx)
     }
 
-    fn get_write_batch(&self, idx: u64) -> DbResult<Option<(WriteBatch, L2BlockId)>> {
+    fn get_write_batch(&self, idx: u64) -> DbResult<Option<WriteBatchEntry>> {
         let st = self.state.lock();
-        Ok(st
-            .write_batches
-            .get(&idx)
-            .cloned()
-            .map(|wb| (wb, st.blocks.get(&idx).cloned().expect("exists"))))
+        Ok(st.write_batches.get(&idx).cloned())
     }
 }

--- a/crates/db/src/stubs/l2.rs
+++ b/crates/db/src/stubs/l2.rs
@@ -35,7 +35,7 @@ impl StubL2Db {
 impl L2BlockDatabase for StubL2Db {
     fn put_block_data(&self, bundle: L2BlockBundle) -> DbResult<()> {
         let blkid = bundle.block().header().get_blockid();
-        let idx = bundle.block().header().blockidx();
+        let idx = bundle.block().header().slot();
 
         {
             let mut tbl = self.blocks.lock();

--- a/crates/db/src/traits.rs
+++ b/crates/db/src/traits.rs
@@ -13,7 +13,7 @@ use strata_primitives::{
 };
 use strata_state::{
     block::L2BlockBundle, bridge_duties::BridgeDutyStatus, chain_state::Chainstate, operation::*,
-    state_op::WriteBatch, sync_event::SyncEvent,
+    state_op::WriteBatchEntry, sync_event::SyncEvent,
 };
 use zkaleido::ProofReceipt;
 
@@ -195,10 +195,10 @@ pub trait ChainstateDatabase {
     /// Stores a write batch in the database, possibly computing that state
     /// under the hood from the writes.  Will not overwrite existing data,
     /// previous writes must be purged first in order to be replaced.
-    fn put_write_batch(&self, idx: u64, batch: WriteBatch, blockid: L2BlockId) -> DbResult<()>;
+    fn put_write_batch(&self, idx: u64, batch: WriteBatchEntry) -> DbResult<()>;
 
     /// Gets the write batch stored to compute a height.
-    fn get_write_batch(&self, idx: u64) -> DbResult<Option<(WriteBatch, L2BlockId)>>;
+    fn get_write_batch(&self, idx: u64) -> DbResult<Option<WriteBatchEntry>>;
 
     /// Tells the database to purge state before a certain index.
     fn purge_entries_before(&self, before_idx: u64) -> DbResult<()>;

--- a/crates/db/src/traits.rs
+++ b/crates/db/src/traits.rs
@@ -190,15 +190,15 @@ pub enum BlockStatus {
 // TODO maybe rewrite this around storing write batches according to blkid?
 pub trait ChainstateDatabase {
     /// Writes the genesis chainstate at index 0.
-    fn write_genesis_state(&self, toplevel: Chainstate) -> DbResult<()>;
+    fn write_genesis_state(&self, toplevel: Chainstate, blockid: L2BlockId) -> DbResult<()>;
 
     /// Stores a write batch in the database, possibly computing that state
     /// under the hood from the writes.  Will not overwrite existing data,
     /// previous writes must be purged first in order to be replaced.
-    fn put_write_batch(&self, idx: u64, batch: WriteBatch) -> DbResult<()>;
+    fn put_write_batch(&self, idx: u64, batch: WriteBatch, blockid: L2BlockId) -> DbResult<()>;
 
     /// Gets the write batch stored to compute a height.
-    fn get_write_batch(&self, idx: u64) -> DbResult<Option<WriteBatch>>;
+    fn get_write_batch(&self, idx: u64) -> DbResult<Option<(WriteBatch, L2BlockId)>>;
 
     /// Tells the database to purge state before a certain index.
     fn purge_entries_before(&self, before_idx: u64) -> DbResult<()>;

--- a/crates/primitives/src/l2.rs
+++ b/crates/primitives/src/l2.rs
@@ -24,6 +24,18 @@ pub struct L2BlockId(Buf32);
 
 impl_buf_wrapper!(L2BlockId, Buf32, 32);
 
+impl L2BlockId {
+    /// Returns a dummy blkid that is all zeroes.
+    pub fn null() -> Self {
+        Self::from(Buf32::zero())
+    }
+
+    /// Checks to see if this is the dummy "zero" blkid.
+    pub fn is_null(&self) -> bool {
+        self.0.is_zero()
+    }
+}
+
 /// Commits to a specific block at some slot.
 #[derive(
     Copy,

--- a/crates/proof-impl/cl-stf/src/lib.rs
+++ b/crates/proof-impl/cl-stf/src/lib.rs
@@ -161,7 +161,8 @@ pub fn process_cl_stf(zkvm: &impl ZkVmEnv, el_vkey: &[u32; 8], btc_blockscan_vke
     };
 
     // 12. Get the final chainstate and construct the output
-    let (final_chain_state, _) = state_cache.finalize();
+    let wb = state_cache.finalize();
+    let final_chain_state = wb.into_toplevel();
     let final_chainstate_root = final_chain_state.compute_state_root();
 
     let output = ClStfOutput {

--- a/crates/proof-impl/cl-stf/src/lib.rs
+++ b/crates/proof-impl/cl-stf/src/lib.rs
@@ -68,7 +68,7 @@ pub fn process_cl_stf(zkvm: &impl ZkVmEnv, el_vkey: &[u32; 8], btc_blockscan_vke
             l2_block.exec_segment(),
             &exec_segment,
             "mismatch between exec segment at height {:?}",
-            l2_block.header().blockidx()
+            l2_block.header().slot()
         );
 
         // 7. Verify that the L1 manifests are consistent with the one that was proven

--- a/crates/rocksdb-store/src/chain_state/db.rs
+++ b/crates/rocksdb-store/src/chain_state/db.rs
@@ -114,6 +114,7 @@ impl ChainstateDatabase for ChainstateDb {
         let mut del_batch = SchemaBatch::new();
         for idx in first_idx..before_idx {
             del_batch.delete::<WriteBatchSchema>(&idx)?;
+            del_batch.delete::<ChainSchema>(&idx)?;
         }
         self.db.write_schemas(del_batch)?;
 
@@ -144,6 +145,7 @@ impl ChainstateDatabase for ChainstateDb {
         let mut del_batch = SchemaBatch::new();
         for idx in new_tip_idx + 1..=last_idx {
             del_batch.delete::<WriteBatchSchema>(&idx)?;
+            del_batch.delete::<ChainSchema>(&idx)?;
         }
         self.db.write_schemas(del_batch)?;
 

--- a/crates/rocksdb-store/src/chain_state/schemas.rs
+++ b/crates/rocksdb-store/src/chain_state/schemas.rs
@@ -1,4 +1,4 @@
-use strata_state::state_op::WriteBatch;
+use strata_state::{id::L2BlockId, state_op::WriteBatch};
 
 use crate::{define_table_with_seek_key_codec, define_table_without_codec, impl_borsh_value_codec};
 
@@ -6,4 +6,10 @@ use crate::{define_table_with_seek_key_codec, define_table_without_codec, impl_b
 define_table_with_seek_key_codec!(
     /// Table to store client states.
     (WriteBatchSchema) u64 => WriteBatch
+);
+
+// L2 chain blocks as processed by chain state.
+define_table_with_seek_key_codec!(
+    /// Table to store known L2 Chain.
+    (ChainSchema) u64 => L2BlockId
 );

--- a/crates/rocksdb-store/src/chain_state/schemas.rs
+++ b/crates/rocksdb-store/src/chain_state/schemas.rs
@@ -1,15 +1,9 @@
-use strata_state::{id::L2BlockId, state_op::WriteBatch};
+use strata_state::state_op::WriteBatchEntry;
 
 use crate::{define_table_with_seek_key_codec, define_table_without_codec, impl_borsh_value_codec};
 
 // Consensus State Schema and corresponding codecs implementation
 define_table_with_seek_key_codec!(
     /// Table to store client states.
-    (WriteBatchSchema) u64 => WriteBatch
-);
-
-// L2 chain blocks as processed by chain state.
-define_table_with_seek_key_codec!(
-    /// Table to store known L2 Chain.
-    (ChainSchema) u64 => L2BlockId
+    (WriteBatchSchema) u64 => WriteBatchEntry
 );

--- a/crates/rocksdb-store/src/l2/db.rs
+++ b/crates/rocksdb-store/src/l2/db.rs
@@ -27,7 +27,7 @@ impl L2BlockDatabase for L2Db {
         let block_id = bundle.block().header().get_blockid();
 
         // append to previous block height data
-        let block_height = bundle.block().header().blockidx();
+        let block_height = bundle.block().header().slot();
 
         self.db
             .with_optimistic_txn(
@@ -57,7 +57,7 @@ impl L2BlockDatabase for L2Db {
         };
 
         // update to previous block height data
-        let block_height = bundle.block().header().blockidx();
+        let block_height = bundle.block().header().slot();
         let mut block_height_data = self.get_blocks_at_height(block_height)?;
         block_height_data.retain(|&block_id| block_id != id);
 
@@ -131,7 +131,7 @@ mod tests {
 
         let bundle = get_mock_data();
         let block_hash = bundle.block().header().get_blockid();
-        let block_height = bundle.block().header().blockidx();
+        let block_height = bundle.block().header().slot();
 
         l2_db
             .put_block_data(bundle.clone())
@@ -163,7 +163,7 @@ mod tests {
         let l2_db = setup_db();
         let bundle = get_mock_data();
         let block_hash = bundle.block().header().get_blockid();
-        let block_height = bundle.block().header().blockidx();
+        let block_height = bundle.block().header().slot();
 
         // deleting non existing block should return false
         let res = l2_db

--- a/crates/rocksdb-store/src/lib.rs
+++ b/crates/rocksdb-store/src/lib.rs
@@ -55,7 +55,7 @@ pub use writer::db::RBL1WriterDb;
 use writer::schemas::{IntentIdxSchema, IntentSchema, PayloadSchema};
 
 use crate::{
-    chain_state::schemas::WriteBatchSchema,
+    chain_state::schemas::{ChainSchema, WriteBatchSchema},
     client_state::schemas::ClientUpdateOutputSchema,
     l1::schemas::{
         L1BlockSchema, L1BlocksByHeightSchema, L1CanonicalBlockSchema, MmrSchema, TxnSchema,
@@ -81,6 +81,7 @@ pub const STORE_COLUMN_FAMILIES: &[ColumnFamilyName] = &[
     L2BlockStatusSchema::COLUMN_FAMILY_NAME,
     L2BlockHeightSchema::COLUMN_FAMILY_NAME,
     WriteBatchSchema::COLUMN_FAMILY_NAME,
+    ChainSchema::COLUMN_FAMILY_NAME,
 
     // Payload/intent schemas
     PayloadSchema::COLUMN_FAMILY_NAME,

--- a/crates/rocksdb-store/src/lib.rs
+++ b/crates/rocksdb-store/src/lib.rs
@@ -55,7 +55,7 @@ pub use writer::db::RBL1WriterDb;
 use writer::schemas::{IntentIdxSchema, IntentSchema, PayloadSchema};
 
 use crate::{
-    chain_state::schemas::{ChainSchema, WriteBatchSchema},
+    chain_state::schemas::WriteBatchSchema,
     client_state::schemas::ClientUpdateOutputSchema,
     l1::schemas::{
         L1BlockSchema, L1BlocksByHeightSchema, L1CanonicalBlockSchema, MmrSchema, TxnSchema,
@@ -81,7 +81,6 @@ pub const STORE_COLUMN_FAMILIES: &[ColumnFamilyName] = &[
     L2BlockStatusSchema::COLUMN_FAMILY_NAME,
     L2BlockHeightSchema::COLUMN_FAMILY_NAME,
     WriteBatchSchema::COLUMN_FAMILY_NAME,
-    ChainSchema::COLUMN_FAMILY_NAME,
 
     // Payload/intent schemas
     PayloadSchema::COLUMN_FAMILY_NAME,

--- a/crates/sequencer/src/block_template/block_assembly.rs
+++ b/crates/sequencer/src/block_template/block_assembly.rs
@@ -28,7 +28,7 @@ use super::error::BlockAssemblyError as Error;
 
 /// Get the total gas used by EL blocks from start of current epoch till prev_slot
 fn get_total_gas_used_in_epoch(storage: &NodeStorage, prev_slot: u64) -> Result<u64, Error> {
-    let chainstate = storage
+    let (chainstate, _) = storage
         .chainstate()
         .get_toplevel_chainstate_blocking(prev_slot)?
         .ok_or(Error::Db(DbError::MissingL2State(prev_slot)))?;
@@ -80,8 +80,7 @@ pub fn prepare_block(
     let (prev_chstate, _) = chsman
         .get_toplevel_chainstate_blocking(prev_slot)?
         .ok_or(Error::MissingBlockChainstate(prev_blkid))?;
-    let epoch = prev_chstate.cur_epoch();
-    let first_block_of_epoch = prev_chstate.prev_epoch().last_slot() + 1 == slot;
+    let first_block_of_epoch = prev_chstate.is_epoch_finishing();
 
     // Figure out the safe L1 blkid.
     // FIXME this is somewhat janky, should get it from the MMR

--- a/crates/sequencer/src/block_template/block_assembly.rs
+++ b/crates/sequencer/src/block_template/block_assembly.rs
@@ -28,10 +28,11 @@ use super::error::BlockAssemblyError as Error;
 
 /// Get the total gas used by EL blocks from start of current epoch till prev_slot
 fn get_total_gas_used_in_epoch(storage: &NodeStorage, prev_slot: u64) -> Result<u64, Error> {
-    let (chainstate, _) = storage
+    let chainstate = storage
         .chainstate()
         .get_toplevel_chainstate_blocking(prev_slot)?
-        .ok_or(Error::Db(DbError::MissingL2State(prev_slot)))?;
+        .ok_or(Error::Db(DbError::MissingL2State(prev_slot)))?
+        .to_chainstate();
 
     let epoch_start_slot = chainstate.prev_epoch().last_slot() + 1;
     let mut gas_used = 0;
@@ -77,9 +78,10 @@ pub fn prepare_block(
     // TODO make this get the prev block slot from somewhere more reliable in
     // case we skip slots
     let prev_slot = prev_block.header().slot();
-    let (prev_chstate, _) = chsman
+    let prev_chstate = chsman
         .get_toplevel_chainstate_blocking(prev_slot)?
-        .ok_or(Error::MissingBlockChainstate(prev_blkid))?;
+        .ok_or(Error::MissingBlockChainstate(prev_blkid))?
+        .to_chainstate();
     let first_block_of_epoch = prev_chstate.is_epoch_finishing();
 
     // Figure out the safe L1 blkid.

--- a/crates/sequencer/src/block_template/block_assembly.rs
+++ b/crates/sequencer/src/block_template/block_assembly.rs
@@ -77,7 +77,7 @@ pub fn prepare_block(
     // TODO make this get the prev block slot from somewhere more reliable in
     // case we skip slots
     let prev_slot = prev_block.header().slot();
-    let prev_chstate = chsman
+    let (prev_chstate, _) = chsman
         .get_toplevel_chainstate_blocking(prev_slot)?
         .ok_or(Error::MissingBlockChainstate(prev_blkid))?;
     let epoch = prev_chstate.cur_epoch();

--- a/crates/sequencer/src/block_template/block_assembly.rs
+++ b/crates/sequencer/src/block_template/block_assembly.rs
@@ -120,10 +120,15 @@ pub fn prepare_block(
     )?;
 
     // Assemble the body and fake header.
-    let block_epoch = prev_chstate.cur_epoch(); // FIXME make this consistent
+    let epoch = if first_block_of_epoch {
+        prev_chstate.cur_epoch() + 1
+    } else {
+        prev_chstate.cur_epoch()
+    };
+
     let body = L2BlockBody::new(l1_seg, exec_seg);
     let fake_stateroot = Buf32::zero();
-    let fake_header = L2BlockHeader::new(slot, block_epoch, ts, prev_blkid, &body, fake_stateroot);
+    let fake_header = L2BlockHeader::new(slot, epoch, ts, prev_blkid, &body, fake_stateroot);
 
     // Execute the block to compute the new state root, then assemble the real header.
     // TODO do something with the write batch?  to prepare it in the database?
@@ -132,7 +137,7 @@ pub fn prepare_block(
     // FIXME: invalid stateroot. Remove l2blockid from ChainState or stateroot from L2Block header.
     let new_state_root = post_state.compute_state_root();
 
-    let header = L2BlockHeader::new(slot, block_epoch, ts, prev_blkid, &body, new_state_root);
+    let header = L2BlockHeader::new(slot, epoch, ts, prev_blkid, &body, new_state_root);
 
     Ok((header, body, block_acc))
 }

--- a/crates/sequencer/src/block_template/worker.rs
+++ b/crates/sequencer/src/block_template/worker.rs
@@ -203,7 +203,7 @@ fn generate_block_template_inner(
     // TODO get and use chainstate
 
     // next slot idx
-    let slot = parent.header().blockidx() + 1;
+    let slot = parent.header().slot() + 1;
 
     // next block timestamp
     let ts = config.ts().unwrap_or_else(now_millis);

--- a/crates/sequencer/src/checkpoint/worker.rs
+++ b/crates/sequencer/src/checkpoint/worker.rs
@@ -272,13 +272,13 @@ fn create_checkpoint_prep_data_from_summary(
 
     // Initial state is the state before applying the first block
     let initial_state_height = first_block.slot() - 1;
-    let initial_state = chsman
+    let (initial_state, _) = chsman
         .get_toplevel_chainstate_blocking(initial_state_height)?
         .ok_or(Error::MissingIdxChainstate(initial_state_height))?;
     let l2_initial_state = initial_state.compute_state_root();
 
     let final_state_height = last_block.slot();
-    let final_state = chsman
+    let (final_state, _) = chsman
         .get_toplevel_chainstate_blocking(final_state_height)?
         .ok_or(Error::MissingIdxChainstate(final_state_height))?;
     let l2_final_state = final_state.compute_state_root();

--- a/crates/sequencer/src/checkpoint/worker.rs
+++ b/crates/sequencer/src/checkpoint/worker.rs
@@ -267,17 +267,17 @@ fn create_checkpoint_prep_data_from_summary(
     let first_block = l2_blocks.first().unwrap();
     let last_block = l2_blocks.last().unwrap();
     let initial_l2_commitment =
-        L2BlockCommitment::new(first_block.blockidx(), first_block.get_blockid());
+        L2BlockCommitment::new(first_block.slot(), first_block.get_blockid());
     let l2_range = (initial_l2_commitment, *summary.terminal());
 
     // Initial state is the state before applying the first block
-    let initial_state_height = first_block.blockidx() - 1;
+    let initial_state_height = first_block.slot() - 1;
     let initial_state = chsman
         .get_toplevel_chainstate_blocking(initial_state_height)?
         .ok_or(Error::MissingIdxChainstate(initial_state_height))?;
     let l2_initial_state = initial_state.compute_state_root();
 
-    let final_state_height = last_block.blockidx();
+    let final_state_height = last_block.slot();
     let final_state = chsman
         .get_toplevel_chainstate_blocking(final_state_height)?
         .ok_or(Error::MissingIdxChainstate(final_state_height))?;
@@ -380,7 +380,7 @@ fn fetch_epoch_l2_headers(
 
         // If we're at the first block we can just exit.
         // Checkpoint 0 range starts from block 1.
-        if cur.blockidx() == 1 {
+        if cur.slot() == 1 {
             break;
         }
 

--- a/crates/sequencer/src/checkpoint/worker.rs
+++ b/crates/sequencer/src/checkpoint/worker.rs
@@ -272,15 +272,17 @@ fn create_checkpoint_prep_data_from_summary(
 
     // Initial state is the state before applying the first block
     let initial_state_height = first_block.slot() - 1;
-    let (initial_state, _) = chsman
+    let initial_state = chsman
         .get_toplevel_chainstate_blocking(initial_state_height)?
-        .ok_or(Error::MissingIdxChainstate(initial_state_height))?;
+        .ok_or(Error::MissingIdxChainstate(initial_state_height))?
+        .to_chainstate();
     let l2_initial_state = initial_state.compute_state_root();
 
     let final_state_height = last_block.slot();
-    let (final_state, _) = chsman
+    let final_state = chsman
         .get_toplevel_chainstate_blocking(final_state_height)?
-        .ok_or(Error::MissingIdxChainstate(final_state_height))?;
+        .ok_or(Error::MissingIdxChainstate(final_state_height))?
+        .to_chainstate();
     let l2_final_state = final_state.compute_state_root();
 
     let mut tx_filters = TxFilterConfig::derive_from(params)

--- a/crates/state/src/block.rs
+++ b/crates/state/src/block.rs
@@ -1,5 +1,3 @@
-use std::ops::Deref;
-
 use arbitrary::Arbitrary;
 use borsh::{BorshDeserialize, BorshSerialize};
 use serde::{Deserialize, Serialize};
@@ -16,10 +14,10 @@ use crate::{
 pub struct L2Block {
     /// Header that links the block into the L2 block chain and carries the
     /// block's credential from a sequencer.
-    header: SignedL2BlockHeader,
+    pub(crate) header: SignedL2BlockHeader,
 
     /// Body that contains the bulk of the data.
-    body: L2BlockBody,
+    pub(crate) body: L2BlockBody,
 }
 
 impl L2Block {
@@ -41,6 +39,12 @@ impl L2Block {
 
     pub fn exec_segment(&self) -> &ExecSegment {
         &self.body.exec_segment
+    }
+
+    pub fn into_parts(self) -> (SignedL2BlockHeader, L2BlockBody) {
+        let Self { header, body } = self;
+
+        (header, body)
     }
 }
 
@@ -206,6 +210,28 @@ impl L2BlockBundle {
     pub fn accessory(&self) -> &L2BlockAccessory {
         &self.accessory
     }
+
+    pub fn header(&self) -> &SignedL2BlockHeader {
+        self.block.header()
+    }
+
+    pub fn body(&self) -> &L2BlockBody {
+        self.block.body()
+    }
+
+    pub fn l1_segment(&self) -> &L1Segment {
+        self.block.l1_segment()
+    }
+
+    pub fn exec_segment(&self) -> &ExecSegment {
+        self.block.exec_segment()
+    }
+
+    pub fn into_parts(self) -> (L2Block, L2BlockAccessory) {
+        let Self { block, accessory } = self;
+
+        (block, accessory)
+    }
 }
 
 impl From<L2BlockBundle> for L2Block {
@@ -214,13 +240,6 @@ impl From<L2BlockBundle> for L2Block {
     }
 }
 
-impl Deref for L2BlockBundle {
-    type Target = L2Block;
-
-    fn deref(&self) -> &Self::Target {
-        &self.block
-    }
-}
 #[cfg(test)]
 mod tests {
     use strata_test_utils::ArbitraryGenerator;

--- a/crates/state/src/block.rs
+++ b/crates/state/src/block.rs
@@ -49,12 +49,12 @@ impl L2Block {
 impl<'a> Arbitrary<'a> for L2Block {
     fn arbitrary(u: &mut arbitrary::Unstructured<'a>) -> arbitrary::Result<Self> {
         let body = L2BlockBody::arbitrary(u)?;
-        let idx = u64::arbitrary(u)?;
+        let slot = u64::arbitrary(u)?;
+        let epoch = u64::arbitrary(u)?;
         let ts = u64::arbitrary(u)?;
         let prev = L2BlockId::from(Buf32::zero());
         let sr = Buf32::arbitrary(u)?;
-        let epoch = u64::arbitrary(u)?;
-        let header = L2BlockHeader::new(idx, epoch, ts, prev, &body, sr);
+        let header = L2BlockHeader::new(slot, epoch, ts, prev, &body, sr);
         let signed_header = SignedL2BlockHeader::new(header, Buf64::arbitrary(u)?);
         Ok(Self::new(signed_header, body))
     }

--- a/crates/state/src/chain_state.rs
+++ b/crates/state/src/chain_state.rs
@@ -1,3 +1,5 @@
+// use std::ops::Deref;
+
 use arbitrary::Arbitrary;
 use borsh::{BorshDeserialize, BorshSerialize};
 use strata_primitives::{
@@ -144,6 +146,37 @@ impl Chainstate {
         &self.exec_env_state
     }
 }
+
+// #[derive(Clone, Debug, Eq, PartialEq, BorshSerialize, BorshDeserialize)]
+// pub struct CommittedChainstate {
+//     blockid: L2BlockId,
+//     chainstate: Chainstate,
+// }
+
+// impl CommittedChainstate {
+//     pub fn new(chainstate: Chainstate, blockid: L2BlockId) -> Self {
+//         Self {
+//             chainstate,
+//             blockid,
+//         }
+//     }
+
+//     pub fn chain_tip_blkid(&self) -> &L2BlockId {
+//         &self.blockid
+//     }
+
+//     pub fn chainstate(&self) -> &Chainstate {
+//         &self.chainstate
+//     }
+// }
+
+// impl Deref for CommittedChainstate {
+//     type Target = Chainstate;
+
+//     fn deref(&self) -> &Self::Target {
+//         &self.chainstate
+//     }
+// }
 
 /// Hashed Chain State. This is used to compute the state root of the [`Chainstate`]
 // TODO: FIXME: Note that this is used as a temporary solution for the state root calculation

--- a/crates/state/src/chain_state.rs
+++ b/crates/state/src/chain_state.rs
@@ -145,38 +145,11 @@ impl Chainstate {
     pub fn exec_env_state(&self) -> &ExecEnvState {
         &self.exec_env_state
     }
+
+    pub fn is_epoch_finishing(&self) -> bool {
+        self.is_epoch_finishing
+    }
 }
-
-// #[derive(Clone, Debug, Eq, PartialEq, BorshSerialize, BorshDeserialize)]
-// pub struct CommittedChainstate {
-//     blockid: L2BlockId,
-//     chainstate: Chainstate,
-// }
-
-// impl CommittedChainstate {
-//     pub fn new(chainstate: Chainstate, blockid: L2BlockId) -> Self {
-//         Self {
-//             chainstate,
-//             blockid,
-//         }
-//     }
-
-//     pub fn chain_tip_blkid(&self) -> &L2BlockId {
-//         &self.blockid
-//     }
-
-//     pub fn chainstate(&self) -> &Chainstate {
-//         &self.chainstate
-//     }
-// }
-
-// impl Deref for CommittedChainstate {
-//     type Target = Chainstate;
-
-//     fn deref(&self) -> &Self::Target {
-//         &self.chainstate
-//     }
-// }
 
 /// Hashed Chain State. This is used to compute the state root of the [`Chainstate`]
 // TODO: FIXME: Note that this is used as a temporary solution for the state root calculation

--- a/crates/state/src/chain_state.rs
+++ b/crates/state/src/chain_state.rs
@@ -184,26 +184,35 @@ impl<'a> Arbitrary<'a> for Chainstate {
     }
 }
 
-#[allow(unused)]
-#[cfg(test)]
-mod tests {
-    //use arbitrary::Unstructured;
+pub struct ChainstateEntry {
+    state: Chainstate,
+    tip: L2BlockId,
+}
 
-    //use super::*;
+impl ChainstateEntry {
+    pub fn new(state: Chainstate, tip: L2BlockId) -> Self {
+        Self { state, tip }
+    }
 
-    // TODO re-enable this test, it's going to be changing a lot so these kinds
-    // of test vectors aren't that useful right now
-    /*#[test]
-    fn test_state_root_calc() {
-        let mut u = Unstructured::new(&[12u8; 50]);
-        let state = Chainstate::arbitrary(&mut u).unwrap();
-        let root = state.state_root();
+    pub fn to_parts(self) -> (Chainstate, L2BlockId) {
+        (self.state, self.tip)
+    }
 
-        let expected = Buf32::from([
-            151, 170, 71, 78, 222, 173, 105, 242, 232, 9, 47, 21, 45, 160, 207, 234, 161, 29, 114,
-            237, 237, 94, 26, 177, 140, 238, 193, 81, 63, 80, 88, 181,
-        ]);
+    pub fn to_chainstate(self) -> Chainstate {
+        self.state
+    }
 
-        assert_eq!(root, expected);
-    }*/
+    pub fn state(&self) -> &Chainstate {
+        &self.state
+    }
+
+    pub fn tip_blockid(&self) -> &L2BlockId {
+        &self.tip
+    }
+}
+
+impl From<ChainstateEntry> for Chainstate {
+    fn from(value: ChainstateEntry) -> Self {
+        value.to_chainstate()
+    }
 }

--- a/crates/state/src/genesis.rs
+++ b/crates/state/src/genesis.rs
@@ -2,13 +2,11 @@
 
 use arbitrary::Arbitrary;
 
-use crate::{bridge_state, exec_env, id::L2BlockId, l1};
+use crate::{bridge_state, exec_env, l1};
 
 /// Genesis data we use to construct the genesis state.
 #[derive(Clone, Debug, Arbitrary)]
 pub struct GenesisStateData {
-    // TODO remove genesis blkid since apparently we don't need it anymore
-    genesis_blkid: L2BlockId,
     l1_state: l1::L1ViewState,
     operator_table: bridge_state::OperatorTable,
     exec_state: exec_env::ExecEnvState,
@@ -16,21 +14,15 @@ pub struct GenesisStateData {
 
 impl GenesisStateData {
     pub fn new(
-        genesis_blkid: L2BlockId,
         l1_state: l1::L1ViewState,
         operator_table: bridge_state::OperatorTable,
         exec_state: exec_env::ExecEnvState,
     ) -> Self {
         Self {
-            genesis_blkid,
             l1_state,
             operator_table,
             exec_state,
         }
-    }
-
-    pub fn genesis_blkid(&self) -> L2BlockId {
-        self.genesis_blkid
     }
 
     pub fn l1_state(&self) -> &l1::L1ViewState {

--- a/crates/state/src/header.rs
+++ b/crates/state/src/header.rs
@@ -216,7 +216,7 @@ impl L2Header for SignedL2BlockHeader {
     }
 
     fn state_root(&self) -> &Buf32 {
-        &self.header.state_root
+        self.header.state_root()
     }
 
     fn get_blockid(&self) -> L2BlockId {

--- a/crates/state/src/header.rs
+++ b/crates/state/src/header.rs
@@ -19,7 +19,6 @@ pub trait L2Header {
     fn exec_payload_hash(&self) -> &Buf32;
     fn state_root(&self) -> &Buf32;
     fn get_blockid(&self) -> L2BlockId;
-    fn epoch(&self) -> u64;
 }
 
 /// Block header that forms the chain we use to reach consensus.
@@ -31,9 +30,6 @@ pub struct L2BlockHeader {
     ///
     /// This is *like* its index, but slots may be skipped.
     pub(crate) slot: u64,
-
-    /// Epoch a block belongs to.
-    pub(crate) epoch: u64,
 
     /// Epoch a block belongs to.
     pub(crate) epoch: u64,
@@ -108,10 +104,6 @@ impl L2Header for L2BlockHeader {
         self.epoch
     }
 
-    fn epoch(&self) -> u64 {
-        self.epoch
-    }
-
     fn timestamp(&self) -> u64 {
         self.timestamp
     }
@@ -144,7 +136,6 @@ fn fill_sighash_buf(tmplt: &L2BlockHeader, buf: &mut [u8]) -> Result<(), io::Err
     cur.write_all(&tmplt.slot.to_be_bytes())?;
     cur.write_all(&tmplt.epoch.to_be_bytes())?;
     cur.write_all(&tmplt.timestamp.to_be_bytes())?;
-    cur.write_all(&tmplt.epoch.to_be_bytes())?;
     cur.write_all(Buf32::from(tmplt.prev_block).as_ref())?;
     cur.write_all(tmplt.l1_segment_hash.as_ref())?;
     cur.write_all(tmplt.exec_segment_hash.as_ref())?;
@@ -193,10 +184,6 @@ impl L2Header for SignedL2BlockHeader {
 
     fn epoch(&self) -> u64 {
         self.header.epoch()
-    }
-
-    fn epoch(&self) -> u64 {
-        self.header.epoch
     }
 
     fn timestamp(&self) -> u64 {

--- a/crates/state/src/state_op.rs
+++ b/crates/state/src/state_op.rs
@@ -193,6 +193,15 @@ impl StateCache {
         state.l1_state.safe_block_header = record;
     }
 
+    pub fn mark_epoch_finishing(&mut self, flag: bool) {
+        let state = self.state_mut();
+        state.is_epoch_finishing = flag;
+    }
+
+    pub fn should_finish_epoch(&self) -> bool {
+        self.state().is_epoch_finishing
+    }
+
     /// Update HeaderVerificationState
     pub fn update_header_vs(
         &mut self,

--- a/crates/state/src/state_op.rs
+++ b/crates/state/src/state_op.rs
@@ -193,7 +193,7 @@ impl StateCache {
         state.l1_state.safe_block_header = record;
     }
 
-    pub fn mark_epoch_finishing(&mut self, flag: bool) {
+    pub fn set_epoch_finishing_flag(&mut self, flag: bool) {
         let state = self.state_mut();
         state.is_epoch_finishing = flag;
     }

--- a/crates/status/src/chain.rs
+++ b/crates/status/src/chain.rs
@@ -53,18 +53,6 @@ impl ChainSyncStatus {
             safe_l1,
         }
     }
-
-    /// Transitional function for as long as we can construct an instance of this
-    /// type from a chainstate.
-    pub fn from_transitional(chs: &Chainstate) -> Self {
-        let tip = L2BlockCommitment::new(chs.chain_tip_slot(), *chs.chain_tip_blkid());
-        Self::new(
-            tip,
-            *chs.prev_epoch(),
-            *chs.finalized_epoch(),
-            chs.l1_view().get_safe_block(),
-        )
-    }
 }
 
 /// Published to the FCM status including chainstate.
@@ -80,13 +68,6 @@ impl ChainSyncStatusUpdate {
             new_status,
             new_tl_chainstate,
         }
-    }
-
-    /// Transitional function for directly constructing the status update from
-    /// the full chainstate.
-    pub fn new_transitional(new_tl_chainstate: Arc<Chainstate>) -> Self {
-        let css = ChainSyncStatus::from_transitional(new_tl_chainstate.as_ref());
-        Self::new(css, new_tl_chainstate)
     }
 
     pub fn new_status(&self) -> ChainSyncStatus {

--- a/crates/status/src/status_manager.rs
+++ b/crates/status/src/status_manager.rs
@@ -6,6 +6,7 @@ use strata_state::{
     bridge_state::{DepositsTable, OperatorTable},
     chain_state::Chainstate,
     client_state::{ClientState, L1Checkpoint, SyncState},
+    id::L2BlockId,
 };
 use thiserror::Error;
 use tokio::sync::watch::{self, error::RecvError};
@@ -97,6 +98,15 @@ impl StatusChannel {
             .borrow()
             .as_ref()
             .map(|css| css.new_tl_chainstate().clone())
+    }
+
+    pub fn get_cur_tip_chainstate_with_block(&self) -> Option<(Arc<Chainstate>, L2BlockId)> {
+        self.receiver.chs.borrow().as_ref().map(|css| {
+            (
+                css.new_tl_chainstate().clone(),
+                *css.new_status().tip_blkid(),
+            )
+        })
     }
 
     /// Gets the latest operator table.

--- a/crates/storage/src/managers/chainstate.rs
+++ b/crates/storage/src/managers/chainstate.rs
@@ -3,14 +3,14 @@
 use std::sync::Arc;
 
 use strata_db::{traits::*, DbResult};
-use strata_state::{chain_state::Chainstate, state_op::WriteBatch};
+use strata_state::{chain_state::Chainstate, id::L2BlockId, state_op::WriteBatch};
 use threadpool::ThreadPool;
 
 use crate::{cache, ops};
 
 pub struct ChainstateManager {
     ops: ops::chainstate::ChainstateOps,
-    wb_cache: cache::CacheTable<u64, Option<WriteBatch>>,
+    wb_cache: cache::CacheTable<u64, Option<(WriteBatch, L2BlockId)>>,
 }
 
 impl ChainstateManager {
@@ -24,33 +24,51 @@ impl ChainstateManager {
 
     /// Writes the genesis state.  This only exists in blocking form because
     /// that's all we need.
-    pub fn write_genesis_state(&self, toplevel: Chainstate) -> DbResult<()> {
-        self.ops.write_genesis_state_blocking(toplevel)
+    pub fn write_genesis_state(
+        &self,
+        toplevel: Chainstate,
+        genesis_blkid: L2BlockId,
+    ) -> DbResult<()> {
+        self.ops
+            .write_genesis_state_blocking(toplevel, genesis_blkid)
     }
 
     /// Stores a new write batch at a particular index.
-    pub async fn put_write_batch_async(&self, idx: u64, wb: WriteBatch) -> DbResult<()> {
-        self.ops.put_write_batch_async(idx, wb).await?;
+    pub async fn put_write_batch_async(
+        &self,
+        idx: u64,
+        wb: WriteBatch,
+        blkid: L2BlockId,
+    ) -> DbResult<()> {
+        self.ops.put_write_batch_async(idx, wb, blkid).await?;
         self.wb_cache.purge(&idx);
         Ok(())
     }
 
     /// Stores a new write batch at a particular index.
-    pub fn put_write_batch_blocking(&self, idx: u64, wb: WriteBatch) -> DbResult<()> {
-        self.ops.put_write_batch_blocking(idx, wb)?;
+    pub fn put_write_batch_blocking(
+        &self,
+        idx: u64,
+        wb: WriteBatch,
+        blkid: L2BlockId,
+    ) -> DbResult<()> {
+        self.ops.put_write_batch_blocking(idx, wb, blkid)?;
         self.wb_cache.purge(&idx);
         Ok(())
     }
 
     /// Gets the writes stored for an index.
-    pub async fn get_write_batch_async(&self, idx: u64) -> DbResult<Option<WriteBatch>> {
+    pub async fn get_write_batch_async(
+        &self,
+        idx: u64,
+    ) -> DbResult<Option<(WriteBatch, L2BlockId)>> {
         self.wb_cache
             .get_or_fetch(&idx, || self.ops.get_write_batch_chan(idx))
             .await
     }
 
     /// Gets the writes stored for an index.
-    pub fn get_write_batch_blocking(&self, idx: u64) -> DbResult<Option<WriteBatch>> {
+    pub fn get_write_batch_blocking(&self, idx: u64) -> DbResult<Option<(WriteBatch, L2BlockId)>> {
         self.wb_cache
             .get_or_fetch_blocking(&idx, || self.ops.get_write_batch_blocking(idx))
     }
@@ -105,18 +123,24 @@ impl ChainstateManager {
 
     /// Convenience function just for extracting the toplevel chainstate from
     /// the write batch at an index.
-    pub async fn get_toplevel_chainstate_async(&self, idx: u64) -> DbResult<Option<Chainstate>> {
+    pub async fn get_toplevel_chainstate_async(
+        &self,
+        idx: u64,
+    ) -> DbResult<Option<(Chainstate, L2BlockId)>> {
         Ok(self
             .get_write_batch_async(idx)
             .await?
-            .map(|wb| wb.into_toplevel()))
+            .map(|(wb, blkid)| (wb.into_toplevel(), blkid)))
     }
 
     /// Convenience function just for extracting the toplevel chainstate from
     /// the write batch at an index.
-    pub fn get_toplevel_chainstate_blocking(&self, idx: u64) -> DbResult<Option<Chainstate>> {
+    pub fn get_toplevel_chainstate_blocking(
+        &self,
+        idx: u64,
+    ) -> DbResult<Option<(Chainstate, L2BlockId)>> {
         Ok(self
             .get_write_batch_blocking(idx)?
-            .map(|wb| wb.into_toplevel()))
+            .map(|(wb, blkid)| (wb.into_toplevel(), blkid)))
     }
 }

--- a/crates/storage/src/ops/chainstate.rs
+++ b/crates/storage/src/ops/chainstate.rs
@@ -3,15 +3,15 @@
 use std::sync::Arc;
 
 use strata_db::traits::*;
-use strata_state::{chain_state::Chainstate, state_op::WriteBatch};
+use strata_state::{chain_state::Chainstate, id::L2BlockId, state_op::WriteBatch};
 
 use crate::exec::*;
 
 inst_ops_simple! {
     (<D: ChainstateDatabase> => ChainstateOps) {
-        write_genesis_state(toplevel: Chainstate) => ();
-        put_write_batch(idx: u64, batch: WriteBatch) => ();
-        get_write_batch(idx: u64) => Option<WriteBatch>;
+        write_genesis_state(toplevel: Chainstate, blockid: L2BlockId) => ();
+        put_write_batch(idx: u64, batch: WriteBatch, blockid: L2BlockId) => ();
+        get_write_batch(idx: u64) => Option<(WriteBatch, L2BlockId)>;
         purge_entries_before(before_idx: u64) => ();
         rollback_writes_to(new_tip_idx: u64) => ();
         get_last_write_idx() => u64;

--- a/crates/storage/src/ops/chainstate.rs
+++ b/crates/storage/src/ops/chainstate.rs
@@ -3,15 +3,15 @@
 use std::sync::Arc;
 
 use strata_db::traits::*;
-use strata_state::{chain_state::Chainstate, id::L2BlockId, state_op::WriteBatch};
+use strata_state::{chain_state::Chainstate, id::L2BlockId, state_op::WriteBatchEntry};
 
 use crate::exec::*;
 
 inst_ops_simple! {
     (<D: ChainstateDatabase> => ChainstateOps) {
         write_genesis_state(toplevel: Chainstate, blockid: L2BlockId) => ();
-        put_write_batch(idx: u64, batch: WriteBatch, blockid: L2BlockId) => ();
-        get_write_batch(idx: u64) => Option<(WriteBatch, L2BlockId)>;
+        put_write_batch(idx: u64, batch: WriteBatchEntry) => ();
+        get_write_batch(idx: u64) => Option<WriteBatchEntry>;
         purge_entries_before(before_idx: u64) => ();
         rollback_writes_to(new_tip_idx: u64) => ();
         get_last_write_idx() => u64;

--- a/crates/sync/src/worker.rs
+++ b/crates/sync/src/worker.rs
@@ -190,14 +190,14 @@ async fn handle_new_block<T: SyncClient>(
 
     loop {
         let block_id = block.header().get_blockid();
-        debug!(block_id = ?block_id, height = block.header().blockidx(), "received new block");
+        debug!(block_id = ?block_id, height = block.header().slot(), "received new block");
 
         if state.has_block(&block_id) {
             warn!(block_id = ?block_id, "block already known");
             return Ok(());
         }
 
-        let height = block.header().blockidx();
+        let height = block.header().slot();
         if height <= state.finalized_height() {
             // got block on different fork than one we're finalized on
             // log error and ignore received blocks
@@ -232,7 +232,7 @@ async fn handle_new_block<T: SyncClient>(
             .l2()
             .put_block_data_async(block.clone())
             .await?;
-        let block_idx = block.header().blockidx();
+        let block_idx = block.header().slot();
         debug!(%block_idx, "l2 sync: sending chain tip msg");
         context
             .sync_manager

--- a/crates/test-utils/src/evm_ee.rs
+++ b/crates/test-utils/src/evm_ee.rs
@@ -139,7 +139,7 @@ impl L2Segment {
                 params.rollup(),
             )
             .unwrap();
-            let (post_state, _) = state_cache.finalize();
+            let post_state = state_cache.finalize().into_toplevel();
             let new_state_root = post_state.compute_state_root();
 
             let header = L2BlockHeader::new(slot, 0, ts, prev_block_id, &body, new_state_root);
@@ -155,7 +155,7 @@ impl L2Segment {
                 params.rollup(),
             )
             .unwrap();
-            let (post_state, _) = state_cache.finalize();
+            let post_state = state_cache.finalize().into_toplevel();
 
             blocks.push(block.clone());
             pre_states.push(pre_state);

--- a/crates/test-utils/src/evm_ee.rs
+++ b/crates/test-utils/src/evm_ee.rs
@@ -124,7 +124,7 @@ impl L2Segment {
             };
             let body = L2BlockBody::new(l1_segment, el_proof_out.clone());
 
-            let slot = prev_block.header().blockidx() + 1;
+            let slot = prev_block.header().slot() + 1;
             let ts = el_proof_in.timestamp;
             let prev_block_id = prev_block.header().get_blockid();
 

--- a/crates/test-utils/src/evm_ee.rs
+++ b/crates/test-utils/src/evm_ee.rs
@@ -1,6 +1,5 @@
 use std::path::PathBuf;
 
-use strata_consensus_logic::genesis::make_genesis_block;
 use strata_primitives::buf::{Buf32, Buf64};
 use strata_proofimpl_evm_ee_stf::{
     primitives::{EvmEeProofInput, EvmEeProofOutput},
@@ -100,8 +99,8 @@ impl L2Segment {
         let mut pre_states = Vec::new();
         let mut post_states = Vec::new();
 
-        let mut prev_block = make_genesis_block(&params).block().clone();
-        let mut prev_chainstate = get_genesis_chainstate();
+        let (prev_block_bundle, mut prev_chainstate) = get_genesis_chainstate(&params);
+        let (mut prev_block, _) = prev_block_bundle.into_parts();
 
         let el_proof_ins = evm_segment.get_inputs();
         let el_proof_outs = evm_segment.get_outputs();

--- a/crates/test-utils/src/l2.rs
+++ b/crates/test-utils/src/l2.rs
@@ -32,7 +32,7 @@ pub fn gen_block(parent: Option<&SignedL2BlockHeader>) -> L2BlockBundle {
         .unwrap()
         .as_millis() as u64;
 
-    let block_idx = parent.map(|h| h.blockidx() + 1).unwrap_or(0);
+    let block_idx = parent.map(|h| h.slot() + 1).unwrap_or(0);
     let prev_block = parent.map(|h| h.get_blockid()).unwrap_or_default();
     let timestamp = parent
         .map(|h| h.timestamp() + 100)

--- a/crates/test-utils/src/l2.rs
+++ b/crates/test-utils/src/l2.rs
@@ -3,7 +3,7 @@ use std::time::{SystemTime, UNIX_EPOCH};
 use bitcoin::secp256k1::{SecretKey, SECP256K1};
 use borsh::to_vec;
 use rand::{rngs::StdRng, SeedableRng};
-use strata_consensus_logic::genesis::{make_genesis_block, make_genesis_chainstate};
+use strata_consensus_logic::genesis::make_l2_genesis;
 use strata_primitives::{
     block_credential,
     buf::Buf64,
@@ -135,13 +135,11 @@ pub fn make_dummy_operator_pubkeys_with_seed(seed: u64) -> OperatorPubkeys {
     OperatorPubkeys::new(pk.into(), pk.into())
 }
 
-pub fn get_genesis_chainstate() -> Chainstate {
-    let params = gen_params();
+pub fn get_genesis_chainstate(params: &Params) -> (L2BlockBundle, Chainstate) {
     let btc_chain = BtcChainSegment::load();
     // Build the genesis block and genesis consensus states.
-    let gblock = make_genesis_block(&params);
     let pregenesis_mfs = vec![btc_chain.get_block_manifest(params.rollup().genesis_l1_height)];
-    make_genesis_chainstate(&gblock, pregenesis_mfs, &params)
+    make_l2_genesis(params, pregenesis_mfs)
 }
 
 pub fn get_test_signed_checkpoint() -> SignedCheckpoint {

--- a/functional-tests/tests/sync/sync_fullnode_l2_lag.py
+++ b/functional-tests/tests/sync/sync_fullnode_l2_lag.py
@@ -93,7 +93,7 @@ def fn_syncs_with_seq(fnrpc, seqrpc):
         fn_tip_slot = fnss["tip_height"]
 
         logging.info(f"Seq tip slot {seq_tip_slot}, fn tip slot {fn_tip_slot}")
-        return fn_tip_slot == seq_tip_slot
+        return fn_tip_slot == seq_tip_slot or seq_tip_slot == fn_tip_slot + 1
 
     return _f
 


### PR DESCRIPTION
## Description
This attempts to fix the ticket by updating how services listen to new blocks in the update notifications from the status channel. This also will make the state transition function have access to the previous block's full header.

Attempt 2

<!--
Provide a brief summary of the changes and the motivation behind them.
-->

### Type of Change

<!--
Select the type of change your PR introduces (put an `x` in all that apply):
-->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature/Enhancement (non-breaking change which adds functionality or enhances an existing one)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactor
- [ ] New or updated tests
- [ ] Dependency Update

## Notes to Reviewers

<!--
Anything in particular you want to note that will help reviewers fulfill their role
in reviewing this PR?
-->

## Checklist

<!--
Ensure all the following are checked:
-->

- [ ] I have performed a self-review of my code.
- [ ] I have commented my code where necessary.
- [ ] I have updated the documentation if needed.
- [ ] My changes do not introduce new warnings.
- [ ] I have added (where necessary) tests that prove my changes are effective or that my feature works.
- [ ] New and existing tests pass with my changes.

## Related Issues

<!--
Link any related issues (e.g., `closes #123`, `fixes #456`).
-->
