### PR TITLE
Str 1282: Fix Prover bug on transactions with calldata sent to non-existent EOA

### DIFF
--- a/crates/proof-impl/evm-ee-stf/src/mpt.rs
+++ b/crates/proof-impl/evm-ee-stf/src/mpt.rs
@@ -64,6 +64,12 @@ pub struct StateAccount {
     pub code_hash: B256,
 }
 
+impl StateAccount {
+    pub fn is_account_empty(&self) -> bool {
+        self.nonce == 0 && self.balance.is_zero() && self.code_hash == KECCAK_EMPTY
+    }
+}
+
 impl Default for StateAccount {
     /// Provides default values for a [StateAccount].
     ///

--- a/crates/proof-impl/evm-ee-stf/src/processor.rs
+++ b/crates/proof-impl/evm-ee-stf/src/processor.rs
@@ -300,6 +300,8 @@ impl EvmProcessor<InMemoryDB> {
                 continue;
             }
 
+            println!("Processing account: {:?}", address);
+
             let state_trie_index = keccak(address);
 
             // Remove from state trie if it has been deleted.

--- a/crates/proof-impl/evm-ee-stf/src/processor.rs
+++ b/crates/proof-impl/evm-ee-stf/src/processor.rs
@@ -284,7 +284,6 @@ impl EvmProcessor<InMemoryDB> {
             if account.account_state == AccountState::None {
                 continue;
             }
-            println!("Processing account: {:?}", address);
             let state_trie_index = keccak(address);
 
             // Remove from state trie if it has been deleted.
@@ -302,10 +301,7 @@ impl EvmProcessor<InMemoryDB> {
 
             // Skip insert if the account is empty.
             if state_account.is_account_empty() {
-                println!("Accoint {:?} {:?} is empty", address, account);
                 continue;
-            } else {
-                println!("Account {:?} {:?} is not empty", address, account);
             }
 
             // Update storage root for account.

--- a/functional-tests/contracts/SelfDestruct.sol
+++ b/functional-tests/contracts/SelfDestruct.sol
@@ -1,0 +1,18 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.0;
+
+/// @title Selfdestruct Contract
+/// @notice Demonstrates updating state and self-destruction of the contract
+contract SelfDestruct {
+    uint256 public state;
+
+    /// @notice Increments the `state` variable by 1
+    function updateState() external {
+        state += 1;
+    }
+
+    /// @notice Destroys the contract and sends any remaining Ether to itself
+    function destroyContract() external {
+        selfdestruct(payable(address(this)));
+    }
+}

--- a/functional-tests/tests/load/basic_load.py
+++ b/functional-tests/tests/load/basic_load.py
@@ -35,4 +35,4 @@ class BasicLoadGenerationTest(testenv.StrataTester):
         self.debug(f"using task id: {task_id}")
         assert task_id is not None
 
-        wait_for_proof_with_time_out(prover_client_rpc, task_id, time_out=30)
+        assert wait_for_proof_with_time_out(prover_client_rpc, task_id, time_out=30)

--- a/functional-tests/tests/prover/prover_el_calldata_txn.py
+++ b/functional-tests/tests/prover/prover_el_calldata_txn.py
@@ -1,5 +1,4 @@
 import flexitest
-from solcx import install_solc, set_solc_version
 from web3 import Web3
 
 from envs import testenv
@@ -8,14 +7,11 @@ from utils import (
     wait_for_proof_with_time_out,
     wait_until_with_value,
 )
-from utils.transaction import SmartContracts
 
 
 @flexitest.register
-class ElBlockhashOpcodeTest(testenv.StrataTester):
+class ElCalldataTransactionProofTest(testenv.StrataTester):
     def __init__(self, ctx: flexitest.InitContext):
-        install_solc(version="0.8.16")
-        set_solc_version("0.8.16")
         ctx.set_env("prover")
 
     def main(self, ctx: flexitest.RunContext):
@@ -28,15 +24,14 @@ class ElBlockhashOpcodeTest(testenv.StrataTester):
         web3: Web3 = reth.create_web3()
         web3.eth.default_account = web3.address
 
-        # Deploy the contract
-        abi, bytecode = SmartContracts.compile_contract("BlockhashOpCode.sol", "BlockhashOpCode")
-        contract = web3.eth.contract(abi=abi, bytecode=bytecode)
-        tx_hash = contract.constructor().transact()
-        tx_receipt = web3.eth.wait_for_transaction_receipt(tx_hash, timeout=30)
-
-        # Call the contract function
-        contract_instance = web3.eth.contract(abi=abi, address=tx_receipt.contractAddress)
-        tx_hash = contract_instance.functions.updateBlockHash().transact()
+        # Create a random address and calldata
+        random_address = Web3.to_checksum_address("0x" + "dead" * 10)
+        calldata = Web3.to_hex(text="Hello, Alpen!")[2:]  # remove '0x' prefix
+        tx = {
+            "to": random_address,
+            "data": calldata,
+        }
+        tx_hash = web3.eth.send_transaction(tx)
         tx_receipt = web3.eth.wait_for_transaction_receipt(tx_hash, timeout=30)
 
         # Prove the corresponding EE block
@@ -63,8 +58,5 @@ class ElBlockhashOpcodeTest(testenv.StrataTester):
 
         task_id = task_ids[0]
         self.debug(f"Using task ID: {task_id}")
-
-        lastBlockHash = contract_instance.functions.lastBlockHash().call()
-        self.debug(f"lastBlockHash: {type(lastBlockHash)} {lastBlockHash.hex()}")
 
         assert wait_for_proof_with_time_out(prover_client_rpc, task_id, time_out=30)

--- a/functional-tests/tests/prover/prover_el_selfdestruct.py
+++ b/functional-tests/tests/prover/prover_el_selfdestruct.py
@@ -1,0 +1,72 @@
+import flexitest
+from solcx import install_solc, set_solc_version
+from web3 import Web3
+
+from envs import testenv
+from utils import (
+    el_slot_to_block_commitment,
+    wait_for_proof_with_time_out,
+    wait_until_with_value,
+)
+from utils.transaction import SmartContracts
+
+
+@flexitest.register
+class ElSelfDestructContractTest(testenv.StrataTester):
+    def __init__(self, ctx: flexitest.InitContext):
+        install_solc(version="0.8.16")
+        set_solc_version("0.8.16")
+        ctx.set_env("prover")
+
+    def main(self, ctx: flexitest.RunContext):
+        reth = ctx.get_service("reth")
+        reth_rpc = reth.create_rpc()
+
+        prover_client = ctx.get_service("prover_client")
+        prover_client_rpc = prover_client.create_rpc()
+
+        web3: Web3 = reth.create_web3()
+        web3.eth.default_account = web3.address
+
+        # Deploy the contract
+        abi, bytecode = SmartContracts.compile_contract("SelfDestruct.sol", "SelfDestruct")
+        contract = web3.eth.contract(abi=abi, bytecode=bytecode)
+        tx_hash = contract.constructor().transact()
+        tx_receipt = web3.eth.wait_for_transaction_receipt(tx_hash, timeout=30)
+
+        # Call the contract function
+        contract_instance = web3.eth.contract(abi=abi, address=tx_receipt.contractAddress)
+        tx_hash = contract_instance.functions.updateState().transact()
+        web3.eth.wait_for_transaction_receipt(tx_hash, timeout=30)
+
+        # Call the contract function
+        contract_instance = web3.eth.contract(abi=abi, address=tx_receipt.contractAddress)
+        tx_hash = contract_instance.functions.destroyContract().transact()
+        tx_receipt_2 = web3.eth.wait_for_transaction_receipt(tx_hash, timeout=30)
+
+        # Prove the corresponding EE block
+        ee_prover_params = {
+            "start_block": tx_receipt["blockNumber"] - 1,
+            "end_block": tx_receipt_2["blockNumber"] + 1,
+        }
+
+        # Wait until the end EE block is generated.
+        wait_until_with_value(
+            lambda: web3.eth.get_block("latest")["number"],
+            lambda height: height >= ee_prover_params["end_block"],
+            error_with="EE blocks not generated",
+        )
+
+        start_block = el_slot_to_block_commitment(reth_rpc, ee_prover_params["start_block"])
+        end_block = el_slot_to_block_commitment(reth_rpc, ee_prover_params["end_block"])
+
+        task_ids = prover_client_rpc.dev_strata_proveElBlocks((start_block, end_block))
+        self.debug(f"Prover task IDs received: {task_ids}")
+
+        if not task_ids:
+            raise Exception("No task IDs received from prover_client_rpc")
+
+        task_id = task_ids[0]
+        self.debug(f"Using task ID: {task_id}")
+
+        assert wait_for_proof_with_time_out(prover_client_rpc, task_id, time_out=30)


### PR DESCRIPTION
## Description
* Fixes an issue in the prover pipeline that fails when handling Ethereum transactions containing calldata directed to externally owned accounts (EOAs).
* Additional functional test for call data and selfdestruct transaction

<!--
Provide a brief summary of the changes and the motivation behind them.
-->

### Type of Change

<!--
Select the type of change your PR introduces (put an `x` in all that apply):
-->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature/Enhancement (non-breaking change which adds functionality or enhances an existing one)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactor
- [x] New or updated tests
- [ ] Dependency Update

## Notes to Reviewers

<!--
Anything in particular you want to note that will help reviewers fulfill their role
in reviewing this PR?
-->

## Checklist

<!--
Ensure all the following are checked:
-->

- [ ] I have performed a self-review of my code.
- [ ] I have commented my code where necessary.
- [ ] I have updated the documentation if needed.
- [ ] My changes do not introduce new warnings.
- [ ] I have added (where necessary) tests that prove my changes are effective or that my feature works.
- [ ] New and existing tests pass with my changes.

## Related Issues

<!--
Link any related issues (e.g., `closes #123`, `fixes #456`).
-->
