### PR TITLE
chore(deps): bump corepc-node to 0.7.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2805,7 +2805,7 @@ dependencies = [
  "tap",
  "thin-vec",
  "thiserror 2.0.12",
- "time 0.3.37",
+ "time",
 ]
 
 [[package]]
@@ -3438,9 +3438,9 @@ dependencies = [
 
 [[package]]
 name = "corepc-node"
-version = "0.7.0"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6cb0b5b9e99b8290eeac6cdccfa4f86821fb49011480d86111d85e26287d128"
+checksum = "b2bcc6e09458f052024ec36e4728bd5619e248643da6175876eb3b10ca6d4d86"
 dependencies = [
  "anyhow",
  "bitcoin_hashes 0.14.0",
@@ -3452,7 +3452,7 @@ dependencies = [
  "tar",
  "tempfile",
  "which",
- "zip 0.5.13",
+ "zip 0.6.6",
 ]
 
 [[package]]
@@ -12756,7 +12756,7 @@ dependencies = [
  "serde_derive",
  "serde_json",
  "serde_with_macros",
- "time 0.3.37",
+ "time",
 ]
 
 [[package]]
@@ -12999,7 +12999,7 @@ dependencies = [
  "num-bigint 0.4.6",
  "num-traits",
  "thiserror 2.0.12",
- "time 0.3.37",
+ "time",
 ]
 
 [[package]]
@@ -14143,7 +14143,7 @@ dependencies = [
  "strata-sp1-guest-builder",
  "strata-test-utils",
  "strata-zkvm-hosts",
- "time 0.3.37",
+ "time",
  "tokio",
  "tracing",
  "zkaleido",
@@ -14796,17 +14796,6 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.1.45"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b797afad3f312d1c66a56d11d0316f916356d11bd158fbc6ca6389ff6bf805a"
-dependencies = [
- "libc",
- "wasi 0.10.0+wasi-snapshot-preview1",
- "winapi",
-]
-
-[[package]]
-name = "time"
 version = "0.3.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "35e7868883861bd0e56d9ac6efcaaca0d6d5d82a2a7ec8209ff492c07cf37b21"
@@ -15190,7 +15179,7 @@ checksum = "3566e8ce28cc0a3fe42519fc80e6b4c943cc4c8cef275620eb8dac2d3d4e06cf"
 dependencies = [
  "crossbeam-channel",
  "thiserror 1.0.69",
- "time 0.3.37",
+ "time",
  "tracing-subscriber 0.3.19",
 ]
 
@@ -15266,7 +15255,7 @@ version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6b1f47d22deb79c3f59fcf2a1f00f60cbdc05462bf17d1cd356c1fefa3f444bd"
 dependencies = [
- "time 0.3.37",
+ "time",
  "tracing",
  "tracing-core",
  "tracing-subscriber 0.3.19",
@@ -15641,7 +15630,7 @@ dependencies = [
  "cfg-if",
  "regex",
  "rustversion",
- "time 0.3.37",
+ "time",
 ]
 
 [[package]]
@@ -15677,12 +15666,6 @@ checksum = "bfa7760aed19e106de2c7c0b581b509f2f25d3dacaf737cb82ac61bc6d760b0e"
 dependencies = [
  "try-lock",
 ]
-
-[[package]]
-name = "wasi"
-version = "0.10.0+wasi-snapshot-preview1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a143597ca7c7793eff794def352d41792a93c481eb1042423ff7ff72ba2c31f"
 
 [[package]]
 name = "wasi"
@@ -16523,16 +16506,15 @@ dependencies = [
 
 [[package]]
 name = "zip"
-version = "0.5.13"
+version = "0.6.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93ab48844d61251bb3835145c521d88aa4031d7139e8485990f60ca911fa0815"
+checksum = "760394e246e4c28189f19d488c058bf16f564016aefac5d32bb1f3b51d5e9261"
 dependencies = [
  "byteorder",
  "bzip2",
  "crc32fast",
+ "crossbeam-utils",
  "flate2",
- "thiserror 1.0.69",
- "time 0.1.45",
 ]
 
 [[package]]
@@ -16718,7 +16700,7 @@ dependencies = [
  "itertools 0.13.0",
  "lazy_static",
  "regex",
- "time 0.3.37",
+ "time",
  "wasm-bindgen",
  "web-sys",
 ]

--- a/crates/btcio/Cargo.toml
+++ b/crates/btcio/Cargo.toml
@@ -36,7 +36,7 @@ strata-status.workspace = true
 strata-test-utils.workspace = true
 
 arbitrary.workspace = true
-corepc-node = { version = "0.7.0", features = ["28_0", "download"] }
+corepc-node = { version = "0.7.1", features = ["28_0", "download"] }
 mockall.workspace = true
 
 [features]

--- a/crates/util/python-utils/Cargo.toml
+++ b/crates/util/python-utils/Cargo.toml
@@ -38,6 +38,6 @@ strata-common.workspace = true
 
 anyhow.workspace = true
 bitcoind-async-client.workspace = true
-corepc-node = { version = "0.7.0", features = ["28_0", "download"] }
+corepc-node = { version = "0.7.1", features = ["28_0", "download"] }
 tokio.workspace = true
 tracing.workspace = true

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -20,7 +20,7 @@ rustdoc.all = "warn"
 
 #anyhow.workspace = true                                  # anyhow should be fine for tests
 #bitcoincore-rpc = "0.19.0"
-#corepc-node = { version = "0.7.0", features = ["28_0", "download"] }
+#corepc-node = { version = "0.7.1", features = ["28_0", "download"] }
 #threadpool.workspace = true
 #tokio.workspace = true
 #tracing.workspace = true


### PR DESCRIPTION
## Description

There's a RUSTSEC advisory on time that should be updated to >=0.2.23. It gets pulled down from corepc-node with download feature from the zip dependency, see the cargo tree below:

```
time 0.1.45
└── zip 0.5.13
    └── corepc-node 0.7.0
```

This was fixed in corepc-node 0.7.1, see
https://github.com/rust-bitcoin/corepc/pull/143

Closes https://github.com/alpenlabs/strata/security/dependabot/23.

### Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature/Enhancement (non-breaking change which adds functionality or enhances an existing one)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactor
- [ ] New or updated tests
- [x] Dependency Update
- [ ] Security Update

## Notes to Reviewers

<!--
Anything in particular you want to note that will help reviewers fulfill their role
in reviewing this PR?
-->

## Checklist

<!--
Ensure all the following are checked:
-->

- [x] I have performed a self-review of my code.
- [x] I have commented my code where necessary.
- [x] I have updated the documentation if needed.
- [x] My changes do not introduce new warnings.
- [x] I have added (where necessary) tests that prove my changes are effective or that my feature works.
- [x] New and existing tests pass with my changes.

## Related Issues

<!--
Link any related issues (e.g., `closes #123`, `fixes #456`).
-->
