### PR TITLE
STR-1170: Add deposit_idx field to DepositInfo and related changes

### DIFF
--- a/bin/strata-client/src/extractor.rs
+++ b/bin/strata-client/src/extractor.rs
@@ -629,7 +629,7 @@ mod tests {
             let tx_ref: OutputRef = arb.generate();
             let amt: BitcoinAmount = arb.generate();
 
-            deposits_table.add_deposit(tx_ref, operators.clone(), amt);
+            deposits_table.create_next_deposit(tx_ref, operators.clone(), amt);
 
             // dispatch about half of the deposits
             let should_dispatch = OsRng.gen_bool(0.5);

--- a/crates/btcio/src/reader/tx_indexer.rs
+++ b/crates/btcio/src/reader/tx_indexer.rs
@@ -128,9 +128,10 @@ mod test {
         let params = gen_params();
         let filter_config = create_tx_filter_config(&params);
         let deposit_config = filter_config.deposit_config.clone();
+        let idx = 0xdeadbeef;
         let ee_addr = vec![1u8; 20]; // Example EVM address
         let deposit_script =
-            build_test_deposit_script(deposit_config.magic_bytes.clone(), ee_addr.clone());
+            build_test_deposit_script(deposit_config.magic_bytes.clone(), idx, ee_addr.clone());
 
         let tx = create_test_deposit_tx(
             Amount::from_sat(deposit_config.deposit_amount),
@@ -146,7 +147,8 @@ mod test {
 
         for op in tx_entries[0].contents().protocol_ops() {
             if let ProtocolOperation::Deposit(deposit_info) = op {
-                assert_eq!(deposit_info.address, ee_addr, "EE address should match");
+                assert_eq!(deposit_info.address, ee_addr, "test: dest should match");
+                assert_eq!(deposit_info.deposit_idx, idx, "test: idx should match");
                 assert_eq!(
                     deposit_info.amt,
                     BitcoinAmount::from_sat(deposit_config.deposit_amount),
@@ -226,13 +228,15 @@ mod test {
         let params = gen_params();
         let filter_config = create_tx_filter_config(&params);
         let deposit_config = filter_config.deposit_config.clone();
+        let idx1 = 0xdeadbeef;
+        let idx2 = 0x1badb007;
         let dest_addr1 = vec![3u8; 20];
         let dest_addr2 = vec![4u8; 20];
 
         let deposit_script1 =
-            build_test_deposit_script(deposit_config.magic_bytes.clone(), dest_addr1.clone());
+            build_test_deposit_script(deposit_config.magic_bytes.clone(), idx1, dest_addr1.clone());
         let deposit_script2 =
-            build_test_deposit_script(deposit_config.magic_bytes.clone(), dest_addr2.clone());
+            build_test_deposit_script(deposit_config.magic_bytes.clone(), idx2, dest_addr2.clone());
 
         let tx1 = create_test_deposit_tx(
             Amount::from_sat(deposit_config.deposit_amount),
@@ -264,17 +268,16 @@ mod test {
                     } else {
                         dest_addr2.clone()
                     },
-                    "EVM address should match for transaction {}",
-                    i
+                    "test: dest should match for transaction {i}",
                 );
+                assert_eq!(deposit_info.idx, [idx1, idx2][i], "test: idx should match");
                 assert_eq!(
                     deposit_info.amt,
                     BitcoinAmount::from_sat(deposit_config.deposit_amount),
-                    "Deposit amount should match for transaction {}",
-                    i
+                    "test: deposit amount should match for transaction {i}",
                 );
             } else {
-                panic!("Expected Deposit info for transaction {}", i);
+                panic!("test: expected DepositInfo for transaction {i}");
             }
         }
     }

--- a/crates/btcio/src/reader/tx_indexer.rs
+++ b/crates/btcio/src/reader/tx_indexer.rs
@@ -270,7 +270,11 @@ mod test {
                     },
                     "test: dest should match for transaction {i}",
                 );
-                assert_eq!(deposit_info.idx, [idx1, idx2][i], "test: idx should match");
+                assert_eq!(
+                    deposit_info.deposit_idx,
+                    [idx1, idx2][i],
+                    "test: idx should match"
+                );
                 assert_eq!(
                     deposit_info.amt,
                     BitcoinAmount::from_sat(deposit_config.deposit_amount),

--- a/crates/btcio/src/reader/tx_indexer.rs
+++ b/crates/btcio/src/reader/tx_indexer.rs
@@ -287,11 +287,12 @@ mod test {
         let params = gen_params();
         let filter_config = create_tx_filter_config(&params);
         let deposit_config = filter_config.deposit_config.clone();
+        let idx = 0xdeadbeef;
         let ee_addr = vec![1u8; 20]; // Example EVM address
 
         // Create deposit utxo
         let deposit_script =
-            build_test_deposit_script(deposit_config.magic_bytes.clone(), ee_addr.clone());
+            build_test_deposit_script(deposit_config.magic_bytes.clone(), idx, ee_addr.clone());
 
         let mut tx = create_test_deposit_tx(
             Amount::from_sat(deposit_config.deposit_amount),

--- a/crates/l1tx/src/deposit/deposit_request.rs
+++ b/crates/l1tx/src/deposit/deposit_request.rs
@@ -53,7 +53,7 @@ pub fn parse_deposit_request_script(
         // helpful.  We shouldn't be emitting a log message for every single tx
         // we see on chain.
         //debug!(?instructions, "missing op_return");
-        return Err(DepositParseError::NoOpReturn);
+        return Err(DepositParseError::MissingTag);
     }
 
     let Some(data) = next_bytes(&mut instructions) else {
@@ -64,40 +64,51 @@ pub fn parse_deposit_request_script(
     // Added a cfg to assert since it feels like it could crash us in
     // production.  I believe this is just a tx standardness policy, not a
     // consensus rule.
+    //
+    // Since it's not a consensus rule, it's a normal error not a panic.
     #[cfg(debug_assertions)]
-    assert!(data.len() < 80);
+    if data.len() > 80 {
+        return Err(DepositParseError::TagOversized);
+    }
 
-    // data has expected magic bytes
+    parse_tag_script(data, config)
+}
+
+fn parse_tag_script(
+    buf: &[u8],
+    config: &DepositTxParams,
+) -> Result<DepositRequestScriptInfo, DepositParseError> {
+    // buf has expected magic bytes
     let magic_bytes = &config.magic_bytes;
     let magic_len = magic_bytes.len();
-    let actual_magic_bytes = &data[..magic_len];
-    if data.len() < magic_len || actual_magic_bytes != magic_bytes {
+    let actual_magic_bytes = &buf[..magic_len];
+    if buf.len() < magic_len || actual_magic_bytes != magic_bytes {
         //debug!(expected_magic_bytes = ?magic_bytes, ?actual_magic_bytes, "mismatched magic
         // bytes");
-        return Err(DepositParseError::MagicBytesMismatch);
+        return Err(DepositParseError::InvalidMagic);
     }
 
     // 32 bytes of control hash
-    let data = &data[magic_len..];
-    if data.len() < 32 {
-        //debug!(?data, expected = 32, got = %data.len(), "incorrect number of bytes in hash");
+    let buf = &buf[magic_len..];
+    if buf.len() < 32 {
+        //debug!(?buf, expected = 32, got = %buf.len(), "incorrect number of bytes in hash");
         return Err(DepositParseError::LeafHashLenMismatch);
     }
-    let ctrl_hash: &[u8; 32] = &data[..32]
+    let ctrl_hash: &[u8; 32] = &buf[..32]
         .try_into()
-        .expect("data length must be greater than 32");
+        .expect("buf length must be greater than 32");
 
     // configured bytes for address
-    let address = &data[32..];
-    if address.len() != config.address_length as usize {
-        // casting is safe as address.len() < data.len() < 80
-        debug!(?data, expected = config.address_length, got = %address.len(), "incorrect number of bytes in address");
-        return Err(DepositParseError::InvalidDestAddress(address.len() as u8));
+    let dest = &buf[32..];
+    if dest.len() != config.address_length as usize {
+        // casting is safe as address.len() < buf.len() < 80
+        debug!(?buf, expected = config.address_length, got = %dest.len(), "incorrect number of bytes in dest");
+        return Err(DepositParseError::InvalidDestLen(dest.len() as u8));
     }
 
     Ok(DepositRequestScriptInfo {
         tap_ctrl_blk_hash: *ctrl_hash,
-        ee_bytes: address.into(),
+        ee_bytes: dest.into(),
     })
 }
 
@@ -163,7 +174,7 @@ mod tests {
         let out = parse_deposit_request_script(&invalid_script, &config);
 
         // Should return an error as there's no OP_RETURN
-        assert!(matches!(out, Err(DepositParseError::NoOpReturn)));
+        assert!(matches!(out, Err(DepositParseError::MissingTag)));
     }
 
     #[test]
@@ -181,7 +192,7 @@ mod tests {
         let out = parse_deposit_request_script(&script, &config);
 
         // Should return an error as EVM address length is invalid
-        assert!(matches!(out, Err(DepositParseError::InvalidDestAddress(_))));
+        assert!(matches!(out, Err(DepositParseError::InvalidDestLen(_))));
     }
 
     #[test]
@@ -218,7 +229,7 @@ mod tests {
         let out = parse_deposit_request_script(&invalid_script, &config);
 
         // Should return an error due to invalid magic bytes
-        assert!(matches!(out, Err(DepositParseError::MagicBytesMismatch)));
+        assert!(matches!(out, Err(DepositParseError::InvalidMagic)));
     }
 
     #[test]

--- a/crates/l1tx/src/deposit/deposit_tx.rs
+++ b/crates/l1tx/src/deposit/deposit_tx.rs
@@ -20,18 +20,19 @@ pub fn extract_deposit_info(tx: &Transaction, config: &DepositTxParams) -> Optio
     // Get the second output (index 1)
     let op_return_out = tx.output.get(1)?;
 
-    // Parse the deposit script from the second output's script_pubkey
-    let ee_address = parse_deposit_script(&op_return_out.script_pubkey, config).ok()?;
-
-    // check if it is exact BRIDGE_DENOMINATION amount
+    // Check if it is exact BRIDGE_DENOMINATION amount
+    // TODO make this not a const!
     if send_addr_out.value.to_sat() != BRIDGE_DENOMINATION.to_sat() {
         return None;
     }
 
-    // check if p2tr address matches
+    // Check if deposit output address matches.
     if send_addr_out.script_pubkey != config.address.address().script_pubkey() {
         return None;
     }
+
+    // Parse the tag from the OP_RETURN output.
+    let tag_data = parse_tag_script(&op_return_out.script_pubkey, config).ok()?;
 
     // Get the first input of the transaction
     let deposit_outpoint = OutputRef::from(OutPoint {
@@ -41,46 +42,79 @@ pub fn extract_deposit_info(tx: &Transaction, config: &DepositTxParams) -> Optio
 
     // Construct and return the DepositInfo
     Some(DepositInfo {
+        deposit_idx: tag_data.deposit_idx,
         amt: send_addr_out.value.into(),
-        address: ee_address.to_vec(),
+        address: tag_data.dest_buf.to_vec(),
         outpoint: deposit_outpoint,
     })
 }
 
+struct DepositTag<'buf> {
+    deposit_idx: u32,
+    dest_buf: &'buf [u8],
+}
+
 /// extracts the EE address given that the script is OP_RETURN type and contains the Magic Bytes
-fn parse_deposit_script<'a>(
+fn parse_tag_script<'a>(
     script: &'a ScriptBuf,
     config: &DepositTxParams,
-) -> Result<&'a [u8], DepositParseError> {
+) -> Result<DepositTag<'a>, DepositParseError> {
     let mut instructions = script.instructions();
 
-    // check if OP_RETURN is present and if not just discard it
+    // Check if OP_RETURN is present and if not just discard it.
     if next_op(&mut instructions) != Some(OP_RETURN) {
-        return Err(DepositParseError::NoOpReturn);
+        return Err(DepositParseError::MissingTag);
     }
 
+    // Extract the data from the next push.
     let Some(data) = next_bytes(&mut instructions) else {
         return Err(DepositParseError::NoData);
     };
 
-    assert!(data.len() < 80);
+    // If it's not a standard tx then something is *probably* up.
+    if data.len() > 80 {
+        return Err(DepositParseError::TagOversized);
+    }
 
+    parse_tag(data, config)
+}
+
+fn parse_tag<'b>(
+    buf: &'b [u8],
+    config: &DepositTxParams,
+) -> Result<DepositTag<'b>, DepositParseError> {
     // data has expected magic bytes
     let magic_bytes = &config.magic_bytes;
     let magic_len = magic_bytes.len();
 
-    if data.len() < magic_len || &data[..magic_len] != magic_bytes {
-        return Err(DepositParseError::MagicBytesMismatch);
+    // Do some math to make sure there is a magic.
+    let exp_min_len = magic_len + 4;
+    if buf.len() < exp_min_len {
+        return Err(DepositParseError::InvalidMagic);
     }
 
-    // configured bytes for address
-    let address = &data[magic_len..];
-    if address.len() != config.address_length as usize {
+    let magic_slice = &buf[..magic_len];
+    if magic_slice != magic_bytes {
+        return Err(DepositParseError::InvalidMagic);
+    }
+
+    // Extract the deposit idx.
+    let di_buf = &buf[magic_len..exp_min_len];
+    let deposit_idx = u32::from_be_bytes([di_buf[0], di_buf[1], di_buf[2], di_buf[3]]);
+
+    // The rest of the buffer is the dest.
+    let dest_buf = &buf[exp_min_len..];
+
+    // TODO make this variable sized
+    if dest_buf.len() != config.address_length as usize {
         // casting is safe as address.len() < data.len() < 80
-        return Err(DepositParseError::InvalidDestAddress(address.len() as u8));
+        return Err(DepositParseError::InvalidDestLen(dest_buf.len() as u8));
     }
 
-    Ok(address)
+    Ok(DepositTag {
+        deposit_idx,
+        dest_buf,
+    })
 }
 
 #[cfg(test)]
@@ -98,10 +132,11 @@ mod tests {
         // values for testing
         let config = get_deposit_tx_config();
         let amt = Amount::from_sat(config.deposit_amount);
+        let idx = 0xdeadbeef;
         let ee_addr = [1; 20];
 
         let deposit_request_script =
-            build_test_deposit_script(config.magic_bytes, ee_addr.to_vec());
+            build_test_deposit_script(config.magic_bytes, idx, ee_addr.to_vec());
 
         let test_transaction = create_test_deposit_tx(
             Amount::from_sat(config.deposit_amount),
@@ -115,6 +150,7 @@ mod tests {
         let out = out.unwrap();
 
         assert_eq!(out.amt, amt.into());
+        assert_eq!(out.deposit_idx, idx);
         assert_eq!(out.address, ee_addr);
     }
 }

--- a/crates/l1tx/src/deposit/error.rs
+++ b/crates/l1tx/src/deposit/error.rs
@@ -2,26 +2,31 @@ use thiserror::Error;
 
 #[derive(Debug, Clone, Error)]
 pub enum DepositParseError {
-    #[error("No OP_RETURN")]
-    NoOpReturn,
+    #[error("missing tag")]
+    MissingTag,
 
-    #[error("No data")]
+    /// What is this used for?
+    #[error("no data")]
     NoData,
 
-    #[error("no magic bytes")]
-    NoMagicBytes,
+    /// We don't accept nonstandard deposit things.
+    #[error("tag too large")]
+    TagOversized,
 
-    #[error("magic bytes mismatch")]
-    MagicBytesMismatch,
+    #[error("missing magic bytes")]
+    MissingMagic,
 
-    #[error("no address found")]
-    NoDestAddress,
+    #[error("invalid magic bytes")]
+    InvalidMagic,
 
-    #[error("invalid destination Address length {0}")]
-    InvalidDestAddress(u8),
+    #[error("missing destination")]
+    MissingDest,
+
+    #[error("invalid destination length {0}")]
+    InvalidDestLen(u8),
 
     #[error("unexpected amount (exp {0}, found {1}) ")]
-    ExpectedAmount(u64, u64),
+    UnexpectedAmt(u64, u64),
 
     #[error("no leaf hash found")]
     NoLeafHash,
@@ -29,6 +34,7 @@ pub enum DepositParseError {
     #[error("expected 32 byte leaf Hash")]
     LeafHashLenMismatch,
 
-    #[error("no taproot script")]
-    NoP2TR,
+    /// Previously called "NoP2TR" which was really ambiguous.
+    #[error("invalid deposit output")]
+    InvalidDepositOutput,
 }

--- a/crates/l1tx/src/filter/mod.rs
+++ b/crates/l1tx/src/filter/mod.rs
@@ -83,17 +83,21 @@ mod test {
         let params = gen_params();
         let filter_conf = create_tx_filter_config(&params);
         let deposit_config = filter_conf.deposit_config.clone();
+        let idx = 0xdeadbeef;
         let ee_addr = vec![1u8; 20]; // Example EVM address
         let deposit_script =
-            build_test_deposit_script(deposit_config.magic_bytes.clone(), ee_addr.clone());
+            build_test_deposit_script(deposit_config.magic_bytes.clone(), idx, ee_addr.clone());
 
         let tx = create_test_deposit_tx(
             Amount::from_sat(deposit_config.deposit_amount),
             &deposit_config.address.address().script_pubkey(),
             &deposit_script,
         );
+
         let deposits: Vec<_> = try_parse_tx_deposit(&tx, &filter_conf).collect();
         assert_eq!(deposits.len(), 1, "Should find one deposit transaction");
+
+        assert_eq!(deposits[0].deposit_idx, idx, "deposit idx should match");
         assert_eq!(deposits[0].address, ee_addr, "EE address should match");
         assert_eq!(
             deposits[0].amt,

--- a/crates/primitives/src/l1/ops.rs
+++ b/crates/primitives/src/l1/ops.rs
@@ -89,13 +89,16 @@ pub enum ProtocolOperation {
     Clone, Debug, PartialEq, Eq, BorshSerialize, BorshDeserialize, Arbitrary, Serialize, Deserialize,
 )]
 pub struct DepositInfo {
-    /// Bitcoin amount
+    /// Deposit from tag output, as assigned by operators.
+    pub deposit_idx: u32,
+
+    /// Bitcoin amount.
     pub amt: BitcoinAmount,
 
-    /// outpoint
+    /// Output for deposit funds at rest.
     pub outpoint: OutputRef,
 
-    /// EE address
+    /// Destination address payload.
     pub address: Vec<u8>,
 }
 

--- a/crates/proof-impl/btc-blockspace/src/tx_indexer.rs
+++ b/crates/proof-impl/btc-blockspace/src/tx_indexer.rs
@@ -94,9 +94,10 @@ mod test {
         let params = gen_params();
         let filter_config = create_tx_filter_config(&params);
         let deposit_config = filter_config.deposit_config.clone();
+        let idx = 0xdeadbeef;
         let ee_addr = vec![1u8; 20]; // Example EVM address
         let deposit_script =
-            build_test_deposit_script(deposit_config.magic_bytes.clone(), ee_addr.clone());
+            build_test_deposit_script(deposit_config.magic_bytes.clone(), idx, ee_addr.clone());
 
         let tx = create_test_deposit_tx(
             Amount::from_sat(deposit_config.deposit_amount),
@@ -108,18 +109,29 @@ mod test {
 
         let tx_entries = index_block(&block, ProverTxVisitorImpl::new, &filter_config);
 
-        assert_eq!(tx_entries.len(), 1, "Should find one relevant transaction");
+        assert_eq!(
+            tx_entries.len(),
+            1,
+            "test: should find one relevant transaction"
+        );
 
         for op in tx_entries[0].contents() {
             if let ProtocolOperation::Deposit(deposit_info) = op {
-                assert_eq!(deposit_info.address, ee_addr, "EE address should match");
+                assert_eq!(
+                    deposit_info.address, ee_addr,
+                    "test: EE address should match"
+                );
+                assert_eq!(
+                    deposit_info.deposit_idx, idx,
+                    "test: deposit idx should match"
+                );
                 assert_eq!(
                     deposit_info.amt,
                     BitcoinAmount::from_sat(deposit_config.deposit_amount),
-                    "Deposit amount should match"
+                    "test: deposit amount should match"
                 );
             } else {
-                panic!("Expected Deposit info");
+                panic!("test: expected DepositInfo");
             }
         }
     }
@@ -150,13 +162,15 @@ mod test {
         let params = gen_params();
         let filter_config = create_tx_filter_config(&params);
         let deposit_config = filter_config.deposit_config.clone();
+        let idx1 = 0xdeafbeef;
+        let idx2 = 0x1badb007;
         let dest_addr1 = vec![3u8; 20];
         let dest_addr2 = vec![4u8; 20];
 
         let deposit_script1 =
-            build_test_deposit_script(deposit_config.magic_bytes.clone(), dest_addr1.clone());
+            build_test_deposit_script(deposit_config.magic_bytes.clone(), idx1, dest_addr1.clone());
         let deposit_script2 =
-            build_test_deposit_script(deposit_config.magic_bytes.clone(), dest_addr2.clone());
+            build_test_deposit_script(deposit_config.magic_bytes.clone(), idx2, dest_addr2.clone());
 
         let tx1 = create_test_deposit_tx(
             Amount::from_sat(deposit_config.deposit_amount),
@@ -173,7 +187,11 @@ mod test {
 
         let tx_entries = index_block(&block, ProverTxVisitorImpl::new, &filter_config);
 
-        assert_eq!(tx_entries.len(), 2, "Should find two relevant transactions");
+        assert_eq!(
+            tx_entries.len(),
+            2,
+            "test: should find two relevant transactions"
+        );
 
         for (i, info) in tx_entries
             .iter()
@@ -188,17 +206,20 @@ mod test {
                     } else {
                         dest_addr2.clone()
                     },
-                    "EVM address should match for transaction {}",
-                    i
+                    "test: dest should match for transaction {i}",
+                );
+                assert_eq!(
+                    deposit_info.deposit_idx,
+                    [idx1, idx2][i],
+                    "test: deposit idx should match"
                 );
                 assert_eq!(
                     deposit_info.amt,
                     BitcoinAmount::from_sat(deposit_config.deposit_amount),
-                    "Deposit amount should match for transaction {}",
-                    i
+                    "test: deposit amount should match for transaction {i}",
                 );
             } else {
-                panic!("Expected Deposit info for transaction {}", i);
+                panic!("test: expected DepositInfo for transaction {i}");
             }
         }
     }
@@ -208,11 +229,12 @@ mod test {
         let params = gen_params();
         let filter_config = create_tx_filter_config(&params);
         let deposit_config = filter_config.deposit_config.clone();
+        let idx = 0xdeadbeef;
         let ee_addr = vec![1u8; 20]; // Example EVM address
 
         // Create deposit utxo
         let deposit_script =
-            build_test_deposit_script(deposit_config.magic_bytes.clone(), ee_addr.clone());
+            build_test_deposit_script(deposit_config.magic_bytes.clone(), idx, ee_addr.clone());
 
         let mut tx = create_test_deposit_tx(
             Amount::from_sat(deposit_config.deposit_amount),

--- a/crates/state/src/bridge_state.rs
+++ b/crates/state/src/bridge_state.rs
@@ -306,7 +306,7 @@ impl DepositsTable {
             Err(pos) => {
                 let entry = DepositEntry::new(idx, tx_ref, operators, amt);
                 self.deposits.insert(pos as usize, entry);
-                self.next_idx = u32::max(self.next_idx + 1, idx);
+                self.next_idx = u32::max(self.next_idx, idx) + 1;
                 true
             }
         }

--- a/crates/state/src/bridge_state.rs
+++ b/crates/state/src/bridge_state.rs
@@ -231,24 +231,31 @@ impl DepositsTable {
         self.len() > 0
     }
 
+    /// Gets the position in the deposit table of a hypothetical deposit entry
+    /// index.
+    pub fn get_deposit_entry_pos(&self, idx: u32) -> Result<u32, u32> {
+        self.deposits
+            .binary_search_by_key(&idx, |e| e.deposit_idx)
+            .map(|i| i as u32)
+            .map_err(|i| i as u32)
+    }
+
     /// Gets a deposit from the table by its idx.
     ///
     /// Does a binary search.
     pub fn get_deposit(&self, idx: u32) -> Option<&DepositEntry> {
-        self.deposits
-            .binary_search_by_key(&idx, |e| e.deposit_idx)
+        self.get_deposit_entry_pos(idx)
             .ok()
-            .map(|i| &self.deposits[i])
+            .map(|i| &self.deposits[i as usize])
     }
 
     /// Gets a mut ref to a deposit from the table by its idx.
     ///
     /// Does a binary search.
     pub fn get_deposit_mut(&mut self, idx: u32) -> Option<&mut DepositEntry> {
-        self.deposits
-            .binary_search_by_key(&idx, |e| e.deposit_idx)
+        self.get_deposit_entry_pos(idx)
             .ok()
-            .map(|i| &mut self.deposits[i])
+            .map(|i| &mut self.deposits[i as usize])
     }
 
     pub fn get_all_deposits_idxs_iters_iter(&self) -> impl Iterator<Item = u32> + '_ {
@@ -261,7 +268,7 @@ impl DepositsTable {
     }
 
     /// Adds a new deposit to the table and returns the index of the new deposit.
-    pub fn add_deposit(
+    pub fn create_next_deposit(
         &mut self,
         tx_ref: OutputRef,
         operators: Vec<OperatorIdx>,
@@ -272,6 +279,37 @@ impl DepositsTable {
         self.deposits.push(deposit_entry);
         self.next_idx += 1;
         idx
+    }
+
+    /// Tries to create a deposit entry at a specific idx.  If the entry requested if after the
+    /// `next_entry`, then updates it to be equal to that.
+    ///
+    /// Returns if we inserted it successfully.
+    pub fn try_create_deposit_at(
+        &mut self,
+        idx: u32,
+        tx_ref: OutputRef,
+        operators: Vec<OperatorIdx>,
+        amt: BitcoinAmount,
+    ) -> bool {
+        // Happy case, if we're creating the next entry we can skip the binary
+        // search.  This should be most cases, where there isn't concurrent
+        // interleaved deposit processing.
+        if idx == self.next_idx {
+            self.create_next_deposit(tx_ref, operators, amt);
+            return true;
+        }
+
+        // Slow path.
+        match self.get_deposit_entry_pos(idx) {
+            Ok(_) => false,
+            Err(pos) => {
+                let entry = DepositEntry::new(idx, tx_ref, operators, amt);
+                self.deposits.insert(pos as usize, entry);
+                self.next_idx = u32::max(self.next_idx + 1, idx);
+                true
+            }
+        }
     }
 
     pub fn next_idx(&self) -> u32 {

--- a/crates/state/src/bridge_state.rs
+++ b/crates/state/src/bridge_state.rs
@@ -306,7 +306,12 @@ impl DepositsTable {
             Err(pos) => {
                 let entry = DepositEntry::new(idx, tx_ref, operators, amt);
                 self.deposits.insert(pos as usize, entry);
-                self.next_idx = u32::max(self.next_idx, idx) + 1;
+
+                // Tricky bookkeeping.
+                if idx >= self.next_idx {
+                    self.next_idx = u32::max(self.next_idx, idx) + 1;
+                }
+
                 true
             }
         }

--- a/crates/state/src/state_op.rs
+++ b/crates/state/src/state_op.rs
@@ -251,12 +251,13 @@ impl StateCache {
     /// Inserts a new deposit with some settings.
     pub fn insert_deposit_entry(
         &mut self,
+        idx: u32,
         tx_ref: OutputRef,
         amt: BitcoinAmount,
         operators: Vec<OperatorIdx>,
-    ) -> u32 {
+    ) -> bool {
         let dt = self.state_mut().deposits_table_mut();
-        dt.add_deposit(tx_ref, operators, amt)
+        dt.try_create_deposit_at(idx, tx_ref, operators, amt)
     }
 
     /// Assigns a withdrawal command to a deposit, with an expiration.

--- a/crates/test-utils/src/bitcoin.rs
+++ b/crates/test-utils/src/bitcoin.rs
@@ -110,8 +110,9 @@ pub fn build_test_deposit_request_script(
     builder.into_script()
 }
 
-pub fn build_test_deposit_script(magic: Vec<u8>, dest_addr: Vec<u8>) -> ScriptBuf {
+pub fn build_test_deposit_script(magic: Vec<u8>, idx: u32, dest_addr: Vec<u8>) -> ScriptBuf {
     let mut data = magic;
+    data.extend(&idx.to_be_bytes()[..]);
     data.extend(dest_addr);
 
     let builder = script::Builder::new()


### PR DESCRIPTION
## Description

In order to address the bug we identified with the bridge messaging, we are adding a field to the deposit payload to indicate the deposit idx that a deposit should have.  This is signed by the operators implicitly by being part of the tx sighash.

This PR makes the related changes on the rollup side to recognize and handle the explicit deposit idx bookkeeping.

### Type of Change

<!--
Select the type of change your PR introduces (put an `x` in all that apply):
-->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature/Enhancement (non-breaking change which adds functionality or enhances an existing one)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactor
- [ ] New or updated tests
- [ ] Dependency Update

## Notes to Reviewers

<!--
Anything in particular you want to note that will help reviewers fulfill their role
in reviewing this PR?
-->

## Checklist

<!--
Ensure all the following are checked:
-->

- [ ] I have performed a self-review of my code.
- [ ] I have commented my code where necessary.
- [ ] I have updated the documentation if needed.
- [ ] My changes do not introduce new warnings.
- [ ] I have added (where necessary) tests that prove my changes are effective or that my feature works.
- [ ] New and existing tests pass with my changes.