### PR TITLE
l1tx: Add deposit transaction signature validation logic

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -94,6 +94,9 @@ jobs:
         run: |
           curl -fsSL https://github.com/tamasfe/taplo/releases/latest/download/taplo-full-linux-x86_64.gz \
             | gzip -d - | install -m 755 /dev/stdin /usr/local/bin/taplo
+      - name: Print taplo version
+        run: |
+          taplo --version
       - name: Run taplo lint
         run: |
           taplo lint

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13934,7 +13934,6 @@ dependencies = [
  "anyhow",
  "bitcoin",
  "borsh",
- "hex",
  "musig2",
  "secp256k1",
  "strata-btcio",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13935,6 +13935,7 @@ dependencies = [
  "bitcoin",
  "borsh",
  "musig2",
+ "secp256k1",
  "strata-btcio",
  "strata-primitives",
  "strata-state",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13934,6 +13934,7 @@ dependencies = [
  "anyhow",
  "bitcoin",
  "borsh",
+ "hex",
  "musig2",
  "secp256k1",
  "strata-btcio",

--- a/bin/prover-client/Cargo.toml
+++ b/bin/prover-client/Cargo.toml
@@ -52,7 +52,7 @@ strata-test-utils.workspace = true
 
 [features]
 default = []
-sp1 = ["strata-zkvm-hosts/sp1"]
-sp1-builder = ["sp1", "strata-zkvm-hosts/sp1-builder"]
 risc0 = ["strata-zkvm-hosts/risc0"]
 risc0-builder = ["risc0", "strata-zkvm-hosts/risc0-builder"]
+sp1 = ["strata-zkvm-hosts/sp1"]
+sp1-builder = ["sp1", "strata-zkvm-hosts/sp1-builder"]

--- a/bin/prover-client/src/operators/btc.rs
+++ b/bin/prover-client/src/operators/btc.rs
@@ -2,7 +2,8 @@ use std::sync::Arc;
 
 use bitcoind_async_client::{traits::Reader, Client};
 use jsonrpsee::http_client::HttpClient;
-use strata_l1tx::filter::TxFilterConfig;
+use strata_btcio::rpc::{traits::ReaderRpc, BitcoinClient};
+use strata_l1tx::filter::types::TxFilterConfig;
 use strata_primitives::{
     l1::L1BlockCommitment,
     params::RollupParams,

--- a/bin/prover-client/src/operators/btc.rs
+++ b/bin/prover-client/src/operators/btc.rs
@@ -2,7 +2,6 @@ use std::sync::Arc;
 
 use bitcoind_async_client::{traits::Reader, Client};
 use jsonrpsee::http_client::HttpClient;
-use strata_btcio::rpc::{traits::ReaderRpc, BitcoinClient};
 use strata_l1tx::filter::types::TxFilterConfig;
 use strata_primitives::{
     l1::L1BlockCommitment,

--- a/bin/prover-perf/Cargo.toml
+++ b/bin/prover-perf/Cargo.toml
@@ -39,5 +39,5 @@ tracing.workspace = true
 
 [features]
 default = ["sp1"]
-sp1 = ["zkaleido-sp1-host/perf", "strata-zkvm-hosts/sp1-builder"]
 risc0 = ["zkaleido-risc0-host/perf", "strata-zkvm-hosts/risc0-builder"]
+sp1 = ["zkaleido-sp1-host/perf", "strata-zkvm-hosts/sp1-builder"]

--- a/bin/prover-perf/src/programs/btc_blockscan.rs
+++ b/bin/prover-perf/src/programs/btc_blockscan.rs
@@ -1,4 +1,4 @@
-use strata_l1tx::filter::TxFilterConfig;
+use strata_l1tx::filter::types::TxFilterConfig;
 use strata_proofimpl_btc_blockspace::{logic::BlockScanProofInput, program::BtcBlockspaceProgram};
 use strata_test_utils::{bitcoin_mainnet_segment::BtcChainSegment, l2::gen_params};
 use tracing::info;

--- a/crates/btcio/src/reader/query.rs
+++ b/crates/btcio/src/reader/query.rs
@@ -10,7 +10,7 @@ use bitcoind_async_client::traits::Reader;
 use secp256k1::XOnlyPublicKey;
 use strata_config::btcio::ReaderConfig;
 use strata_l1tx::{
-    filter::{indexer::index_block, TxFilterConfig},
+    filter::{indexer::index_block, types::TxFilterConfig},
     messages::RelevantTxEntry,
 };
 use strata_primitives::{

--- a/crates/btcio/src/reader/state.rs
+++ b/crates/btcio/src/reader/state.rs
@@ -1,7 +1,7 @@
 use std::collections::VecDeque;
 
 use bitcoin::BlockHash;
-use strata_l1tx::filter::TxFilterConfig;
+use strata_l1tx::filter::types::TxFilterConfig;
 
 /// State we use in various parts of the reader.
 #[derive(Debug)]

--- a/crates/btcio/src/reader/tx_indexer.rs
+++ b/crates/btcio/src/reader/tx_indexer.rs
@@ -84,14 +84,8 @@ mod test {
         hashes::Hash,
         Amount, Block, BlockHash, CompactTarget, ScriptBuf, Transaction, TxMerkleNode,
     };
-    use strata_l1tx::{
-        filter::{indexer::index_block, types::TxFilterConfig},
-        utils::test_utils::create_tx_filter_config,
-    };
-    use strata_primitives::{
-        l1::{payload::L1Payload, BitcoinAmount, ProtocolOperation},
-        params::Params,
-    };
+    use strata_l1tx::{filter::indexer::index_block, utils::test_utils::create_tx_filter_config};
+    use strata_primitives::l1::{payload::L1Payload, BitcoinAmount, ProtocolOperation};
     use strata_test_utils::{
         bitcoin::{
             build_test_deposit_request_script, build_test_deposit_script, create_test_deposit_tx,
@@ -299,6 +293,10 @@ mod test {
         }
     }
 
+    // TODO; re-enable this when we decide multiple ops can be present with deposits
+    // Also, This could just be okay in the future where protocol Ops is going to be replaced by
+    // some other mechanism.
+    #[ignore]
     #[test]
     fn test_index_tx_with_multiple_ops() {
         let params = gen_params();

--- a/crates/l1tx/Cargo.toml
+++ b/crates/l1tx/Cargo.toml
@@ -16,7 +16,6 @@ thiserror.workspace = true
 tracing.workspace = true
 
 [dev-dependencies]
-hex.workspace = true
 strata-btcio = { workspace = true, features = ["test_utils"] }
 strata-state = { workspace = true, features = ["test_utils"] }
 strata-test-utils.workspace = true

--- a/crates/l1tx/Cargo.toml
+++ b/crates/l1tx/Cargo.toml
@@ -11,6 +11,7 @@ anyhow.workspace = true
 bitcoin.workspace = true
 borsh.workspace = true
 musig2.workspace = true
+secp256k1.workspace = true
 thiserror.workspace = true
 tracing.workspace = true
 

--- a/crates/l1tx/Cargo.toml
+++ b/crates/l1tx/Cargo.toml
@@ -16,6 +16,7 @@ thiserror.workspace = true
 tracing.workspace = true
 
 [dev-dependencies]
+hex.workspace = true
 strata-btcio = { workspace = true, features = ["test_utils"] }
 strata-state = { workspace = true, features = ["test_utils"] }
 strata-test-utils.workspace = true

--- a/crates/l1tx/src/deposit/constants.rs
+++ b/crates/l1tx/src/deposit/constants.rs
@@ -1,5 +1,0 @@
-use strata_primitives::l1::BitcoinAmount;
-
-/// Bridge denomination amount.
-// TODO make configurable from params
-pub const BRIDGE_DENOMINATION: BitcoinAmount = BitcoinAmount::from_int_btc(10);

--- a/crates/l1tx/src/deposit/deposit_tx.rs
+++ b/crates/l1tx/src/deposit/deposit_tx.rs
@@ -4,6 +4,7 @@ use bitcoin::{
     hashes::Hash,
     opcodes::all::OP_RETURN,
     sighash::{Prevouts, SighashCache},
+    taproot::TAPROOT_CONTROL_NODE_SIZE,
     Amount, OutPoint, ScriptBuf, TapNodeHash, TapSighashType, Transaction, TxOut, XOnlyPublicKey,
 };
 use secp256k1::{schnorr::Signature, Message};
@@ -19,9 +20,9 @@ use crate::{
     utils::{next_bytes, next_op},
 };
 
-const TAKEBACK_HASH_LEN: usize = 32;
-const SATS_AMOUNT_LEN: usize = 8;
-const DEPOSIT_IDX_LEN: usize = 4;
+const TAKEBACK_HASH_LEN: usize = TAPROOT_CONTROL_NODE_SIZE;
+const SATS_AMOUNT_LEN: usize = size_of::<u64>();
+const DEPOSIT_IDX_LEN: usize = size_of::<u32>();
 
 /// Extracts the DepositInfo from the Deposit Transaction
 pub fn extract_deposit_info(tx: &Transaction, config: &DepositTxParams) -> Option<DepositInfo> {

--- a/crates/l1tx/src/deposit/deposit_tx.rs
+++ b/crates/l1tx/src/deposit/deposit_tx.rs
@@ -80,6 +80,10 @@ fn validate_deposit_signature(
     // Initialize necessary variables and dependencies
     let secp = secp256k1::SECP256K1;
 
+    // FIXME: Use latest version of `bitcoin` once released. The underlying
+    // `bitcoinconsensus==0.106` will have support for taproot validation. So here, we just need
+    // to create TxOut from operator pubkeys and tapnode hash and call `tx.verify()`.
+
     // Extract and validate input signature
     let input = tx.input[0].clone();
 

--- a/crates/l1tx/src/deposit/error.rs
+++ b/crates/l1tx/src/deposit/error.rs
@@ -2,6 +2,9 @@ use thiserror::Error;
 
 #[derive(Debug, Clone, Error)]
 pub enum DepositParseError {
+    #[error("invalid data")]
+    InvalidData,
+
     #[error("missing tag")]
     MissingTag,
 
@@ -25,16 +28,6 @@ pub enum DepositParseError {
     #[error("invalid destination length {0}")]
     InvalidDestLen(u8),
 
-    #[error("unexpected amount (exp {0}, found {1}) ")]
-    UnexpectedAmt(u64, u64),
-
-    #[error("no leaf hash found")]
-    NoLeafHash,
-
     #[error("expected 32 byte leaf Hash")]
     LeafHashLenMismatch,
-
-    /// Previously called "NoP2TR" which was really ambiguous.
-    #[error("invalid deposit output")]
-    InvalidDepositOutput,
 }

--- a/crates/l1tx/src/deposit/mod.rs
+++ b/crates/l1tx/src/deposit/mod.rs
@@ -1,5 +1,4 @@
 pub mod common;
-pub mod constants;
 pub mod deposit_request;
 pub mod deposit_tx;
 pub mod error;

--- a/crates/l1tx/src/deposit/test_utils.rs
+++ b/crates/l1tx/src/deposit/test_utils.rs
@@ -1,4 +1,4 @@
-use strata_primitives::params::DepositTxParams;
+use strata_primitives::{l1::XOnlyPk, params::DepositTxParams};
 use strata_test_utils::bitcoin::test_taproot_addr;
 
 pub fn get_deposit_tx_config() -> DepositTxParams {
@@ -7,5 +7,6 @@ pub fn get_deposit_tx_config() -> DepositTxParams {
         address_length: 20,
         deposit_amount: 1_000_000_000,
         address: test_taproot_addr(),
+        operators_pubkey: XOnlyPk::from_address(&test_taproot_addr()).unwrap(),
     }
 }

--- a/crates/l1tx/src/envelope/parser.rs
+++ b/crates/l1tx/src/envelope/parser.rs
@@ -8,7 +8,7 @@ use thiserror::Error;
 use tracing::*;
 
 use crate::{
-    filter::TxFilterConfig,
+    filter::types::TxFilterConfig,
     utils::{next_bytes, next_op},
 };
 

--- a/crates/l1tx/src/filter/mod.rs
+++ b/crates/l1tx/src/filter/mod.rs
@@ -7,11 +7,11 @@ pub mod types;
 mod withdrawal_fulfillment;
 
 use checkpoint::parse_valid_checkpoint_envelopes;
-pub use types::TxFilterConfig;
 use withdrawal_fulfillment::try_parse_tx_as_withdrawal_fulfillment;
 
-use crate::deposit::{
-    deposit_request::extract_deposit_request_info, deposit_tx::extract_deposit_info,
+use crate::{
+    deposit::{deposit_request::extract_deposit_request_info, deposit_tx::extract_deposit_info},
+    filter::types::TxFilterConfig,
 };
 
 // TODO move all these functions to other modules

--- a/crates/l1tx/src/filter/mod.rs
+++ b/crates/l1tx/src/filter/mod.rs
@@ -62,6 +62,7 @@ fn find_deposit_spends<'tx>(
 mod test {
     use bitcoin::{
         consensus::deserialize,
+        hex::FromHex,
         secp256k1::{Keypair, Secp256k1, SecretKey},
         Amount, ScriptBuf, Transaction, Witness,
     };
@@ -240,14 +241,14 @@ mod test {
     fn test_deposit_tx_with_test_vector() {
         // Set up test vector and decode transaction
         let txraw = "0200000000010186e7cee076c18d5d33a642ef689027265be442bce68294a335d8665e4eb81ab10000000000fdffffff0200e1f505000000002251209accbdba14ffa7ca9d636ec63beee4c00c9b9504e4fc4f71a779491907ff1ef10000000000000000486a467374726174610000000070997970c51812dc3a010c7d01b50e0d17dc79c8eb9ee3797b83d854f724f2ab625938deea929282a5330927a0e8ae994b9b2b240000000005f767a0014101a54bdc1dd43416bd0618969eb040735fbbfab1103a6c55a7a80f28e5aaa9c0f57d483dcc84d68d4add23515560c743d789b1a0dd596db40b3bd70407185da20100000000";
-        let txbytes = hex::decode(txraw).unwrap();
+        let txbytes = Vec::from_hex(txraw).unwrap();
         let tx: Transaction = deserialize(&txbytes).expect("failed to deserialize tx");
 
         // The operator pubkeys that has signed the above tx.
         let op_pubkeys: Vec<_> = vec![
-            hex::decode("b49092f76d06f8002e0b7f1c63b5058db23fd4465b4f6954b53e1f352a04754d"),
-            hex::decode("1e62d54af30569fd7269c14b6766f74d85ea00c911c4e1a423d4ba2ae4c34dc4"),
-            hex::decode("a4d869ccd09c470f8f86d3f1b0997fa2695933aaea001875b9db145ae9c1f4ba"),
+            Vec::from_hex("b49092f76d06f8002e0b7f1c63b5058db23fd4465b4f6954b53e1f352a04754d"),
+            Vec::from_hex("1e62d54af30569fd7269c14b6766f74d85ea00c911c4e1a423d4ba2ae4c34dc4"),
+            Vec::from_hex("a4d869ccd09c470f8f86d3f1b0997fa2695933aaea001875b9db145ae9c1f4ba"),
         ]
         .into_iter()
         .map(|x| Buf32::try_from_slice(&x.unwrap()).unwrap())

--- a/crates/l1tx/src/filter/mod.rs
+++ b/crates/l1tx/src/filter/mod.rs
@@ -61,10 +61,14 @@ fn find_deposit_spends<'tx>(
 #[cfg(test)]
 mod test {
     use bitcoin::{
+        consensus::deserialize,
         secp256k1::{Keypair, Secp256k1, SecretKey},
-        Amount, ScriptBuf,
+        Amount, ScriptBuf, Transaction, Witness,
     };
-    use strata_primitives::l1::BitcoinAmount;
+    use borsh::BorshDeserialize;
+    use strata_primitives::{
+        buf::Buf32, l1::BitcoinAmount, operator::OperatorPubkeys, params::OperatorConfig,
+    };
     use strata_test_utils::{
         bitcoin::{
             build_test_deposit_request_script, build_test_deposit_script, create_test_deposit_tx,
@@ -76,6 +80,7 @@ mod test {
     use crate::{
         filter::{extract_deposit_requests, try_parse_tx_deposit},
         utils::test_utils::create_tx_filter_config,
+        TxFilterConfig,
     };
 
     #[test]
@@ -168,7 +173,7 @@ mod test {
         );
 
         let deposits: Vec<_> = try_parse_tx_deposit(&tx, &filter_conf).collect();
-        assert!(deposits.is_empty(), "Should find no deposit request");
+        assert!(deposits.is_empty(), "Should find no deposit");
     }
 
     #[test]
@@ -229,5 +234,61 @@ mod test {
 
         let deposits: Vec<_> = try_parse_tx_deposit(&tx, &filter_conf).collect();
         assert!(deposits.is_empty(), "Should find no deposit request");
+    }
+
+    #[test]
+    fn test_deposit_tx_with_test_vector() {
+        // Set up test vector and decode transaction
+        let txraw = "0200000000010186e7cee076c18d5d33a642ef689027265be442bce68294a335d8665e4eb81ab10000000000fdffffff0200e1f505000000002251209accbdba14ffa7ca9d636ec63beee4c00c9b9504e4fc4f71a779491907ff1ef10000000000000000486a467374726174610000000070997970c51812dc3a010c7d01b50e0d17dc79c8eb9ee3797b83d854f724f2ab625938deea929282a5330927a0e8ae994b9b2b240000000005f767a0014101a54bdc1dd43416bd0618969eb040735fbbfab1103a6c55a7a80f28e5aaa9c0f57d483dcc84d68d4add23515560c743d789b1a0dd596db40b3bd70407185da20100000000";
+        let txbytes = hex::decode(txraw).unwrap();
+        let tx: Transaction = deserialize(&txbytes).expect("failed to deserialize tx");
+
+        // The operator pubkeys that has signed the above tx.
+        let op_pubkeys: Vec<_> = vec![
+            hex::decode("b49092f76d06f8002e0b7f1c63b5058db23fd4465b4f6954b53e1f352a04754d"),
+            hex::decode("1e62d54af30569fd7269c14b6766f74d85ea00c911c4e1a423d4ba2ae4c34dc4"),
+            hex::decode("a4d869ccd09c470f8f86d3f1b0997fa2695933aaea001875b9db145ae9c1f4ba"),
+        ]
+        .into_iter()
+        .map(|x| Buf32::try_from_slice(&x.unwrap()).unwrap())
+        .map(|wpk| OperatorPubkeys::new(wpk, wpk)) // Just have same wallet/signing keys
+        .collect();
+
+        // Configure and update rollup params by setting the custom operator keys
+        let mut params = gen_params();
+
+        params.rollup.operator_config = OperatorConfig::Static(op_pubkeys);
+
+        // Derive filter config and update magic bytes and deposit amount that the above transaction
+        // has.
+        let mut filterconf = TxFilterConfig::derive_from(params.rollup()).unwrap();
+        filterconf.deposit_config.magic_bytes = "strata".bytes().collect();
+        filterconf.deposit_config.deposit_amount = 100_000_000;
+
+        let deposits: Vec<_> = try_parse_tx_deposit(&tx, &filterconf).collect();
+        assert_eq!(deposits.len(), 1, "Should find one deposit transaction");
+
+        // The transaction contains the following ee address in opreturn, check if it is parsed.
+        let exp_address = vec![
+            0x70, 0x99, 0x79, 0x70, 0xc5, 0x18, 0x12, 0xdc, 0x3a, 0x01, 0x0c, 0x7d, 0x01, 0xb5,
+            0x0e, 0x0d, 0x17, 0xdc, 0x79, 0xc8,
+        ];
+
+        assert_eq!(deposits[0].deposit_idx, 0, "deposit idx should match");
+        assert_eq!(deposits[0].address, exp_address, "EE address should match");
+        assert_eq!(
+            deposits[0].amt,
+            BitcoinAmount::from_sat(filterconf.deposit_config.deposit_amount),
+            "Deposit amount should match"
+        );
+
+        // Now tamper the witness of the transaction, to check if the validation passes. It should
+        // not.
+        let mut tx = tx.clone();
+        let mut witness = tx.input[0].witness.to_vec();
+        witness[0][0] ^= 255; // flip the bits
+        tx.input[0].witness = Witness::from_slice(&witness);
+        let deposits: Vec<_> = try_parse_tx_deposit(&tx, &filterconf).collect();
+        assert_eq!(deposits.len(), 0, "Should not find any deposit transaction");
     }
 }

--- a/crates/l1tx/src/lib.rs
+++ b/crates/l1tx/src/lib.rs
@@ -3,3 +3,5 @@ pub mod envelope;
 pub mod filter;
 pub mod messages;
 pub mod utils;
+
+pub use filter::types::TxFilterConfig;

--- a/crates/primitives/src/l1/btc.rs
+++ b/crates/primitives/src/l1/btc.rs
@@ -27,7 +27,7 @@ use crate::{buf::Buf32, constants::HASH_SIZE, errors::ParseError};
 
 /// L1 output reference.
 #[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd, Serialize, Deserialize)]
-pub struct OutputRef(OutPoint);
+pub struct OutputRef(pub OutPoint);
 
 impl From<OutPoint> for OutputRef {
     fn from(value: OutPoint) -> Self {

--- a/crates/primitives/src/params.rs
+++ b/crates/primitives/src/params.rs
@@ -148,8 +148,7 @@ pub struct DepositTxParams {
     // TODO rename to be `max_addr_len`
     pub address_length: u8,
 
-    /// Exact bitcoin amount in the at-rest deposit.
-    // TODO: rename this to deposit_denominations and set the type to be a vec(possibly sorted)
+    /// Exact bitcoin amount(sats) in the at-rest deposit.
     pub deposit_amount: u64,
 
     /// federation address derived from operator entries

--- a/crates/primitives/src/params.rs
+++ b/crates/primitives/src/params.rs
@@ -5,7 +5,10 @@ use serde::{Deserialize, Serialize};
 use thiserror::Error;
 
 use crate::{
-    block_credential::CredRule, l1::BitcoinAddress, operator::OperatorPubkeys, prelude::Buf32,
+    block_credential::CredRule,
+    l1::{BitcoinAddress, XOnlyPk},
+    operator::OperatorPubkeys,
+    prelude::Buf32,
     proof::RollupVerifyingKey,
 };
 
@@ -151,17 +154,9 @@ pub struct DepositTxParams {
 
     /// federation address derived from operator entries
     pub address: BitcoinAddress,
-}
 
-impl RollupParams {
-    pub fn get_deposit_params(&self, address: BitcoinAddress) -> DepositTxParams {
-        DepositTxParams {
-            magic_bytes: self.rollup_name.clone().into_bytes().to_vec(),
-            address_length: self.address_length,
-            deposit_amount: self.deposit_amount,
-            address,
-        }
-    }
+    /// Operators' aggregated pubkey(untweaked internal pubkey)
+    pub operators_pubkey: XOnlyPk,
 }
 
 /// Describes how we decide to wait for proofs for checkpoints to generate.

--- a/crates/proof-impl/btc-blockspace/Cargo.toml
+++ b/crates/proof-impl/btc-blockspace/Cargo.toml
@@ -20,4 +20,5 @@ sha2.workspace = true
 hex.workspace = true
 rand.workspace = true
 strata-btcio.workspace = true
-strata-test-utils.workspace = true
+strata-l1tx = { workspace = true, features = ["test_utils"] }
+strata-test-utils = { workspace = true }

--- a/crates/proof-impl/btc-blockspace/src/logic.rs
+++ b/crates/proof-impl/btc-blockspace/src/logic.rs
@@ -5,7 +5,7 @@ use bitcoin::{
     Block,
 };
 use borsh::{BorshDeserialize, BorshSerialize};
-use strata_l1tx::filter::{indexer::index_block, TxFilterConfig};
+use strata_l1tx::filter::{indexer::index_block, types::TxFilterConfig};
 use strata_primitives::l1::{L1TxProof, ProtocolOperation};
 use zkaleido::ZkVmEnv;
 

--- a/crates/proof-impl/btc-blockspace/src/tx_indexer.rs
+++ b/crates/proof-impl/btc-blockspace/src/tx_indexer.rs
@@ -55,14 +55,8 @@ mod test {
         Amount, Block, BlockHash, CompactTarget, ScriptBuf, Transaction, TxMerkleNode,
     };
     use strata_btcio::test_utils::create_checkpoint_envelope_tx;
-    use strata_l1tx::{
-        filter::{indexer::index_block, types::TxFilterConfig},
-        utils::test_utils::create_tx_filter_config,
-    };
-    use strata_primitives::{
-        l1::{payload::L1Payload, BitcoinAmount, ProtocolOperation},
-        params::Params,
-    };
+    use strata_l1tx::{filter::indexer::index_block, utils::test_utils::create_tx_filter_config};
+    use strata_primitives::l1::{payload::L1Payload, BitcoinAmount, ProtocolOperation};
     use strata_test_utils::{
         bitcoin::{build_test_deposit_script, create_test_deposit_tx, test_taproot_addr},
         l2::{gen_params, get_test_signed_checkpoint},
@@ -234,6 +228,10 @@ mod test {
         }
     }
 
+    // TODO; re-enable this when we decide multiple ops can be present with deposits
+    // Also, This could just be okay in the future where protocol Ops is going to be replaced by
+    // some other mechanism.
+    #[ignore]
     #[test]
     fn test_index_tx_with_multiple_ops() {
         let params = gen_params();

--- a/crates/proof-impl/btc-blockspace/src/tx_indexer.rs
+++ b/crates/proof-impl/btc-blockspace/src/tx_indexer.rs
@@ -55,7 +55,10 @@ mod test {
         Amount, Block, BlockHash, CompactTarget, ScriptBuf, Transaction, TxMerkleNode,
     };
     use strata_btcio::test_utils::create_checkpoint_envelope_tx;
-    use strata_l1tx::filter::{indexer::index_block, TxFilterConfig};
+    use strata_l1tx::{
+        filter::{indexer::index_block, types::TxFilterConfig},
+        utils::test_utils::create_tx_filter_config,
+    };
     use strata_primitives::{
         l1::{payload::L1Payload, BitcoinAmount, ProtocolOperation},
         params::Params,
@@ -85,24 +88,23 @@ mod test {
         }
     }
 
-    fn create_tx_filter_config(params: &Params) -> TxFilterConfig {
-        TxFilterConfig::derive_from(params.rollup()).expect("can't get filter config")
-    }
-
     #[test]
     fn test_index_deposits() {
         let params = gen_params();
-        let filter_config = create_tx_filter_config(&params);
+        let (filter_config, keypair) = create_tx_filter_config(&params);
         let deposit_config = filter_config.deposit_config.clone();
         let idx = 0xdeadbeef;
         let ee_addr = vec![1u8; 20]; // Example EVM address
+        let tapnode_hash = [0u8; 32];
         let deposit_script =
-            build_test_deposit_script(deposit_config.magic_bytes.clone(), idx, ee_addr.clone());
+            build_test_deposit_script(&deposit_config, idx, ee_addr.clone(), &tapnode_hash);
 
         let tx = create_test_deposit_tx(
             Amount::from_sat(deposit_config.deposit_amount),
             &deposit_config.address.address().script_pubkey(),
             &deposit_script,
+            &keypair,
+            &tapnode_hash,
         );
 
         let block = create_test_block(vec![tx]);
@@ -139,12 +141,15 @@ mod test {
     #[test]
     fn test_index_no_deposit() {
         let params = gen_params();
-        let filter_config = create_tx_filter_config(&params);
+        let (filter_config, keypair) = create_tx_filter_config(&params);
+        let tapnode_hash = [0u8; 32];
         let deposit_config = filter_config.deposit_config.clone();
         let irrelevant_tx = create_test_deposit_tx(
             Amount::from_sat(deposit_config.deposit_amount),
             &test_taproot_addr().address().script_pubkey(),
             &ScriptBuf::new(),
+            &keypair,
+            &tapnode_hash,
         );
 
         let block = create_test_block(vec![irrelevant_tx]);
@@ -160,27 +165,32 @@ mod test {
     #[test]
     fn test_index_multiple_deposits() {
         let params = gen_params();
-        let filter_config = create_tx_filter_config(&params);
+        let (filter_config, keypair) = create_tx_filter_config(&params);
         let deposit_config = filter_config.deposit_config.clone();
         let idx1 = 0xdeafbeef;
         let idx2 = 0x1badb007;
         let dest_addr1 = vec![3u8; 20];
         let dest_addr2 = vec![4u8; 20];
+        let tapnodehash = [0u8; 32];
 
         let deposit_script1 =
-            build_test_deposit_script(deposit_config.magic_bytes.clone(), idx1, dest_addr1.clone());
+            build_test_deposit_script(&deposit_config, idx1, dest_addr1.clone(), &tapnodehash);
         let deposit_script2 =
-            build_test_deposit_script(deposit_config.magic_bytes.clone(), idx2, dest_addr2.clone());
+            build_test_deposit_script(&deposit_config, idx2, dest_addr2.clone(), &tapnodehash);
 
         let tx1 = create_test_deposit_tx(
             Amount::from_sat(deposit_config.deposit_amount),
             &deposit_config.address.address().script_pubkey(),
             &deposit_script1,
+            &keypair,
+            &tapnodehash,
         );
         let tx2 = create_test_deposit_tx(
             Amount::from_sat(deposit_config.deposit_amount),
             &deposit_config.address.address().script_pubkey(),
             &deposit_script2,
+            &keypair,
+            &tapnodehash,
         );
 
         let block = create_test_block(vec![tx1, tx2]);
@@ -227,19 +237,22 @@ mod test {
     #[test]
     fn test_index_tx_with_multiple_ops() {
         let params = gen_params();
-        let filter_config = create_tx_filter_config(&params);
+        let (filter_config, keypair) = create_tx_filter_config(&params);
         let deposit_config = filter_config.deposit_config.clone();
         let idx = 0xdeadbeef;
         let ee_addr = vec![1u8; 20]; // Example EVM address
+        let tapnode_hash = [0u8; 32];
 
         // Create deposit utxo
         let deposit_script =
-            build_test_deposit_script(deposit_config.magic_bytes.clone(), idx, ee_addr.clone());
+            build_test_deposit_script(&deposit_config, idx, ee_addr.clone(), &tapnode_hash);
 
         let mut tx = create_test_deposit_tx(
             Amount::from_sat(deposit_config.deposit_amount),
             &deposit_config.address.address().script_pubkey(),
             &deposit_script,
+            &keypair,
+            &tapnode_hash,
         );
 
         // Create envelope tx and copy its input to the above deposit tx

--- a/crates/sequencer/src/checkpoint/worker.rs
+++ b/crates/sequencer/src/checkpoint/worker.rs
@@ -3,7 +3,7 @@
 use std::sync::Arc;
 
 use strata_db::{types::CheckpointEntry, DbError};
-use strata_l1tx::filter::TxFilterConfig;
+use strata_l1tx::filter::types::TxFilterConfig;
 use strata_primitives::{
     self,
     epoch::EpochCommitment,

--- a/crates/test-utils/src/bitcoin.rs
+++ b/crates/test-utils/src/bitcoin.rs
@@ -11,10 +11,10 @@ use bitcoin::{
     Address, Amount, Block, Network, ScriptBuf, Sequence, TapNodeHash, TapSighashType, Transaction,
     TxIn, TxOut, Witness,
 };
-use strata_l1tx::filter::TxFilterConfig;
+use strata_l1tx::TxFilterConfig;
 use strata_primitives::{
-    l1::{BitcoinAddress, L1HeaderRecord, OutputRef},
-    params::DepositTxParams,
+    l1::{BitcoinAddress, L1HeaderRecord, OutputRef, XOnlyPk},
+    params::{DepositTxParams, Params},
 };
 
 use crate::{l2::gen_params, ArbitraryGenerator};
@@ -52,20 +52,6 @@ pub fn get_btc_mainnet_block() -> Block {
 pub fn get_test_tx_filter_config() -> TxFilterConfig {
     let config = gen_params();
     TxFilterConfig::derive_from(config.rollup()).expect("can't derive filter config")
-}
-
-pub fn get_taproot_addr_and_keypair() -> (Address, Keypair) {
-    // Generate valid signature
-    let secp = Secp256k1::new();
-
-    // Step 1. Create a random internal key (you can use a fixed one in tests)
-    let secret_key = SecretKey::from_slice(&[42u8; 32]).unwrap();
-    let keypair = Keypair::from_secret_key(&secp, &secret_key);
-    let (internal_xonly, _parity) = keypair.x_only_public_key();
-
-    // Step 2. Create a Taproot address
-    let taproot_addr = Address::p2tr(&secp, internal_xonly, None, Network::Regtest);
-    (taproot_addr, keypair)
 }
 
 pub fn create_test_deposit_tx(

--- a/crates/test-utils/src/bitcoin.rs
+++ b/crates/test-utils/src/bitcoin.rs
@@ -54,9 +54,29 @@ pub fn get_test_tx_filter_config() -> TxFilterConfig {
     TxFilterConfig::derive_from(config.rollup()).expect("can't derive filter config")
 }
 
+/// Creates a signed test Taproot deposit transaction.
+///
+/// Generates a dummy input referencing a random previous output, and constructs a
+/// transaction with two outputs:
+/// - A payment to `out_script_pubkey` with the specified amount.
+/// - An OP_RETURN output using `opreturn_script` with zero value.
+///
+/// The input is signed using Taproot key spend with `SIGHASH_DEFAULT`, and the address
+/// is derived from the provided `keypair` and `tapnode_hash`.
+///
+/// # Arguments
+/// - `amt`: Amount to deposit.
+/// - `out_script_pubkey`: Script to spend to.
+/// - `opreturn_script`: Script for the OP_RETURN output. This contains the metadata for the
+///   deposit.
+/// - `keypair`: Keypair used to sign the transaction.
+/// - `tapnode_hash`: Optional Taproot node hash for script path commitment.
+///
+/// # Returns
+/// A signed [`Transaction`] ready for testing or simulation.
 pub fn create_test_deposit_tx(
     amt: Amount,
-    addr_script: &ScriptBuf,
+    out_script_pubkey: &ScriptBuf,
     opreturn_script: &ScriptBuf,
     keypair: &Keypair,
     tapnode_hash: &[u8; 32],
@@ -87,8 +107,8 @@ pub fn create_test_deposit_tx(
     // Construct the outputs
     let outputs = vec![
         TxOut {
-            value: amt, // 10 BTC in satoshis
-            script_pubkey: addr_script.clone(),
+            value: amt,
+            script_pubkey: out_script_pubkey.clone(),
         },
         TxOut {
             value: Amount::ZERO, // Amount is zero for OP_RETURN

--- a/crates/test-utils/src/bitcoin.rs
+++ b/crates/test-utils/src/bitcoin.rs
@@ -6,15 +6,15 @@ use bitcoin::{
     hashes::Hash,
     opcodes::all::OP_RETURN,
     script::{self, PushBytesBuf},
-    secp256k1::{Keypair, Message, Secp256k1, SecretKey},
+    secp256k1::{Keypair, Message, Secp256k1},
     sighash::{Prevouts, SighashCache},
-    Address, Amount, Block, Network, ScriptBuf, Sequence, TapNodeHash, TapSighashType, Transaction,
-    TxIn, TxOut, Witness,
+    Address, Amount, Block, ScriptBuf, Sequence, TapNodeHash, TapSighashType, Transaction, TxIn,
+    TxOut, Witness,
 };
 use strata_l1tx::TxFilterConfig;
 use strata_primitives::{
-    l1::{BitcoinAddress, L1HeaderRecord, OutputRef, XOnlyPk},
-    params::{DepositTxParams, Params},
+    l1::{BitcoinAddress, L1HeaderRecord, OutputRef},
+    params::DepositTxParams,
 };
 
 use crate::{l2::gen_params, ArbitraryGenerator};

--- a/provers/sp1/guest-evm-ee-stf/Cargo.toml
+++ b/provers/sp1/guest-evm-ee-stf/Cargo.toml
@@ -10,11 +10,11 @@ strata-proofimpl-evm-ee-stf = { path = "../../../crates/proof-impl/evm-ee-stf" }
 zkaleido-sp1-guest-env = { git = "https://github.com/alpenlabs/zkaleido", tag = "v0.1.0-alpha-rc9" }
 
 [patch.crates-io]
+bn = { git = "https://github.com/sp1-patches/bn", package = "substrate-bn", tag = "patch-0.6.0-sp1-4.0.0" }
 k256 = { git = "https://github.com/sp1-patches/elliptic-curves", tag = "patch-k256-13.4-sp1-4.1.0" }
 secp256k1 = { git = "https://github.com/sp1-patches/rust-secp256k1", tag = "patch-0.29.1-sp1-4.1.0" }
 sha2-v0-10-8 = { git = "https://github.com/sp1-patches/RustCrypto-hashes", package = "sha2", tag = "patch-sha2-0.10.8-sp1-4.0.0" }
 tiny-keccak = { git = "https://github.com/sp1-patches/tiny-keccak", tag = "patch-2.0.2-sp1-4.0.0" }
-bn = { git = "https://github.com/sp1-patches/bn", package = "substrate-bn", tag = "patch-0.6.0-sp1-4.0.0" }
 
 
 [features]


### PR DESCRIPTION
## Description

This PR introduces an extra check to the parsed deposit transaction. It now also checks that the deposit transaction is not only being spent to N-of-N operators with specified amount but is also being spent by N-of-N operators.

This is necessary because anyone can create a deposit transaction that spends the amount to the operators. But since this won't have any Deposit request transaction, and hence no deposit index assigned, operators can't withdraw from this using the protocol.


### Type of Change

<!--
Select the type of change your PR introduces (put an `x` in all that apply):
-->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature/Enhancement (non-breaking change which adds functionality or enhances an existing one)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactor
- [x] New or updated tests
- [ ] Dependency Update

## Notes to Reviewers

<!--
Anything in particular you want to note that will help reviewers fulfill their role
in reviewing this PR?
-->

## Checklist

<!--
Ensure all the following are checked:
-->

- [x] I have performed a self-review of my code.
- [x] I have commented my code where necessary.
- [ ] I have updated the documentation if needed.
- [x] My changes do not introduce new warnings.
- [x] I have added (where necessary) tests that prove my changes are effective or that my feature works.
- [x] New and existing tests pass with my changes.

## Related Issues

<!--
Link any related issues (e.g., `closes #123`, `fixes #456`).
-->
