### PR TITLE
STR-1212 use BIP39 seed in Strata EVM wallet

### DIFF
--- a/bin/strata-cli/src/seed.rs
+++ b/bin/strata-cli/src/seed.rs
@@ -102,7 +102,7 @@ impl Seed {
         let derivation_path = DerivationPath::master().extend(BIP44_STRATA_EVM_WALLET_PATH);
 
         let mnemonic = Mnemonic::from_entropy(self.0.as_ref()).expect("valid entropy");
-        // Assuming an empty passphrase.
+        // We do not use a passphrase.
         let bip39_seed = mnemonic.to_seed("");
         // Network choice affects how extended public and private keys are serialized. See
         // https://github.com/bitcoin/bips/blob/master/bip-0032.mediawiki#serialization-format.

--- a/bin/strata-cli/src/seed.rs
+++ b/bin/strata-cli/src/seed.rs
@@ -33,7 +33,7 @@ impl BaseWallet {
 }
 
 #[derive(Clone)]
-// NOTE: This is not a BIP39 seed, instead a random bytes of entropy.
+// NOTE: This is not a BIP39 seed, instead random bytes of entropy.
 pub struct Seed(Zeroizing<[u8; SEED_LEN]>);
 
 impl Seed {

--- a/bin/strata-cli/src/seed.rs
+++ b/bin/strata-cli/src/seed.rs
@@ -393,7 +393,8 @@ mod test {
     }
 
     #[test]
-    // Test L2 wallet address  matches the one from BIP39 tool.
+    // Test L2 wallet address matches the one from BIP39 tool (e.g. https://iancoleman.io/bip39/)
+    // using the same menmonic and derivation path.
     fn test_l2_wallet_address() {
         let seed = Seed(
             [

--- a/bin/strata-cli/src/seed.rs
+++ b/bin/strata-cli/src/seed.rs
@@ -276,12 +276,10 @@ pub mod password;
 
 #[cfg(test)]
 mod test {
-    use alloy::providers::WalletProvider;
     use rand_core::OsRng;
     use sha2::digest::generic_array::GenericArray;
 
     use super::*;
-    use crate::{settings::Settings, strata::StrataWallet};
 
     #[test]
     // Sanity checks on curve scalar construction, to ensure proper rejection
@@ -403,9 +401,8 @@ mod test {
             ]
             .into(),
         );
-        let settings = Settings::load().unwrap();
-        let l2wallet = StrataWallet::new(&seed, &settings.strata_endpoint).unwrap();
-        let address = l2wallet.default_signer_address().to_string();
+        let l2wallet = seed.get_strata_wallet();
+        let address = l2wallet.default_signer().address().to_string();
         // BIP39 Mnemonic for `seed` should be:
         // rival ivory defy future meat build young envelope mimic like motion loan
         // The expected address is obtained using the BIP39 tool with the above mnemonic


### PR DESCRIPTION
## Description

@john-light noticed that the strata receive strata address does not match the address from 
[BIP39 - Mnemonic Code](https://iancoleman.io/bip39/) using the mnemonic and BIP44 derivation path used for our Strata EVM wallet. We need to pass a BIP39 seed to get the master key.

Tested that the address printed by `strata receive strata` now matches the one from [BIP39 - Mnemonic Code](https://iancoleman.io/bip39/).

See [STR-1212](https://alpenlabs.atlassian.net/browse/STR-1212)

### Type of Change

<!--
Select the type of change your PR introduces (put an `x` in all that apply):
-->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature/Enhancement (non-breaking change which adds functionality or enhances an existing one)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactor
- [ ] New or updated tests
- [ ] Dependency Update

## Notes to Reviewers

<!--
Anything in particular you want to note that will help reviewers fulfill their role
in reviewing this PR?
-->

## Checklist

<!--
Ensure all the following are checked:
-->

- [x] I have performed a self-review of my code.
- [x] I have commented my code where necessary.
- [x] I have updated the documentation if needed.
- [x] My changes do not introduce new warnings.
- [ ] I have added (where necessary) tests that prove my changes are effective or that my feature works.
- [x] New and existing tests pass with my changes.

## Related Issues

<!--
Link any related issues (e.g., `closes #123`, `fixes #456`).
-->


[STR-1212]: https://alpenlabs.atlassian.net/browse/STR-1212?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ