### PR TITLE
chore(deps): bump bitcoin to 0.32.6

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2503,9 +2503,9 @@ checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
 
 [[package]]
 name = "bitcoin"
-version = "0.32.5"
+version = "0.32.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce6bc65742dea50536e35ad42492b234c27904a27f0abdcbce605015cb4ea026"
+checksum = "ad8929a18b8e33ea6b3c09297b687baaa71fb1b97353243a3f1029fad5c59c5b"
 dependencies = [
  "base58ck",
  "base64 0.21.7",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -186,7 +186,7 @@ bdk_esplora = { version = "0.20.1", features = [
 ], default-features = false }
 bdk_wallet = "1.0.0"
 bincode = "1.3"
-bitcoin = { version = "=0.32.5", features = ["serde"] }
+bitcoin = { version = "0.32.6", features = ["serde"] }
 bitcoin-bosd = { version = "0.4.0", default-features = false }
 bitcoind-async-client = "0.1.1"
 borsh = { version = "1.5.0", features = ["derive"] }

--- a/crates/btcio/src/writer/builder.rs
+++ b/crates/btcio/src/writer/builder.rs
@@ -461,7 +461,7 @@ fn assert_correct_address(
     network: Network,
 ) {
     let recovery_key_pair = key_pair.tap_tweak(SECP256K1, taproot_spend_info.merkle_root());
-    let x_only_pub_key = recovery_key_pair.to_inner().x_only_public_key().0;
+    let x_only_pub_key = recovery_key_pair.to_keypair().x_only_public_key().0;
     assert_eq!(
         Address::p2tr_tweaked(
             TweakedPublicKey::dangerous_assume_tweaked(x_only_pub_key),

--- a/crates/l1tx/src/deposit/deposit_tx.rs
+++ b/crates/l1tx/src/deposit/deposit_tx.rs
@@ -123,7 +123,7 @@ fn validate_deposit_signature(
     let msg = Message::from_digest(*sighash.as_byte_array());
 
     // Verify the Schnorr signature
-    secp.verify_schnorr(&schnorr_sig, &msg, &tweaked_key.to_inner())
+    secp.verify_schnorr(&schnorr_sig, &msg, &tweaked_key.to_x_only_public_key())
         .ok()
 }
 

--- a/crates/l1tx/src/filter/checkpoint.rs
+++ b/crates/l1tx/src/filter/checkpoint.rs
@@ -16,8 +16,8 @@ pub fn parse_valid_checkpoint_envelopes<'a>(
 ) -> impl Iterator<Item = SignedCheckpoint> + 'a {
     tx.input.iter().flat_map(move |inp| {
         inp.witness
-            .tapscript()
-            .and_then(|scr| parse_envelope_payloads(&scr.into(), filter_conf).ok())
+            .taproot_leaf_script()
+            .and_then(|scr| parse_envelope_payloads(&scr.script.into(), filter_conf).ok())
             .map(|items| {
                 items
                     .into_iter()

--- a/crates/test-utils/src/bitcoin.rs
+++ b/crates/test-utils/src/bitcoin.rs
@@ -138,7 +138,7 @@ pub fn create_test_deposit_tx(
     let tweaked_pair = keypair.tap_tweak(&secp, Some(tapscript_root));
 
     // Sign the sighash
-    let sig = secp.sign_schnorr(&msg, &tweaked_pair.to_inner());
+    let sig = secp.sign_schnorr(&msg, &tweaked_pair.to_keypair());
 
     tx.input[0].witness.push(sig.as_ref());
 


### PR DESCRIPTION
## Description

- Bumps `rust-bitcoin` to `0.32.6`.
- Removes the `=` bound in `Cargo.toml`.
- Fixes the deprecated methods.

### Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature/Enhancement (non-breaking change which adds functionality or enhances an existing one)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactor
- [ ] New or updated tests
- [x] Dependency Update

## Notes to Reviewers

Why upgrading?
First, we should always upgrade.
Second, `0.32.5` has:

- P2A support https://github.com/rust-bitcoin/rust-bitcoin/pull/4111 
- `Psbt::sign` for taproot using `<PublicKey, SecretKey>` maps https://github.com/rust-bitcoin/rust-bitcoin/pull/4238

We can start to experiment in the near future with ephemeral anchors in the bridge tx graph (P2A support) and we can also start to use PSBTs with Taproot since the bug with signing them with a pk<->sk map.

## Checklist

- [x] I have performed a self-review of my code.
- [x] I have commented my code where necessary.
- [x] I have updated the documentation if needed.
- [x] My changes do not introduce new warnings.
- [x] I have added (where necessary) tests that prove my changes are effective or that my feature works.
- [x] New and existing tests pass with my changes.

## Related Issues

<!--
Link any related issues (e.g., `closes #123`, `fixes #456`).
-->
