### PR TITLE
Rename strata_address to alpen_address in deposit.rs

### DIFF
--- a/bin/alpen-cli/src/cmd/deposit.rs
+++ b/bin/alpen-cli/src/cmd/deposit.rs
@@ -110,7 +110,7 @@ pub async fn deposit(
     // Construct the DRT metadata OP_RETURN:
     // <magic_bytes>
     // <recovery_address_pk>
-    // <strata_address>
+    // <alpen_address>
     const MBL: usize = MAGIC_BYTES.len();
     const XONLYPK: usize = 32; // X-only PKs are 32-bytes in P2TR SegWit v1 addresses
     const ALPEN_ADDRESS_LEN: usize = 20; // EVM addresses are 20 bytes long


### PR DESCRIPTION
## Description
Updates the comment in deposit.rs to use alpen_address instead of strata_address to maintain consistency with the codebase naming conventions. This is a minor documentation change that aligns the comments with the actual implementation.

Changes:
- Changed comment `// <strata_address>` to `// <alpen_address>` in deposit.rs