### PR TITLE
Fix Empty Proof Verification for non-native mode

### DIFF
--- a/bin/prover-client/src/checkpoint_runner/runner.rs
+++ b/bin/prover-client/src/checkpoint_runner/runner.rs
@@ -58,7 +58,7 @@ async fn process_checkpoint(
 
     let cur = runner_state.current_checkpoint_idx;
     if !should_update_checkpoint(cur, fetched_ckpt) {
-        warn!(fetched = %fetched_ckpt, ?cur, "fetched checkpoint is not newer than current");
+        info!(fetched = %fetched_ckpt, ?cur, "fetched checkpoint is not newer than current");
         return Ok(());
     }
 


### PR DESCRIPTION
## Description
* Fixes bug on verification of empty proof in timeout mode. 
* Created the following ticket for tracking the long-term fix: [STR-1252](https://alpenlabs.atlassian.net/browse/STR-1252).
* Refactor prover client’s checkpoint polling result log level from warning to info.
<!--
Provide a brief summary of the changes and the motivation behind them.
-->

### Type of Change

<!--
Select the type of change your PR introduces (put an `x` in all that apply):
-->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature/Enhancement (non-breaking change which adds functionality or enhances an existing one)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Refactor
- [ ] New or updated tests
- [x] Dependency Update

## Notes to Reviewers

<!--
Anything in particular you want to note that will help reviewers fulfill their role
in reviewing this PR?
-->

## Checklist

<!--
Ensure all the following are checked:
-->

- [ ] I have performed a self-review of my code.
- [ ] I have commented my code where necessary.
- [ ] I have updated the documentation if needed.
- [ ] My changes do not introduce new warnings.
- [ ] I have added (where necessary) tests that prove my changes are effective or that my feature works.
- [ ] New and existing tests pass with my changes.

## Related Issues

<!--
Link any related issues (e.g., `closes #123`, `fixes #456`).
-->


[STR-1252]: https://alpenlabs.atlassian.net/browse/STR-1252?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ