### PR TITLE
chore: fix comment typos across multiple files

### DIFF
--- a/bin/strata-cli/src/seed.rs
+++ b/bin/strata-cli/src/seed.rs
@@ -391,7 +391,7 @@ mod test {
 
     #[test]
     // Test L2 wallet address matches the one from BIP39 tool (e.g. https://iancoleman.io/bip39/)
-    // using the same menmonic and derivation path.
+    // using the same mnemonic and derivation path.
     fn test_l2_wallet_address() {
         let seed = Seed(
             [

--- a/crates/db/src/types.rs
+++ b/crates/db/src/types.rs
@@ -242,7 +242,7 @@ impl From<CheckpointEntry> for Checkpoint {
     }
 }
 
-/// Status of the commmitment
+/// Status of the commitment
 #[derive(Debug, Clone, PartialEq, BorshSerialize, BorshDeserialize, Arbitrary)]
 pub enum CheckpointProvingStatus {
     /// Proof has not been created for this checkpoint

--- a/crates/primitives/src/params.rs
+++ b/crates/primitives/src/params.rs
@@ -138,7 +138,7 @@ impl RollupParams {
 /// Configuration common among deposit and deposit request transaction
 #[derive(Clone, Debug, PartialEq, Eq, BorshSerialize, BorshDeserialize, Deserialize, Serialize)]
 pub struct DepositTxParams {
-    /// Magic bytes we use to regonize a deposit with.
+    /// Magic bytes we use to recognize a deposit with.
     pub magic_bytes: Vec<u8>,
 
     /// Maximum EE address length.


### PR DESCRIPTION
This PR fixes several typos across the codebase:

- In bin/strata-cli/src/seed.rs: Fixed "memnonic" to "mnemonic" in comments
- In crates/db/src/types.rs: Fixed "commmitment" to "commitment" in comments
- In crates/primitives/src/params.rs: Fixed "regonize" to "recognize" in comments

These changes only affect comments and do not modify any functional code.