### PR TITLE
feat!(strata-cli): X-Only PK of recovery address instead of take back leaf hash

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6515,6 +6515,11 @@ dependencies = [
 ]
 
 [[package]]
+name = "make_buf"
+version = "1.0.1"
+source = "git+https://github.com/alpenlabs/make_buf.git?rev=903dbe1d4068712ee046c54fe2906ba04e72c905#903dbe1d4068712ee046c54fe2906ba04e72c905"
+
+[[package]]
 name = "malloc_buf"
 version = "0.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -13511,6 +13516,7 @@ dependencies = [
  "directories",
  "indicatif",
  "keyring",
+ "make_buf",
  "rand_core 0.6.4",
  "reqwest 0.12.12",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6457,6 +6457,11 @@ dependencies = [
 ]
 
 [[package]]
+name = "make_buf"
+version = "1.0.1"
+source = "git+https://github.com/alpenlabs/make_buf.git?rev=903dbe1d4068712ee046c54fe2906ba04e72c905#903dbe1d4068712ee046c54fe2906ba04e72c905"
+
+[[package]]
 name = "malachite"
 version = "0.4.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6513,11 +6518,6 @@ dependencies = [
  "malachite-base",
  "malachite-nz",
 ]
-
-[[package]]
-name = "make_buf"
-version = "1.0.1"
-source = "git+https://github.com/alpenlabs/make_buf.git?rev=903dbe1d4068712ee046c54fe2906ba04e72c905#903dbe1d4068712ee046c54fe2906ba04e72c905"
 
 [[package]]
 name = "malloc_buf"

--- a/bin/strata-cli/Cargo.toml
+++ b/bin/strata-cli/Cargo.toml
@@ -36,6 +36,7 @@ config = { version = "0.14.0", default-features = false, features = ["toml"] }
 dialoguer = "0.11.0"
 directories = "5.0.1"
 indicatif = { version = "0.17.8", features = ["improved_unicode", "tokio"] }
+make_buf = { git = "https://github.com/alpenlabs/make_buf.git", rev = "903dbe1d4068712ee046c54fe2906ba04e72c905" }
 rand_core.workspace = true
 reqwest.workspace = true
 serde.workspace = true

--- a/bin/strata-cli/src/cmd/deposit.rs
+++ b/bin/strata-cli/src/cmd/deposit.rs
@@ -15,9 +15,10 @@ use indicatif::ProgressBar;
 use make_buf::make_buf;
 use strata_bridge_tx_builder::constants::MAGIC_BYTES;
 use strata_primitives::constants::UNSPENDABLE_PUBLIC_KEY;
+use strata_primitives::constants::RECOVER_DELAY;
 
 use crate::{
-    constants::{BRIDGE_IN_AMOUNT, RECOVER_AT_DELAY, RECOVER_DELAY, SIGNET_BLOCK_TIME},
+    constants::{BRIDGE_IN_AMOUNT, RECOVER_AT_DELAY, SIGNET_BLOCK_TIME},
     link::{OnchainObject, PrettyPrint},
     recovery::DescriptorRecovery,
     seed::Seed,

--- a/bin/strata-cli/src/constants.rs
+++ b/bin/strata-cli/src/constants.rs
@@ -2,11 +2,7 @@ use std::time::Duration;
 
 use alloy::consensus::constants::ETH_TO_WEI;
 use bdk_wallet::bitcoin::{bip32::ChildNumber, Amount, Network};
-
-/// Number of blocks after bridge in transaction confirmation that the recovery path can be spent.
-///
-/// 144 is the number of blocks in a day.
-pub const RECOVER_DELAY: u32 = 144;
+use strata_primitives::constants::RECOVER_DELAY;
 
 /// Number of blocks that the wallet considers a transaction "buried" or final taking into account
 /// reorgs that might happen.

--- a/crates/primitives/src/constants.rs
+++ b/crates/primitives/src/constants.rs
@@ -23,6 +23,9 @@ pub const SEC_NONCE_SIZE: usize = 64;
 /// The size (in bytes) of a Hash (such as [`Txid`](bitcoin::Txid)).
 pub const HASH_SIZE: usize = 32;
 
+/// Number of blocks after bridge in transaction confirmation that the recovery path can be spent.
+pub const RECOVER_DELAY: u32 = 1_008;
+
 /// Strata base index for keys.
 ///
 /// These should be _hardened_ [`ChildNumber`].

--- a/crates/util/python-utils/src/constants.rs
+++ b/crates/util/python-utils/src/constants.rs
@@ -5,9 +5,6 @@ use bdk_wallet::bitcoin::{Amount, Network};
 /// Magic bytes to add to the metadata output in transactions to help identify them.
 pub const MAGIC_BYTES: &[u8; 11] = b"alpenstrata";
 
-/// Number of blocks after bridge in transaction confirmation that the recovery path can be spent.
-pub(crate) const RECOVER_DELAY: u32 = 1008;
-
 /// 10 BTC + 0.01 to cover fees in the following transaction where the operator spends it into the
 /// federation.
 pub(crate) const BRIDGE_IN_AMOUNT: Amount = Amount::from_sat(1_001_000_000);

--- a/crates/util/python-utils/src/drt.rs
+++ b/crates/util/python-utils/src/drt.rs
@@ -11,10 +11,10 @@ use bdk_wallet::{
 };
 use pyo3::prelude::*;
 use revm_primitives::alloy_primitives::Address as RethAddress;
-use strata_primitives::constants::UNSPENDABLE_PUBLIC_KEY;
+use strata_primitives::constants::{RECOVER_DELAY, UNSPENDABLE_PUBLIC_KEY};
 
 use crate::{
-    constants::{BRIDGE_IN_AMOUNT, MAGIC_BYTES, NETWORK, RECOVER_DELAY, XPRIV},
+    constants::{BRIDGE_IN_AMOUNT, MAGIC_BYTES, NETWORK, XPRIV},
     error::Error,
     parse::{parse_address, parse_el_address, parse_xonly_pk},
     taproot::{bridge_wallet, new_bitcoind_client, sync_wallet, taproot_wallet, ExtractP2trPubkey},


### PR DESCRIPTION
## Description

Deposit Request Transactions (DRT) now need X-Only PK of recovery address instead of take back leaf hash.
This fixes the `strata-cli` DRT metadata `OP_RETURN` construction.

### Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature/Enhancement (non-breaking change which adds functionality or enhances an existing one)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactor
- [ ] New or updated tests
- [ ] Dependency Update

## Notes to Reviewers

The new `OP_RETURN` now is:

1. magic bytes
2. 32-byte X-only PK for the recovery P2TR address
3. 20-byte EL address

## Checklist

- [x] I have performed a self-review of my code.
- [x] I have commented my code where necessary.
- [x] I have updated the documentation if needed.
- [x] My changes do not introduce new warnings.
- [x] I have added (where necessary) tests that prove my changes are effective or that my feature works.
- [x] New and existing tests pass with my changes.

## Related Issues

STR-1176
