### PR TITLE
(STR-1349): Do not include deposit request in protocol ops

### DIFF
--- a/crates/btcio/src/reader/tx_indexer.rs
+++ b/crates/btcio/src/reader/tx_indexer.rs
@@ -47,7 +47,6 @@ impl TxVisitor for ReaderTxVisitorImpl {
     }
 
     fn visit_deposit_request(&mut self, dr: DepositRequestInfo) {
-        self.ops.push(ProtocolOperation::DepositRequest(dr.clone()));
         self.deposit_requests.push(dr);
     }
 
@@ -156,6 +155,8 @@ mod test {
         }
     }
 
+    // Ignored because deposit request is not included as ops
+    #[ignore]
     #[test]
     fn test_index_txs_deposit_request() {
         let params = gen_params();

--- a/crates/btcio/src/reader/tx_indexer.rs
+++ b/crates/btcio/src/reader/tx_indexer.rs
@@ -82,6 +82,7 @@ mod test {
         test_index_deposit_request_with_visitor, test_index_deposit_with_visitor,
         test_index_multiple_deposits_with_visitor, test_index_no_deposit_with_visitor,
         test_index_tx_with_multiple_ops_with_visitor,
+        test_index_withdrawal_fulfillment_with_visitor,
     };
 
     use crate::reader::tx_indexer::ReaderTxVisitorImpl;
@@ -96,29 +97,38 @@ mod test {
     #[ignore = "Ignored because deposit request is not included as ops"]
     #[test]
     fn test_index_txs_deposit_request() {
-        let _ = test_index_deposit_request_with_visitor(ReaderTxVisitorImpl::new, |tx| {
-            tx.contents().protocol_ops().to_vec()
+        let _ = test_index_deposit_request_with_visitor(ReaderTxVisitorImpl::new, |ind_output| {
+            ind_output.contents().protocol_ops().to_vec()
         });
     }
 
     #[test]
     fn test_index_no_deposit() {
-        let _ = test_index_no_deposit_with_visitor(ReaderTxVisitorImpl::new, |tx| {
-            tx.contents().protocol_ops().to_vec()
+        let _ = test_index_no_deposit_with_visitor(ReaderTxVisitorImpl::new, |ind_output| {
+            ind_output.contents().protocol_ops().to_vec()
         });
     }
 
     #[test]
     fn test_index_multiple_deposits() {
-        let _ = test_index_multiple_deposits_with_visitor(ReaderTxVisitorImpl::new, |op_txs| {
-            op_txs.contents().protocol_ops().to_vec()
+        let _ = test_index_multiple_deposits_with_visitor(ReaderTxVisitorImpl::new, |ind_output| {
+            ind_output.contents().protocol_ops().to_vec()
         });
     }
 
     #[test]
     fn test_index_tx_with_multiple_ops() {
-        let _ = test_index_tx_with_multiple_ops_with_visitor(ReaderTxVisitorImpl::new, |tx| {
-            tx.contents().protocol_ops().to_vec()
-        });
+        let _ =
+            test_index_tx_with_multiple_ops_with_visitor(ReaderTxVisitorImpl::new, |ind_output| {
+                ind_output.contents().protocol_ops().to_vec()
+            });
+    }
+
+    #[test]
+    fn test_index_withdrawal_fulfillment() {
+        let _ = test_index_withdrawal_fulfillment_with_visitor(
+            ReaderTxVisitorImpl::new,
+            |ind_output| ind_output.contents().protocol_ops().to_vec(),
+        );
     }
 }

--- a/crates/btcio/src/reader/tx_indexer.rs
+++ b/crates/btcio/src/reader/tx_indexer.rs
@@ -78,285 +78,47 @@ impl TxVisitor for ReaderTxVisitorImpl {
 
 #[cfg(test)]
 mod test {
-    use bitcoin::{
-        block::{Header, Version},
-        hashes::Hash,
-        Amount, Block, BlockHash, CompactTarget, ScriptBuf, Transaction, TxMerkleNode,
-    };
-    use strata_l1tx::{filter::indexer::index_block, utils::test_utils::create_tx_filter_config};
-    use strata_primitives::l1::{payload::L1Payload, BitcoinAmount, ProtocolOperation};
-    use strata_test_utils::{
-        bitcoin::{
-            build_test_deposit_request_script, build_test_deposit_script, create_test_deposit_tx,
-            test_taproot_addr,
-        },
-        l2::{gen_params, get_test_signed_checkpoint},
+    use strata_test_utils::tx_indexer::{
+        test_index_deposit_request_with_visitor, test_index_deposit_with_visitor,
+        test_index_multiple_deposits_with_visitor, test_index_no_deposit_with_visitor,
+        test_index_tx_with_multiple_ops_with_visitor,
     };
 
-    use crate::{
-        reader::tx_indexer::ReaderTxVisitorImpl, test_utils::create_checkpoint_envelope_tx,
-    };
-
-    const TEST_ADDR: &str = "bcrt1q6u6qyya3sryhh42lahtnz2m7zuufe7dlt8j0j5";
-
-    //Helper function to create a test block with given transactions
-    fn create_test_block(transactions: Vec<Transaction>) -> Block {
-        let bhash = BlockHash::from_byte_array([0; 32]);
-        Block {
-            header: Header {
-                version: Version::ONE,
-                prev_blockhash: bhash,
-                merkle_root: TxMerkleNode::from_byte_array(*bhash.as_byte_array()),
-                time: 100,
-                bits: CompactTarget::from_consensus(1),
-                nonce: 1,
-            },
-            txdata: transactions,
-        }
-    }
+    use crate::reader::tx_indexer::ReaderTxVisitorImpl;
 
     #[test]
     fn test_index_deposits() {
-        let params = gen_params();
-        let (filter_config, keypair) = create_tx_filter_config(&params);
-        let deposit_config = filter_config.deposit_config.clone();
-        let idx = 0xdeadbeef;
-        let ee_addr = vec![1u8; 20]; // Example EVM address
-        let tapnode_hash = [0u8; 32];
-        let deposit_script =
-            build_test_deposit_script(&deposit_config, idx, ee_addr.clone(), &tapnode_hash);
-
-        let tx = create_test_deposit_tx(
-            Amount::from_sat(deposit_config.deposit_amount),
-            &deposit_config.address.address().script_pubkey(),
-            &deposit_script,
-            &keypair,
-            &tapnode_hash,
-        );
-
-        let block = create_test_block(vec![tx]);
-
-        let tx_entries = index_block(&block, ReaderTxVisitorImpl::new, &filter_config);
-
-        assert_eq!(tx_entries.len(), 1, "Should find one relevant transaction");
-
-        for op in tx_entries[0].contents().protocol_ops() {
-            if let ProtocolOperation::Deposit(deposit_info) = op {
-                assert_eq!(deposit_info.address, ee_addr, "test: dest should match");
-                assert_eq!(deposit_info.deposit_idx, idx, "test: idx should match");
-                assert_eq!(
-                    deposit_info.amt,
-                    BitcoinAmount::from_sat(deposit_config.deposit_amount),
-                    "Deposit amount should match"
-                );
-            } else {
-                panic!("Expected Deposit info");
-            }
-        }
+        let _ = test_index_deposit_with_visitor(ReaderTxVisitorImpl::new, |tx| {
+            tx.contents().protocol_ops().to_vec()
+        });
     }
 
-    // Ignored because deposit request is not included as ops
-    #[ignore]
+    #[ignore = "Ignored because deposit request is not included as ops"]
     #[test]
     fn test_index_txs_deposit_request() {
-        let params = gen_params();
-        let (filter_config, key_pair) = create_tx_filter_config(&params);
-        let mut deposit_config = filter_config.deposit_config.clone();
-
-        let extra_amt = 10000;
-        deposit_config.deposit_amount += extra_amt;
-        let dest_addr = vec![2u8; 20]; // Example EVM address
-        let dummy_block = [0u8; 32]; // Example dummy block
-        let tapnode_hash = [0u8; 32];
-
-        let deposit_request_script = build_test_deposit_request_script(
-            deposit_config.magic_bytes.clone(),
-            dummy_block.to_vec(),
-            dest_addr.clone(),
-        );
-
-        let tx = create_test_deposit_tx(
-            Amount::from_sat(deposit_config.deposit_amount), // Any amount
-            &deposit_config.address.address().script_pubkey(),
-            &deposit_request_script,
-            &key_pair,
-            &tapnode_hash,
-        );
-
-        let block = create_test_block(vec![tx]);
-
-        let tx_entries = index_block(&block, ReaderTxVisitorImpl::new, &filter_config);
-        let dep_reqs = tx_entries
-            .iter()
-            .flat_map(|tx| tx.contents().deposit_reqs())
-            .collect::<Vec<_>>();
-
-        assert_eq!(dep_reqs.len(), 1, "Should find one deposit request");
-
-        for dep_req_info in dep_reqs {
-            assert_eq!(dep_req_info.address, dest_addr, "EE address should match");
-            assert_eq!(
-                dep_req_info.take_back_leaf_hash, dummy_block,
-                "Control block should match"
-            );
-        }
+        let _ = test_index_deposit_request_with_visitor(ReaderTxVisitorImpl::new, |tx| {
+            tx.contents().protocol_ops().to_vec()
+        });
     }
 
     #[test]
     fn test_index_no_deposit() {
-        let params = gen_params();
-        let (filter_config, keypair) = create_tx_filter_config(&params);
-        let deposit_config = filter_config.deposit_config.clone();
-        let tapnode_hash = [0u8; 32];
-        let irrelevant_tx = create_test_deposit_tx(
-            Amount::from_sat(deposit_config.deposit_amount),
-            &test_taproot_addr().address().script_pubkey(),
-            &ScriptBuf::new(),
-            &keypair,
-            &tapnode_hash,
-        );
-
-        let block = create_test_block(vec![irrelevant_tx]);
-
-        let tx_entries = index_block(&block, ReaderTxVisitorImpl::new, &filter_config);
-
-        assert!(
-            tx_entries.is_empty(),
-            "Should not find any relevant transactions"
-        );
+        let _ = test_index_no_deposit_with_visitor(ReaderTxVisitorImpl::new, |tx| {
+            tx.contents().protocol_ops().to_vec()
+        });
     }
 
     #[test]
     fn test_index_multiple_deposits() {
-        let params = gen_params();
-        let (filter_config, keypair) = create_tx_filter_config(&params);
-        let deposit_config = filter_config.deposit_config.clone();
-        let idx1 = 0xdeadbeef;
-        let idx2 = 0x1badb007;
-        let dest_addr1 = vec![3u8; 20];
-        let dest_addr2 = vec![4u8; 20];
-        let tapnode_hash = [0u8; 32];
-
-        let deposit_script1 =
-            build_test_deposit_script(&deposit_config, idx1, dest_addr1.clone(), &tapnode_hash);
-        let deposit_script2 =
-            build_test_deposit_script(&deposit_config, idx2, dest_addr2.clone(), &tapnode_hash);
-
-        let tx1 = create_test_deposit_tx(
-            Amount::from_sat(deposit_config.deposit_amount),
-            &deposit_config.address.address().script_pubkey(),
-            &deposit_script1,
-            &keypair,
-            &tapnode_hash,
-        );
-        let tx2 = create_test_deposit_tx(
-            Amount::from_sat(deposit_config.deposit_amount),
-            &deposit_config.address.address().script_pubkey(),
-            &deposit_script2,
-            &keypair,
-            &tapnode_hash,
-        );
-
-        let block = create_test_block(vec![tx1, tx2]);
-
-        let tx_entries = index_block(&block, ReaderTxVisitorImpl::new, &filter_config);
-
-        assert_eq!(tx_entries.len(), 2, "Should find two relevant transactions");
-
-        for (i, info) in tx_entries
-            .iter()
-            .flat_map(|op_txs| op_txs.contents().protocol_ops())
-            .enumerate()
-        {
-            if let ProtocolOperation::Deposit(deposit_info) = info {
-                assert_eq!(
-                    deposit_info.address,
-                    if i == 0 {
-                        dest_addr1.clone()
-                    } else {
-                        dest_addr2.clone()
-                    },
-                    "test: dest should match for transaction {i}",
-                );
-                assert_eq!(
-                    deposit_info.deposit_idx,
-                    [idx1, idx2][i],
-                    "test: idx should match"
-                );
-                assert_eq!(
-                    deposit_info.amt,
-                    BitcoinAmount::from_sat(deposit_config.deposit_amount),
-                    "test: deposit amount should match for transaction {i}",
-                );
-            } else {
-                panic!("test: expected DepositInfo for transaction {i}");
-            }
-        }
+        let _ = test_index_multiple_deposits_with_visitor(ReaderTxVisitorImpl::new, |op_txs| {
+            op_txs.contents().protocol_ops().to_vec()
+        });
     }
 
-    // TODO; re-enable this when we decide multiple ops can be present with deposits
-    // Also, This could just be okay in the future where protocol Ops is going to be replaced by
-    // some other mechanism.
-    #[ignore]
     #[test]
     fn test_index_tx_with_multiple_ops() {
-        let params = gen_params();
-        let (filter_config, keypair) = create_tx_filter_config(&params);
-        let deposit_config = filter_config.deposit_config.clone();
-        let idx = 0xdeadbeef;
-        let ee_addr = vec![1u8; 20]; // Example EVM address
-        let tapnode_hash = [0u8; 32];
-
-        // Create deposit utxo
-        let deposit_script =
-            build_test_deposit_script(&deposit_config, idx, ee_addr.clone(), &tapnode_hash);
-
-        let mut tx = create_test_deposit_tx(
-            Amount::from_sat(deposit_config.deposit_amount),
-            &deposit_config.address.address().script_pubkey(),
-            &deposit_script,
-            &keypair,
-            &tapnode_hash,
-        );
-
-        // Create envelope tx and copy its input to the above deposit tx
-        let num_envelopes = 1;
-        let l1_payloads: Vec<_> = (0..num_envelopes)
-            .map(|_| {
-                let signed_checkpoint = get_test_signed_checkpoint();
-                L1Payload::new_checkpoint(borsh::to_vec(&signed_checkpoint).unwrap())
-            })
-            .collect();
-        let envtx = create_checkpoint_envelope_tx(&params, TEST_ADDR, l1_payloads);
-        tx.input.push(envtx.input[0].clone());
-
-        // Create a block with single tx that has multiple ops
-        let block = create_test_block(vec![tx]);
-
-        let tx_entries = index_block(&block, ReaderTxVisitorImpl::new, &filter_config);
-        println!("tx_entries: {:?}", tx_entries);
-
-        assert_eq!(
-            tx_entries.len(),
-            1,
-            "Should find one matching transaction entry"
-        );
-        assert_eq!(
-            tx_entries[0].contents().protocol_ops().len(),
-            2,
-            "Should find two protocol ops"
-        );
-
-        let mut dep_count = 0;
-        let mut ckpt_count = 0;
-        for op in tx_entries[0].contents().protocol_ops() {
-            match op {
-                ProtocolOperation::Deposit(_) => dep_count += 1,
-                ProtocolOperation::Checkpoint(_) => ckpt_count += 1,
-                _ => {}
-            }
-        }
-        assert_eq!(dep_count, 1, "should have one deposit");
-        assert_eq!(ckpt_count, 1, "should have one checkpoint");
+        let _ = test_index_tx_with_multiple_ops_with_visitor(ReaderTxVisitorImpl::new, |tx| {
+            tx.contents().protocol_ops().to_vec()
+        });
     }
 }

--- a/crates/l1tx/src/filter/withdrawal_fulfillment.rs
+++ b/crates/l1tx/src/filter/withdrawal_fulfillment.rs
@@ -126,7 +126,6 @@ mod test {
             generate_withdrawal_fulfillment_data(deposit_amt());
         let filterconfig = get_filter_config_from_deposit_entries(params, &deposit_entries);
 
-
         let txn = Transaction {
             version: Version(1),
             lock_time: LockTime::from_height(0).unwrap(),
@@ -175,7 +174,6 @@ mod test {
             generate_withdrawal_fulfillment_data(deposit_amt());
         let filterconfig = get_filter_config_from_deposit_entries(params, &deposit_entries);
 
-
         let txn = Transaction {
             version: Version(1),
             lock_time: LockTime::from_height(0).unwrap(),
@@ -213,7 +211,6 @@ mod test {
         let (addresses, txids, deposit_entries) =
             generate_withdrawal_fulfillment_data(deposit_amt());
         let filterconfig = get_filter_config_from_deposit_entries(params, &deposit_entries);
-
 
         let txn = Transaction {
             version: Version(1),
@@ -253,7 +250,6 @@ mod test {
             generate_withdrawal_fulfillment_data(deposit_amt());
         let filterconfig = get_filter_config_from_deposit_entries(params, &deposit_entries);
 
-
         let txn = Transaction {
             version: Version(1),
             lock_time: LockTime::from_height(0).unwrap(),
@@ -289,7 +285,6 @@ mod test {
         let params: Params = gen_params();
         let (addresses, _, deposit_entries) = generate_withdrawal_fulfillment_data(deposit_amt());
         let filterconfig = get_filter_config_from_deposit_entries(params, &deposit_entries);
-
 
         let txn = Transaction {
             version: Version(1),

--- a/crates/l1tx/src/filter/withdrawal_fulfillment.rs
+++ b/crates/l1tx/src/filter/withdrawal_fulfillment.rs
@@ -5,7 +5,7 @@ use strata_primitives::{
 };
 use tracing::debug;
 
-use super::TxFilterConfig;
+use crate::filter::types::TxFilterConfig;
 
 /// Parse transaction and search for a Withdrawal Fulfillment transaction to an expected address.
 pub fn try_parse_tx_as_withdrawal_fulfillment(
@@ -96,19 +96,18 @@ fn parse_opreturn_metadata(script_buf: &ScriptBuf) -> Option<(u32, u32, [u8; 32]
 
 #[cfg(test)]
 mod test {
-    use bitcoin::{
-        absolute::LockTime, consensus, transaction::Version, Amount, OutPoint, Transaction, TxOut,
-    };
-    use strata_primitives::{
-        bitcoin_bosd::Descriptor, l1::OutputRef, params::Params, sorted_vec::FlatTable,
-    };
-    use strata_state::bridge_state::{
-        DepositEntry, DepositState, DispatchCommand, DispatchedState, WithdrawOutput,
-    };
-    use strata_test_utils::{l2::gen_params, ArbitraryGenerator};
+    use bitcoin::{absolute::LockTime, transaction::Version, Amount, Transaction, TxOut};
+    use strata_primitives::params::Params;
+    use strata_test_utils::{bitcoin::generate_withdrawal_fulfillment_data, l2::gen_params};
 
     use super::*;
-    use crate::filter::types::{conv_deposit_to_fulfillment, OPERATOR_FEE};
+    use crate::{
+        filter::types::OPERATOR_FEE,
+        utils::test_utils::{
+            create_opreturn_metadata_for_withdrawal_fulfillment,
+            get_filter_config_from_deposit_entries,
+        },
+    };
 
     const DEPOSIT_AMT: Amount = Amount::from_int_btc(10);
 
@@ -120,120 +119,14 @@ mod test {
         DEPOSIT_AMT - OPERATOR_FEE
     }
 
-    fn create_opreturn_metadata(
-        operator_idx: u32,
-        deposit_idx: u32,
-        deposit_txid: &[u8; 32],
-    ) -> ScriptBuf {
-        let mut metadata = [0u8; 40];
-        // first 4 bytes = operator idx
-        metadata[..4].copy_from_slice(&operator_idx.to_be_bytes());
-        // next 4 bytes = deposit idx
-        metadata[4..8].copy_from_slice(&deposit_idx.to_be_bytes());
-        metadata[8..40].copy_from_slice(deposit_txid);
-        Descriptor::new_op_return(&metadata).unwrap().to_script()
-    }
-
-    fn create_outputref(txid_bytes: &[u8; 32], vout: u32) -> OutputRef {
-        OutPoint::new(consensus::deserialize(txid_bytes).unwrap(), vout).into()
-    }
-
-    fn generate_data() -> (Vec<Descriptor>, Vec<[u8; 32]>, TxFilterConfig) {
-        let params: Params = gen_params();
-        let mut gen = ArbitraryGenerator::new();
-        let mut addresses = Vec::new();
-        let mut txids = Vec::<[u8; 32]>::new();
-        for _ in 0..10 {
-            addresses.push(Descriptor::new_p2wpkh(&gen.generate()));
-            txids.push(gen.generate());
-        }
-
-        let mut filterconfig = TxFilterConfig::derive_from(params.rollup()).unwrap();
-
-        let create_dispatched_deposit_entry =
-            |operator_idx: u32,
-             deposit_idx: u32,
-             addr: Descriptor,
-             deadline: u64,
-             deposit_txid: &[u8; 32],
-             withdrawal_request_txid: Option<Buf32>| {
-                DepositEntry::new(
-                    deposit_idx,
-                    create_outputref(deposit_txid, 0),
-                    vec![0, 1, 2],
-                    deposit_amt(),
-                    withdrawal_request_txid,
-                )
-                .with_state(DepositState::Dispatched(DispatchedState::new(
-                    DispatchCommand::new(vec![WithdrawOutput::new(
-                        addr,
-                        Amount::from_btc(10.0).unwrap().into(),
-                    )]),
-                    operator_idx,
-                    deadline,
-                )))
-            };
-
-        let deposits = vec![
-            // deposits with withdrawal assignments
-            create_dispatched_deposit_entry(
-                1,
-                2,
-                addresses[0].clone(),
-                100,
-                &txids[0],
-                gen.generate(),
-            ),
-            create_dispatched_deposit_entry(
-                2,
-                3,
-                addresses[1].clone(),
-                100,
-                &txids[1],
-                gen.generate(),
-            ),
-            create_dispatched_deposit_entry(
-                0,
-                4,
-                addresses[2].clone(),
-                100,
-                &txids[2],
-                gen.generate(),
-            ),
-            // deposits without withdrawal assignments
-            DepositEntry::new(
-                5,
-                create_outputref(&txids[3], 0),
-                vec![0, 1, 2],
-                deposit_amt(),
-                None,
-            )
-            .with_state(DepositState::Accepted),
-            DepositEntry::new(
-                6,
-                create_outputref(&txids[4], 0),
-                vec![0, 1, 2],
-                deposit_amt(),
-                None,
-            )
-            .with_state(DepositState::Accepted),
-        ];
-
-        // Watch all withdrawals that have been ordered.
-        let exp_fulfillments = deposits
-            .iter()
-            .flat_map(conv_deposit_to_fulfillment)
-            .collect::<Vec<_>>();
-
-        filterconfig.expected_withdrawal_fulfillments =
-            FlatTable::try_from_unsorted(exp_fulfillments).expect("types: malformed deposits");
-
-        (addresses, txids, filterconfig)
-    }
-
     #[test]
     fn test_parse_withdrawal_fulfillment_transactions_ok() {
-        let (addresses, txids, filterconfig) = generate_data();
+        let params: Params = gen_params();
+        let (addresses, txids, deposit_entries) =
+            generate_withdrawal_fulfillment_data(deposit_amt());
+        let filterconfig = get_filter_config_from_deposit_entries(params, &deposit_entries);
+
+
         let txn = Transaction {
             version: Version(1),
             lock_time: LockTime::from_height(0).unwrap(),
@@ -246,7 +139,9 @@ mod test {
                 },
                 // metadata with operator index
                 TxOut {
-                    script_pubkey: create_opreturn_metadata(1, 2, &txids[0]),
+                    script_pubkey: create_opreturn_metadata_for_withdrawal_fulfillment(
+                        1, 2, &txids[0],
+                    ),
                     value: Amount::from_sat(0),
                 },
                 // change
@@ -275,7 +170,11 @@ mod test {
     #[test]
     fn test_parse_withdrawal_fulfillment_transactions_fail_wrong_order() {
         // TESTCASE: valid withdrawal, but different order of txout
-        let (addresses, txids, filterconfig) = generate_data();
+        let params: Params = gen_params();
+        let (addresses, txids, deposit_entries) =
+            generate_withdrawal_fulfillment_data(deposit_amt());
+        let filterconfig = get_filter_config_from_deposit_entries(params, &deposit_entries);
+
 
         let txn = Transaction {
             version: Version(1),
@@ -289,7 +188,9 @@ mod test {
                 },
                 // metadata with operator index
                 TxOut {
-                    script_pubkey: create_opreturn_metadata(1, 2, &txids[0]),
+                    script_pubkey: create_opreturn_metadata_for_withdrawal_fulfillment(
+                        1, 2, &txids[0],
+                    ),
                     value: Amount::from_sat(0),
                 },
                 // front payment
@@ -308,7 +209,11 @@ mod test {
     #[test]
     fn test_parse_withdrawal_fulfillment_transactions_fail_wrong_operator() {
         // TESTCASE: correct amount but wrong operator idx for deposit
-        let (addresses, txids, filterconfig) = generate_data();
+        let params: Params = gen_params();
+        let (addresses, txids, deposit_entries) =
+            generate_withdrawal_fulfillment_data(deposit_amt());
+        let filterconfig = get_filter_config_from_deposit_entries(params, &deposit_entries);
+
 
         let txn = Transaction {
             version: Version(1),
@@ -322,7 +227,9 @@ mod test {
                 },
                 // metadata with operator index
                 TxOut {
-                    script_pubkey: create_opreturn_metadata(2, 2, &txids[0]),
+                    script_pubkey: create_opreturn_metadata_for_withdrawal_fulfillment(
+                        2, 2, &txids[0],
+                    ),
                     value: Amount::from_sat(0),
                 },
                 // change
@@ -341,7 +248,11 @@ mod test {
     #[test]
     fn test_parse_withdrawal_fulfillment_transactions_fail_wrong_deposit_txid() {
         // TESTCASE: correct amount and operator idx for deposit, but wrong deposit txid
-        let (addresses, txids, filterconfig) = generate_data();
+        let params: Params = gen_params();
+        let (addresses, txids, deposit_entries) =
+            generate_withdrawal_fulfillment_data(deposit_amt());
+        let filterconfig = get_filter_config_from_deposit_entries(params, &deposit_entries);
+
 
         let txn = Transaction {
             version: Version(1),
@@ -355,7 +266,9 @@ mod test {
                 },
                 // metadata with operator index
                 TxOut {
-                    script_pubkey: create_opreturn_metadata(1, 2, &txids[5]),
+                    script_pubkey: create_opreturn_metadata_for_withdrawal_fulfillment(
+                        1, 2, &txids[5],
+                    ),
                     value: Amount::from_sat(0),
                 },
                 // change
@@ -373,7 +286,10 @@ mod test {
 
     #[test]
     fn test_parse_withdrawal_fulfillment_transactions_fail_missing_op_return() {
-        let (addresses, _txids, filterconfig) = generate_data();
+        let params: Params = gen_params();
+        let (addresses, _, deposit_entries) = generate_withdrawal_fulfillment_data(deposit_amt());
+        let filterconfig = get_filter_config_from_deposit_entries(params, &deposit_entries);
+
 
         let txn = Transaction {
             version: Version(1),

--- a/crates/proof-impl/btc-blockspace/src/tx_indexer.rs
+++ b/crates/proof-impl/btc-blockspace/src/tx_indexer.rs
@@ -1,7 +1,9 @@
 use strata_l1tx::filter::indexer::TxVisitor;
 use strata_primitives::{
     batch::SignedCheckpoint,
-    l1::{DaCommitment, DepositInfo, ProtocolOperation},
+    l1::{
+        DaCommitment, DepositInfo, DepositSpendInfo, ProtocolOperation, WithdrawalFulfillmentInfo,
+    },
 };
 
 /// Ops indexer for use with the prover.
@@ -34,6 +36,15 @@ impl TxVisitor for ProverTxVisitorImpl {
 
     fn visit_checkpoint(&mut self, ckpt: SignedCheckpoint) {
         self.ops.push(ProtocolOperation::Checkpoint(ckpt));
+    }
+
+    fn visit_withdrawal_fulfillment(&mut self, info: WithdrawalFulfillmentInfo) {
+        self.ops
+            .push(ProtocolOperation::WithdrawalFulfillment(info));
+    }
+
+    fn visit_deposit_spend(&mut self, info: DepositSpendInfo) {
+        self.ops.push(ProtocolOperation::DepositSpent(info));
     }
 
     fn finalize(self) -> Option<Vec<ProtocolOperation>> {

--- a/crates/proof-impl/btc-blockspace/src/tx_indexer.rs
+++ b/crates/proof-impl/btc-blockspace/src/tx_indexer.rs
@@ -60,248 +60,46 @@ impl TxVisitor for ProverTxVisitorImpl {
 /// visitor `ProverOpsVisitor` and indexing of deposit requests.
 #[cfg(test)]
 mod test {
-    use bitcoin::{
-        block::{Header, Version},
-        hashes::Hash,
-        Amount, Block, BlockHash, CompactTarget, ScriptBuf, Transaction, TxMerkleNode,
-    };
-    use strata_btcio::test_utils::create_checkpoint_envelope_tx;
-    use strata_l1tx::{filter::indexer::index_block, utils::test_utils::create_tx_filter_config};
-    use strata_primitives::l1::{payload::L1Payload, BitcoinAmount, ProtocolOperation};
-    use strata_test_utils::{
-        bitcoin::{build_test_deposit_script, create_test_deposit_tx, test_taproot_addr},
-        l2::{gen_params, get_test_signed_checkpoint},
+    use strata_test_utils::tx_indexer::{
+        test_index_deposit_request_with_visitor, test_index_deposit_with_visitor,
+        test_index_multiple_deposits_with_visitor, test_index_no_deposit_with_visitor,
+        test_index_tx_with_multiple_ops_with_visitor,
     };
 
     use super::ProverTxVisitorImpl;
 
-    const TEST_ADDR: &str = "bcrt1q6u6qyya3sryhh42lahtnz2m7zuufe7dlt8j0j5";
-
-    //Helper function to create a test block with given transactions
-    fn create_test_block(transactions: Vec<Transaction>) -> Block {
-        let bhash = BlockHash::from_byte_array([0; 32]);
-        Block {
-            header: Header {
-                version: Version::ONE,
-                prev_blockhash: bhash,
-                merkle_root: TxMerkleNode::from_byte_array(*bhash.as_byte_array()),
-                time: 100,
-                bits: CompactTarget::from_consensus(1),
-                nonce: 1,
-            },
-            txdata: transactions,
-        }
-    }
-
     #[test]
     fn test_index_deposits() {
-        let params = gen_params();
-        let (filter_config, keypair) = create_tx_filter_config(&params);
-        let deposit_config = filter_config.deposit_config.clone();
-        let idx = 0xdeadbeef;
-        let ee_addr = vec![1u8; 20]; // Example EVM address
-        let tapnode_hash = [0u8; 32];
-        let deposit_script =
-            build_test_deposit_script(&deposit_config, idx, ee_addr.clone(), &tapnode_hash);
+        let _ =
+            test_index_deposit_with_visitor(ProverTxVisitorImpl::new, |tx| tx.contents().clone());
+    }
 
-        let tx = create_test_deposit_tx(
-            Amount::from_sat(deposit_config.deposit_amount),
-            &deposit_config.address.address().script_pubkey(),
-            &deposit_script,
-            &keypair,
-            &tapnode_hash,
-        );
-
-        let block = create_test_block(vec![tx]);
-
-        let tx_entries = index_block(&block, ProverTxVisitorImpl::new, &filter_config);
-
-        assert_eq!(
-            tx_entries.len(),
-            1,
-            "test: should find one relevant transaction"
-        );
-
-        for op in tx_entries[0].contents() {
-            if let ProtocolOperation::Deposit(deposit_info) = op {
-                assert_eq!(
-                    deposit_info.address, ee_addr,
-                    "test: EE address should match"
-                );
-                assert_eq!(
-                    deposit_info.deposit_idx, idx,
-                    "test: deposit idx should match"
-                );
-                assert_eq!(
-                    deposit_info.amt,
-                    BitcoinAmount::from_sat(deposit_config.deposit_amount),
-                    "test: deposit amount should match"
-                );
-            } else {
-                panic!("test: expected DepositInfo");
-            }
-        }
+    #[ignore = "Ignored because deposit request is not included as ops"]
+    #[test]
+    fn test_index_txs_deposit_request() {
+        let _ = test_index_deposit_request_with_visitor(ProverTxVisitorImpl::new, |tx| {
+            tx.contents().clone()
+        });
     }
 
     #[test]
     fn test_index_no_deposit() {
-        let params = gen_params();
-        let (filter_config, keypair) = create_tx_filter_config(&params);
-        let tapnode_hash = [0u8; 32];
-        let deposit_config = filter_config.deposit_config.clone();
-        let irrelevant_tx = create_test_deposit_tx(
-            Amount::from_sat(deposit_config.deposit_amount),
-            &test_taproot_addr().address().script_pubkey(),
-            &ScriptBuf::new(),
-            &keypair,
-            &tapnode_hash,
-        );
-
-        let block = create_test_block(vec![irrelevant_tx]);
-
-        let tx_entries = index_block(&block, ProverTxVisitorImpl::new, &filter_config);
-
-        assert!(
-            tx_entries.is_empty(),
-            "Should not find any relevant transactions"
-        );
+        let _ = test_index_no_deposit_with_visitor(ProverTxVisitorImpl::new, |tx| {
+            tx.contents().clone()
+        });
     }
 
     #[test]
     fn test_index_multiple_deposits() {
-        let params = gen_params();
-        let (filter_config, keypair) = create_tx_filter_config(&params);
-        let deposit_config = filter_config.deposit_config.clone();
-        let idx1 = 0xdeafbeef;
-        let idx2 = 0x1badb007;
-        let dest_addr1 = vec![3u8; 20];
-        let dest_addr2 = vec![4u8; 20];
-        let tapnodehash = [0u8; 32];
-
-        let deposit_script1 =
-            build_test_deposit_script(&deposit_config, idx1, dest_addr1.clone(), &tapnodehash);
-        let deposit_script2 =
-            build_test_deposit_script(&deposit_config, idx2, dest_addr2.clone(), &tapnodehash);
-
-        let tx1 = create_test_deposit_tx(
-            Amount::from_sat(deposit_config.deposit_amount),
-            &deposit_config.address.address().script_pubkey(),
-            &deposit_script1,
-            &keypair,
-            &tapnodehash,
-        );
-        let tx2 = create_test_deposit_tx(
-            Amount::from_sat(deposit_config.deposit_amount),
-            &deposit_config.address.address().script_pubkey(),
-            &deposit_script2,
-            &keypair,
-            &tapnodehash,
-        );
-
-        let block = create_test_block(vec![tx1, tx2]);
-
-        let tx_entries = index_block(&block, ProverTxVisitorImpl::new, &filter_config);
-
-        assert_eq!(
-            tx_entries.len(),
-            2,
-            "test: should find two relevant transactions"
-        );
-
-        for (i, info) in tx_entries
-            .iter()
-            .flat_map(|op_txs| op_txs.contents())
-            .enumerate()
-        {
-            if let ProtocolOperation::Deposit(deposit_info) = info {
-                assert_eq!(
-                    deposit_info.address,
-                    if i == 0 {
-                        dest_addr1.clone()
-                    } else {
-                        dest_addr2.clone()
-                    },
-                    "test: dest should match for transaction {i}",
-                );
-                assert_eq!(
-                    deposit_info.deposit_idx,
-                    [idx1, idx2][i],
-                    "test: deposit idx should match"
-                );
-                assert_eq!(
-                    deposit_info.amt,
-                    BitcoinAmount::from_sat(deposit_config.deposit_amount),
-                    "test: deposit amount should match for transaction {i}",
-                );
-            } else {
-                panic!("test: expected DepositInfo for transaction {i}");
-            }
-        }
+        let _ = test_index_multiple_deposits_with_visitor(ProverTxVisitorImpl::new, |op_txs| {
+            op_txs.contents().clone()
+        });
     }
 
-    // TODO; re-enable this when we decide multiple ops can be present with deposits
-    // Also, This could just be okay in the future where protocol Ops is going to be replaced by
-    // some other mechanism.
-    #[ignore]
     #[test]
     fn test_index_tx_with_multiple_ops() {
-        let params = gen_params();
-        let (filter_config, keypair) = create_tx_filter_config(&params);
-        let deposit_config = filter_config.deposit_config.clone();
-        let idx = 0xdeadbeef;
-        let ee_addr = vec![1u8; 20]; // Example EVM address
-        let tapnode_hash = [0u8; 32];
-
-        // Create deposit utxo
-        let deposit_script =
-            build_test_deposit_script(&deposit_config, idx, ee_addr.clone(), &tapnode_hash);
-
-        let mut tx = create_test_deposit_tx(
-            Amount::from_sat(deposit_config.deposit_amount),
-            &deposit_config.address.address().script_pubkey(),
-            &deposit_script,
-            &keypair,
-            &tapnode_hash,
-        );
-
-        // Create envelope tx and copy its input to the above deposit tx
-        let num_envelopes = 1;
-        let l1_payloads: Vec<_> = (0..num_envelopes)
-            .map(|_| {
-                let signed_checkpoint = get_test_signed_checkpoint();
-                L1Payload::new_checkpoint(borsh::to_vec(&signed_checkpoint).unwrap())
-            })
-            .collect();
-        let envtx = create_checkpoint_envelope_tx(&params, TEST_ADDR, l1_payloads);
-        tx.input.push(envtx.input[0].clone());
-
-        // Create a block with single tx that has multiple ops
-        let block = create_test_block(vec![tx]);
-
-        let tx_entries = index_block(&block, ProverTxVisitorImpl::new, &filter_config);
-
-        assert_eq!(
-            tx_entries.len(),
-            1,
-            "Should find one matching transaction entry"
-        );
-        assert_eq!(
-            tx_entries[0].contents().len(),
-            2,
-            "Should find two protocol ops"
-        );
-
-        let mut dep_count = 0;
-        let mut ckpt_count = 0;
-        for op in tx_entries[0].contents() {
-            match op {
-                ProtocolOperation::Deposit(_) => dep_count += 1,
-                ProtocolOperation::Checkpoint(_) => ckpt_count += 1,
-                _ => {}
-            }
-        }
-
-        assert_eq!(dep_count, 1, "should have one deposit");
-        assert_eq!(ckpt_count, 1, "should have one checkpoint");
+        let _ = test_index_tx_with_multiple_ops_with_visitor(ProverTxVisitorImpl::new, |tx| {
+            tx.contents().clone()
+        });
     }
 }

--- a/crates/proof-impl/btc-blockspace/src/tx_indexer.rs
+++ b/crates/proof-impl/btc-blockspace/src/tx_indexer.rs
@@ -64,28 +64,30 @@ mod test {
         test_index_deposit_request_with_visitor, test_index_deposit_with_visitor,
         test_index_multiple_deposits_with_visitor, test_index_no_deposit_with_visitor,
         test_index_tx_with_multiple_ops_with_visitor,
+        test_index_withdrawal_fulfillment_with_visitor,
     };
 
     use super::ProverTxVisitorImpl;
 
     #[test]
     fn test_index_deposits() {
-        let _ =
-            test_index_deposit_with_visitor(ProverTxVisitorImpl::new, |tx| tx.contents().clone());
+        let _ = test_index_deposit_with_visitor(ProverTxVisitorImpl::new, |ind_output| {
+            ind_output.contents().clone()
+        });
     }
 
     #[ignore = "Ignored because deposit request is not included as ops"]
     #[test]
     fn test_index_txs_deposit_request() {
-        let _ = test_index_deposit_request_with_visitor(ProverTxVisitorImpl::new, |tx| {
-            tx.contents().clone()
+        let _ = test_index_deposit_request_with_visitor(ProverTxVisitorImpl::new, |ind_output| {
+            ind_output.contents().clone()
         });
     }
 
     #[test]
     fn test_index_no_deposit() {
-        let _ = test_index_no_deposit_with_visitor(ProverTxVisitorImpl::new, |tx| {
-            tx.contents().clone()
+        let _ = test_index_no_deposit_with_visitor(ProverTxVisitorImpl::new, |ind_output| {
+            ind_output.contents().clone()
         });
     }
 
@@ -98,8 +100,17 @@ mod test {
 
     #[test]
     fn test_index_tx_with_multiple_ops() {
-        let _ = test_index_tx_with_multiple_ops_with_visitor(ProverTxVisitorImpl::new, |tx| {
-            tx.contents().clone()
-        });
+        let _ =
+            test_index_tx_with_multiple_ops_with_visitor(ProverTxVisitorImpl::new, |ind_output| {
+                ind_output.contents().clone()
+            });
+    }
+
+    #[test]
+    fn test_index_withdrawal_fulfillment() {
+        let _ = test_index_withdrawal_fulfillment_with_visitor(
+            ProverTxVisitorImpl::new,
+            |ind_output| ind_output.contents().clone(),
+        );
     }
 }

--- a/crates/test-utils/Cargo.toml
+++ b/crates/test-utils/Cargo.toml
@@ -10,10 +10,10 @@ rust.unused_crate_dependencies = "deny"
 strata-btcio.workspace = true
 strata-chaintsn.workspace = true
 strata-consensus-logic.workspace = true
-strata-l1tx.workspace = true
+strata-l1tx = { workspace = true, features = ["test_utils"] }
 strata-primitives.workspace = true
 strata-proofimpl-evm-ee-stf.workspace = true
-strata-state.workspace = true
+strata-state = { workspace = true, features = ["test_utils"] }
 
 anyhow.workspace = true
 arbitrary.workspace = true

--- a/crates/test-utils/src/lib.rs
+++ b/crates/test-utils/src/lib.rs
@@ -6,6 +6,7 @@ pub mod bitcoin_mainnet_segment;
 pub mod bridge;
 pub mod evm_ee;
 pub mod l2;
+pub mod tx_indexer;
 
 /// The default buffer size for the `ArbitraryGenerator`.
 const ARB_GEN_LEN: usize = 65_536;

--- a/crates/test-utils/src/tx_indexer.rs
+++ b/crates/test-utils/src/tx_indexer.rs
@@ -1,0 +1,279 @@
+use bitcoin::{
+    block::{Header, Version},
+    hashes::Hash,
+    Amount, Block, BlockHash, CompactTarget, ScriptBuf, Transaction, TxMerkleNode,
+};
+use strata_l1tx::{
+    filter::indexer::{index_block, TxVisitor},
+    messages::Indexed,
+    utils::test_utils::create_tx_filter_config,
+};
+use strata_primitives::l1::{BitcoinAmount, ProtocolOperation};
+
+use crate::{
+    bitcoin::{
+        build_test_deposit_request_script, build_test_deposit_script, create_test_deposit_tx,
+        test_taproot_addr,
+    },
+    l2::gen_params,
+};
+
+// TEST FUNCTIONS
+
+/// Runs a test deposit transaction with the given parameters and returns the indexer's output.
+/// The caller can then perform further tests on the output.
+pub fn test_index_multiple_deposits_with_visitor<V>(
+    visitor: impl Fn() -> V,
+    ops_extractor: fn(&Indexed<V::Output>) -> Vec<ProtocolOperation>,
+) -> Vec<Indexed<V::Output>>
+where
+    V: TxVisitor,
+{
+    let params = gen_params();
+    let (filter_config, keypair) = create_tx_filter_config(&params);
+    let deposit_config = filter_config.deposit_config.clone();
+    let idx1 = 0xdeafbeef;
+    let idx2 = 0x1badb007;
+    let dest_addr1 = vec![3u8; 20];
+    let dest_addr2 = vec![4u8; 20];
+    let tapnodehash = [0u8; 32];
+
+    let deposit_script1 =
+        build_test_deposit_script(&deposit_config, idx1, dest_addr1.clone(), &tapnodehash);
+    let deposit_script2 =
+        build_test_deposit_script(&deposit_config, idx2, dest_addr2.clone(), &tapnodehash);
+
+    let tx1 = create_test_deposit_tx(
+        Amount::from_sat(deposit_config.deposit_amount),
+        &deposit_config.address.address().script_pubkey(),
+        &deposit_script1,
+        &keypair,
+        &tapnodehash,
+    );
+    let tx2 = create_test_deposit_tx(
+        Amount::from_sat(deposit_config.deposit_amount),
+        &deposit_config.address.address().script_pubkey(),
+        &deposit_script2,
+        &keypair,
+        &tapnodehash,
+    );
+
+    let block = create_test_block(vec![tx1, tx2]);
+
+    let tx_entries = index_block(&block, visitor, &filter_config);
+
+    assert_eq!(
+        tx_entries.len(),
+        2,
+        "test: should find two relevant transactions"
+    );
+
+    for (i, info) in tx_entries.iter().flat_map(|e| ops_extractor(e)).enumerate() {
+        if let ProtocolOperation::Deposit(deposit_info) = info {
+            assert_eq!(
+                deposit_info.address,
+                if i == 0 {
+                    dest_addr1.clone()
+                } else {
+                    dest_addr2.clone()
+                },
+                "test: dest should match for transaction {i}",
+            );
+            assert_eq!(
+                deposit_info.deposit_idx,
+                [idx1, idx2][i],
+                "test: deposit idx should match"
+            );
+            assert_eq!(
+                deposit_info.amt,
+                BitcoinAmount::from_sat(deposit_config.deposit_amount),
+                "test: deposit amount should match for transaction {i}",
+            );
+        } else {
+            panic!("test: expected DepositInfo for transaction {i}");
+        }
+    }
+
+    tx_entries
+}
+
+pub fn test_index_no_deposit_with_visitor<V>(
+    visitor: impl Fn() -> V,
+    _: fn(&Indexed<V::Output>) -> Vec<ProtocolOperation>,
+) -> Vec<Indexed<V::Output>>
+where
+    V: TxVisitor,
+{
+    let params = gen_params();
+    let (filter_config, keypair) = create_tx_filter_config(&params);
+    let tapnode_hash = [0u8; 32];
+    let deposit_config = filter_config.deposit_config.clone();
+    let irrelevant_tx = create_test_deposit_tx(
+        Amount::from_sat(deposit_config.deposit_amount),
+        &test_taproot_addr().address().script_pubkey(),
+        &ScriptBuf::new(),
+        &keypair,
+        &tapnode_hash,
+    );
+
+    let block = create_test_block(vec![irrelevant_tx]);
+
+    let tx_entries = index_block(&block, visitor, &filter_config);
+
+    assert!(
+        tx_entries.is_empty(),
+        "Should not find any relevant transactions"
+    );
+    tx_entries
+}
+
+pub fn test_index_deposit_request_with_visitor<V>(
+    visitor_fn: impl Fn() -> V,
+    extract_proto_ops: fn(&Indexed<V::Output>) -> Vec<ProtocolOperation>,
+) -> Vec<Indexed<V::Output>>
+where
+    V: TxVisitor,
+{
+    let params = gen_params();
+    let (filter_config, key_pair) = create_tx_filter_config(&params);
+    let mut deposit_config = filter_config.deposit_config.clone();
+
+    let extra_amt = 10_000;
+    deposit_config.deposit_amount += extra_amt;
+
+    let dest_addr = vec![2u8; 20]; // EVM address
+    let dummy_block = [0u8; 32]; // Take-back block hash
+    let tapnode_hash = [0u8; 32]; // Taproot tweak
+
+    let deposit_request_script = build_test_deposit_request_script(
+        deposit_config.magic_bytes.clone(),
+        dummy_block.to_vec(),
+        dest_addr.clone(),
+    );
+
+    let tx = create_test_deposit_tx(
+        Amount::from_sat(deposit_config.deposit_amount),
+        &deposit_config.address.address().script_pubkey(),
+        &deposit_request_script,
+        &key_pair,
+        &tapnode_hash,
+    );
+
+    let block = create_test_block(vec![tx]);
+    let tx_entries = index_block(&block, visitor_fn, &filter_config);
+
+    let deposit_reqs: Vec<_> = tx_entries
+        .iter()
+        .flat_map(|x| {
+            extract_proto_ops(x).into_iter().filter_map(|o| match o {
+                ProtocolOperation::DepositRequest(dr) => Some(dr),
+                _ => None,
+            })
+        })
+        .collect();
+
+    assert_eq!(deposit_reqs.len(), 1, "Should find one deposit request");
+
+    for dep_req_info in &deposit_reqs {
+        assert_eq!(dep_req_info.address, dest_addr, "EE address should match");
+        assert_eq!(
+            dep_req_info.take_back_leaf_hash, dummy_block,
+            "Control block hash should match"
+        );
+    }
+    tx_entries
+}
+
+pub fn test_index_deposit_with_visitor<V>(
+    visitor_fn: impl Fn() -> V,
+    extract_ops: fn(&Indexed<V::Output>) -> Vec<ProtocolOperation>,
+) -> Vec<Indexed<V::Output>>
+where
+    V: TxVisitor,
+{
+    let params = gen_params();
+    let (filter_config, keypair) = create_tx_filter_config(&params);
+    let deposit_config = filter_config.deposit_config.clone();
+
+    let idx = 0xdeadbeef;
+    let ee_addr = vec![1u8; 20];
+    let tapnode_hash = [0u8; 32];
+
+    let deposit_script =
+        build_test_deposit_script(&deposit_config, idx, ee_addr.clone(), &tapnode_hash);
+
+    let tx = create_test_deposit_tx(
+        Amount::from_sat(deposit_config.deposit_amount),
+        &deposit_config.address.address().script_pubkey(),
+        &deposit_script,
+        &keypair,
+        &tapnode_hash,
+    );
+
+    let block = create_test_block(vec![tx]);
+
+    let tx_entries = index_block(&block, visitor_fn, &filter_config);
+
+    assert_eq!(tx_entries.len(), 1, "Should find one relevant transaction");
+
+    let ops = extract_ops(&tx_entries[0]);
+
+    assert_eq!(ops.len(), 1, "Should find exactly one protocol operation");
+
+    match &ops[0] {
+        ProtocolOperation::Deposit(deposit_info) => {
+            assert_eq!(deposit_info.address, ee_addr, "EE address should match");
+            assert_eq!(deposit_info.deposit_idx, idx, "Deposit idx should match");
+            assert_eq!(
+                deposit_info.amt,
+                BitcoinAmount::from_sat(deposit_config.deposit_amount),
+                "Deposit amount should match"
+            );
+        }
+        _ => panic!("Expected Deposit info"),
+    }
+
+    tx_entries
+}
+
+// TODO: implement this properly when we need to. For now, trying to support multiple ops is
+// creating more issues than helping us.
+pub fn test_index_tx_with_multiple_ops_with_visitor<V>(
+    visitor: impl Fn() -> V,
+    _extract_ops: fn(&Indexed<V::Output>) -> Vec<ProtocolOperation>,
+) -> Vec<Indexed<V::Output>>
+where
+    V: TxVisitor,
+{
+    // TODO: fill in details as necessary
+    let params = gen_params();
+    let (filter_config, _) = create_tx_filter_config(&params);
+
+    // Create a block with single tx that has multiple ops
+    let block = create_test_block(vec![]);
+
+    let tx_entries = index_block(&block, visitor, &filter_config);
+    println!("tx_entries: {:?}", tx_entries.len());
+
+    // TODO: Add tests on tx_entries
+
+    tx_entries
+}
+
+// HELPERS
+
+/// Helper function to create a test block with given transactions
+fn create_test_block(transactions: Vec<Transaction>) -> Block {
+    let bhash = BlockHash::from_byte_array([0; 32]);
+    Block {
+        header: Header {
+            version: Version::ONE,
+            prev_blockhash: bhash,
+            merkle_root: TxMerkleNode::from_byte_array(*bhash.as_byte_array()),
+            time: 100,
+            bits: CompactTarget::from_consensus(1),
+            nonce: 1,
+        },
+        txdata: transactions,
+    }
+}


### PR DESCRIPTION
Fixes: https://alpenlabs.atlassian.net/browse/STR-1349
## Description

This PR does the following:
1. Removes including DRTs to protocol ops in btcio transaction indexer. This was inconsistent with how prover indexed DRTs. Interesting but prover did not indexed DRT while btcio indexer did.
2. Adds indexing withdrawal fulfillment and deposit spent to prover indexer. btcio indexer already had this.
3. Refactored tests to reuse similar logic between prover and btcio tx indexers. This comprises the large portion of this PR.
4. Add corresponding new tests.

### Type of Change

<!--
Select the type of change your PR introduces (put an `x` in all that apply):
-->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature/Enhancement (non-breaking change which adds functionality or enhances an existing one)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Refactor
- [ ] New or updated tests
- [ ] Dependency Update

## Notes to Reviewers

<!--
Anything in particular you want to note that will help reviewers fulfill their role
in reviewing this PR?
-->

## Checklist

<!--
Ensure all the following are checked:
-->

- [x] I have performed a self-review of my code.
- [x] I have commented my code where necessary.
- [ ] I have updated the documentation if needed.
- [x] My changes do not introduce new warnings.
- [ ] I have added (where necessary) tests that prove my changes are effective or that my feature works.
- [x] New and existing tests pass with my changes.

## Related Issues

<!--
Link any related issues (e.g., `closes #123`, `fixes #456`).
-->
