### PR TITLE
Str-1106: run fn tests in prover strict mode where applicable

### DIFF
--- a/functional-tests/envs/testenv.py
+++ b/functional-tests/envs/testenv.py
@@ -137,7 +137,9 @@ class BasicEnvConfig(flexitest.EnvConfig):
                 json.dump(custom_chain, f)
             custom_chain = json_path
 
-        settings = self.rollup_settings or RollupParamsSettings.new_default().fast_batch()
+        settings = (
+            self.rollup_settings or RollupParamsSettings.new_default().fast_batch().strict_mode()
+        )
         if custom_chain != self.custom_chain:
             settings = settings.with_chainconfig(custom_chain)
         params_gen_data = generate_simple_params(initdir, settings, self.n_operators)

--- a/functional-tests/tests/crash/crash_sync_event_finalize_epoch.py
+++ b/functional-tests/tests/crash/crash_sync_event_finalize_epoch.py
@@ -2,13 +2,17 @@ import flexitest
 
 from envs import testenv
 from mixins import seq_crash_mixin
-from utils import wait_until
+from utils import ProverClientSettings, wait_until
 
 
 @flexitest.register
 class CrashSyncEventFinalizeEpochTest(seq_crash_mixin.SeqCrashMixin):
     def __init__(self, ctx: flexitest.InitContext):
-        ctx.set_env(testenv.BasicEnvConfig(101))
+        ctx.set_env(
+            testenv.BasicEnvConfig(
+                101, prover_client_settings=ProverClientSettings.new_with_proving()
+            )
+        )
 
     def main(self, ctx: flexitest.RunContext):
         cur_chain_tip = self.handle_bail(lambda: "sync_event_finalize_epoch", timeout=60)

--- a/functional-tests/tests/el_sync_from_chainstate.py
+++ b/functional-tests/tests/el_sync_from_chainstate.py
@@ -25,7 +25,11 @@ class ELSyncFromChainstateTest(testenv.StrataTester):
     """This tests sync when el is missing blocks"""
 
     def __init__(self, ctx: flexitest.InitContext):
-        ctx.set_env(testenv.BasicEnvConfig(101))
+        ctx.set_env(
+            testenv.BasicEnvConfig(
+                101, prover_client_settings=ProverClientSettings.new_with_proving()
+            )
+        )
 
     def main(self, ctx: flexitest.RunContext):
         seq = ctx.get_service("sequencer")


### PR DESCRIPTION
## Description

<!--
Provide a brief summary of the changes and the motivation behind them.
-->

- Run fn tests in prover strict mode for the Basic Env by default. 
- Hub Network Env is left untouched because it doesn't have the prover service configured (and so running in strict mode is not possible)

### Type of Change

<!--
Select the type of change your PR introduces (put an `x` in all that apply):
-->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature/Enhancement (non-breaking change which adds functionality or enhances an existing one)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactor
- [x] New or updated tests
- [ ] Dependency Update

## Notes to Reviewers

<!--
Anything in particular you want to note that will help reviewers fulfill their role
in reviewing this PR?
-->

## Checklist

<!--
Ensure all the following are checked:
-->

- [x] I have performed a self-review of my code.
- [x] I have commented my code where necessary.
- [x] I have updated the documentation if needed.
- [x] My changes do not introduce new warnings.
- [x] I have added (where necessary) tests that prove my changes are effective or that my feature works.
- [x] New and existing tests pass with my changes.

## Related Issues

<!--
Link any related issues (e.g., `closes #123`, `fixes #456`).
-->
