### PR TITLE
Str 1275 exp backoff for engine calls

### DIFF
--- a/crates/common/src/lib.rs
+++ b/crates/common/src/lib.rs
@@ -4,6 +4,7 @@
 use serde::{Deserialize, Serialize};
 
 pub mod logging;
+pub mod retry;
 
 #[cfg(feature = "debug-utils")]
 mod bail_manager;

--- a/crates/common/src/retry/mod.rs
+++ b/crates/common/src/retry/mod.rs
@@ -1,0 +1,154 @@
+use std::{thread::sleep, time::Duration};
+
+use tracing::{error, warn};
+
+pub mod policies;
+
+/// Runs a fallible operation with a backoff retry.
+///
+/// Retries the given `operation` up to `max_retries` times with delays
+/// increasing according to the provided config that implements [`Backoff`] trait.
+///
+/// Logs a warning on each failure and an error if all retries are exhausted.
+///
+/// # Parameters
+///
+/// - `name`: Identifier used in logs for the operation.
+/// - `max_retries`: Maximum number of retry attempts.
+/// - `backoff`: Backoff configuration for computing delay.
+/// - `operation`: Closure returning `Result`; retried on `Err`.
+///
+/// # Returns
+///
+/// - `Ok(R)` if the operation succeeds within allowed attempts.
+/// - `Err(E)` if all attempts fail.
+///
+/// # Example
+///
+/// ```rust
+/// let result = retry_with_backoff(
+///     "my_task",
+///     || try_something(),
+///     3,
+///     ExponentialBackoff {
+///         base_delay_ms: 500,
+///         multiplier: 150,
+///         multiplier_base: 100,
+///     },
+/// );
+/// ```
+pub fn retry_with_backoff<R, E, F>(
+    name: &str,
+    max_retries: u16,
+    backoff: &impl Backoff,
+    operation: F,
+) -> Result<R, E>
+where
+    F: FnMut() -> Result<R, E>,
+    E: std::fmt::Debug,
+{
+    retry_with_backoff_inner(name, max_retries, backoff, operation, sleep)
+}
+
+/// Inner method that acutally does the retry which is generic on the sleep function.
+fn retry_with_backoff_inner<R, E, F, S>(
+    name: &str,
+    max_retries: u16,
+    backoff: &impl Backoff,
+    mut operation: F,
+    mut sleep_fn: S,
+) -> Result<R, E>
+where
+    F: FnMut() -> Result<R, E>,
+    E: std::fmt::Debug,
+    S: FnMut(Duration),
+{
+    let mut delay = backoff.base_delay_ms();
+
+    for attempt in 0..=max_retries {
+        match operation() {
+            Ok(value) => return Ok(value),
+            Err(err) if attempt < max_retries => {
+                warn!(
+                    "Attempt {} failed with {:?} while running {}. Retrying in {:?}",
+                    attempt + 1,
+                    err,
+                    name,
+                    delay
+                );
+                sleep_fn(Duration::from_millis(delay));
+                delay = backoff.next_delay_ms(delay);
+            }
+            Err(err) => {
+                error!(
+                    "Max retries exceeded while running {}, returning with the last error",
+                    name
+                );
+                return Err(err);
+            }
+        }
+    }
+
+    // This point should be unreachable
+    unreachable!()
+}
+
+pub trait Backoff {
+    /// Base delay in ms.
+    fn base_delay_ms(&self) -> u64;
+
+    /// Generates next delay given current delay.
+    fn next_delay_ms(&self, curr_delay_ms: u64) -> u64;
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::{Arc, Mutex};
+
+    use super::*;
+
+    struct HalfBackoff;
+
+    impl Backoff for HalfBackoff {
+        fn base_delay_ms(&self) -> u64 {
+            128
+        }
+
+        fn next_delay_ms(&self, curr: u64) -> u64 {
+            curr / 2
+        }
+    }
+
+    #[test]
+    fn tracks_sleep_and_retries_correctly() {
+        let backoff = HalfBackoff;
+        let counter = Arc::new(Mutex::new(0));
+        let sleep_log = Arc::new(Mutex::new(Vec::new()));
+        let max_retries = 2;
+
+        let result = retry_with_backoff_inner(
+            "mock_op",
+            max_retries,
+            &backoff,
+            {
+                let counter = Arc::clone(&counter);
+                move || -> Result<(), &str> {
+                    let mut count = counter.lock().unwrap();
+                    *count += 1;
+                    Err("fail")
+                }
+            },
+            {
+                let sleep_log = Arc::clone(&sleep_log);
+                move |dur| {
+                    sleep_log.lock().unwrap().push(dur.as_millis() as u64);
+                }
+            },
+        );
+
+        assert_eq!(result, Err("fail"));
+        assert_eq!(*counter.lock().unwrap(), 1 + max_retries);
+        assert_eq!(sleep_log.lock().unwrap().len(), max_retries as usize);
+        assert_eq!(sleep_log.lock().unwrap().to_vec(), vec![128, 64]);
+    }
+}

--- a/crates/common/src/retry/mod.rs
+++ b/crates/common/src/retry/mod.rs
@@ -26,15 +26,19 @@ pub mod policies;
 /// # Example
 ///
 /// ```rust
+/// use strata_common::retry::{policies::ExponentialBackoff, retry_with_backoff};
+///
+/// // A dummy function for the example.
+/// fn try_something() -> Result<(), &'static str> {
+///     // In a real scenario, this would attempt an operation that might fail.
+///     Err("failed to do something")
+/// }
+///
 /// let result = retry_with_backoff(
 ///     "my_task",
-///     || try_something(),
 ///     3,
-///     ExponentialBackoff {
-///         base_delay_ms: 500,
-///         multiplier: 150,
-///         multiplier_base: 100,
-///     },
+///     &ExponentialBackoff::new(500, 150, 100),
+///     || try_something(),
 /// );
 /// ```
 pub fn retry_with_backoff<R, E, F>(
@@ -50,7 +54,7 @@ where
     retry_with_backoff_inner(name, max_retries, backoff, operation, sleep)
 }
 
-/// Inner method that acutally does the retry which is generic on the sleep function.
+/// Inner method that actually does the retry which is generic on the sleep function.
 fn retry_with_backoff_inner<R, E, F, S>(
     name: &str,
     max_retries: u16,

--- a/crates/common/src/retry/mod.rs
+++ b/crates/common/src/retry/mod.rs
@@ -4,6 +4,9 @@ use tracing::{error, warn};
 
 pub mod policies;
 
+/// Default maximum number of retries for engine calls.
+pub const DEFAULT_ENGINE_CALL_MAX_RETRIES: u16 = 4;
+
 /// Runs a fallible operation with a backoff retry.
 ///
 /// Retries the given `operation` up to `max_retries` times with delays

--- a/crates/common/src/retry/policies.rs
+++ b/crates/common/src/retry/policies.rs
@@ -13,21 +13,6 @@ use super::Backoff;
 ///   `multiplier_base = 100` represents a 1.5× multiplier.
 /// - `multiplier_base`: The denominator of the backoff multiplier. Used in conjunction with
 ///   `multiplier` to scale the delay after each retry.
-///
-/// # Example
-///
-/// ```
-/// use std::time::Duration;
-///
-/// let backoff = ExponentialBackoff {
-///     base_delay_ms: 1000,
-///     multiplier: 150,
-///     multiplier_base: 100,
-/// };
-///
-/// // This represents a backoff that starts at 1000ms,
-/// // and grows by 1.5x each retry: 1000ms → 1500ms → 2250ms → ...
-/// ```
 pub struct ExponentialBackoff {
     /// Initial delay before the first retry, in milliseconds.
     base_delay_ms: u64,
@@ -46,6 +31,13 @@ impl ExponentialBackoff {
             base_delay_ms,
             multiplier,
             multiplier_base,
+        }
+    }
+
+    pub fn new_with_default_multiplier(base_delay_ms: u64) -> Self {
+        Self {
+            base_delay_ms,
+            ..Default::default()
         }
     }
 }

--- a/crates/common/src/retry/policies.rs
+++ b/crates/common/src/retry/policies.rs
@@ -61,3 +61,42 @@ impl Backoff for ExponentialBackoff {
         curr_delay_ms * self.multiplier / self.multiplier_base
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    #[should_panic]
+    fn test_exponential_backoff_zero_multiplier_base() {
+        // This should panic because we can't have a zero denominator
+        let _ = ExponentialBackoff::new(1000, 20, 0);
+    }
+
+    #[test]
+    fn test_backoff_trait_implementation() {
+        let backoff = ExponentialBackoff::new(1000, 20, 10);
+
+        // Test base_delay_ms() method
+        assert_eq!(backoff.base_delay_ms(), 1000);
+
+        // Test next_delay_ms() method with initial value
+        let delay1 = backoff.next_delay_ms(1000);
+        assert_eq!(delay1, 2000); // 1000 * 20 / 10 = 2000
+
+        // Test next_delay_ms() method with subsequent value
+        let delay2 = backoff.next_delay_ms(delay1);
+        assert_eq!(delay2, 4000); // 2000 * 20 / 10 = 4000
+
+        // Test with default multipliers
+        let backoff2 = ExponentialBackoff::default();
+        let delay = backoff2.next_delay_ms(1000);
+        assert_eq!(delay, 1500); // 1000 * 15 / 10 = 1500
+
+        // test with new_with_default_multiplier
+        let backoff3 = ExponentialBackoff::new_with_default_multiplier(2000);
+        assert_eq!(backoff3.base_delay_ms, 2000);
+        let delay = backoff3.next_delay_ms(1000);
+        assert_eq!(delay, 1500); // 1000 * 15 / 10 = 1500
+    }
+}

--- a/crates/common/src/retry/policies.rs
+++ b/crates/common/src/retry/policies.rs
@@ -1,0 +1,71 @@
+use super::Backoff;
+
+/// Configuration for exponential retry backoff.
+///
+/// This struct defines how delays should increase between retry attempts
+/// using a fixed-point multiplier. It avoids floating-point math by
+/// expressing the multiplier as a ratio (`multiplier / multiplier_base`).
+///
+/// # Fields
+///
+/// - `base_delay_ms`: The initial delay in milliseconds before the first retry.
+/// - `multiplier`: The numerator of the backoff multiplier. For example, `150` with
+///   `multiplier_base = 100` represents a 1.5× multiplier.
+/// - `multiplier_base`: The denominator of the backoff multiplier. Used in conjunction with
+///   `multiplier` to scale the delay after each retry.
+///
+/// # Example
+///
+/// ```
+/// use std::time::Duration;
+///
+/// let backoff = ExponentialBackoff {
+///     base_delay_ms: 1000,
+///     multiplier: 150,
+///     multiplier_base: 100,
+/// };
+///
+/// // This represents a backoff that starts at 1000ms,
+/// // and grows by 1.5x each retry: 1000ms → 1500ms → 2250ms → ...
+/// ```
+pub struct ExponentialBackoff {
+    /// Initial delay before the first retry, in milliseconds.
+    base_delay_ms: u64,
+
+    /// Numerator of the backoff multiplier (e.g., `150` for 1.5x).
+    multiplier: u64,
+
+    /// Denominator of the backoff multiplier (e.g., `100` for 1.5x).
+    multiplier_base: u64,
+}
+
+impl ExponentialBackoff {
+    pub fn new(base_delay_ms: u64, multiplier: u64, multiplier_base: u64) -> Self {
+        assert!(multiplier_base != 0);
+        Self {
+            base_delay_ms,
+            multiplier,
+            multiplier_base,
+        }
+    }
+}
+
+impl Default for ExponentialBackoff {
+    fn default() -> Self {
+        Self {
+            base_delay_ms: 1500, // 1.5 secs should be a sane default
+            multiplier: 15,
+            multiplier_base: 10,
+        }
+    }
+}
+
+impl Backoff for ExponentialBackoff {
+    fn base_delay_ms(&self) -> u64 {
+        self.base_delay_ms
+    }
+
+    fn next_delay_ms(&self, curr_delay_ms: u64) -> u64 {
+        curr_delay_ms * self.multiplier / self.multiplier_base
+    }
+}

--- a/crates/eectl/src/errors.rs
+++ b/crates/eectl/src/errors.rs
@@ -14,9 +14,6 @@ pub enum EngineError {
     #[error("invalid address {0:?}")]
     InvalidAddress(Vec<u8>),
 
-    #[error("payload malformed")]
-    PayloadMalformed,
-
     #[error("missing block in db {0}")]
     DbMissingBlock(L2BlockId),
 

--- a/crates/evmexec/src/engine.rs
+++ b/crates/evmexec/src/engine.rs
@@ -158,7 +158,6 @@ impl<T: EngineRpc> RpcExecEngineInner<T> {
         // TODO: correct error type
         let update_status = forkchoice_result.map_err(|err| EngineError::Other(err.to_string()))?;
 
-        // FIXME: IF Reth being in syncing state for any reason, it will return None for payload_id
         let payload_id: PayloadId = update_status
             .payload_id
             .ok_or(EngineError::Other("payload_id missing".into()))?; // should never happen

--- a/crates/evmexec/src/engine.rs
+++ b/crates/evmexec/src/engine.rs
@@ -158,6 +158,7 @@ impl<T: EngineRpc> RpcExecEngineInner<T> {
         // TODO: correct error type
         let update_status = forkchoice_result.map_err(|err| EngineError::Other(err.to_string()))?;
 
+        // FIXME: IF Reth being in syncing state for any reason, it will return None for payload_id
         let payload_id: PayloadId = update_status
             .payload_id
             .ok_or(EngineError::Other("payload_id missing".into()))?; // should never happen

--- a/crates/sequencer/Cargo.toml
+++ b/crates/sequencer/Cargo.toml
@@ -5,7 +5,7 @@ version = "0.3.0-alpha.1"
 
 [dependencies]
 strata-chaintsn.workspace = true
-strata-common = { workspace = true, optional = true }
+strata-common.workspace = true
 strata-consensus-logic.workspace = true
 strata-db.workspace = true
 strata-eectl.workspace = true

--- a/crates/sequencer/src/block_template/block_assembly.rs
+++ b/crates/sequencer/src/block_template/block_assembly.rs
@@ -1,5 +1,8 @@
 use std::{thread, time};
 
+use strata_common::retry::{
+    policies::ExponentialBackoff, retry_with_backoff, DEFAULT_ENGINE_CALL_MAX_RETRIES,
+};
 use strata_consensus_logic::checkpoint_verification;
 use strata_db::DbError;
 use strata_eectl::{
@@ -311,9 +314,15 @@ fn prepare_exec_data<E: ExecEngineCtl>(
         remaining_gas_limit,
     );
 
-    // TODO: should we use retry with backoff in here too?
-    // IMO yes, but we don't need graceful shutdown for it
-    let key = engine.prepare_payload(payload_env)?;
+    // If the payload preparation fails, we can safely retry in the next iteration.
+    // The fork-choice manager includes graceful shutdown logic to handle any
+    // persistent issues that may arise.
+    let key = retry_with_backoff(
+        "engine_prepare_payload",
+        DEFAULT_ENGINE_CALL_MAX_RETRIES,
+        &ExponentialBackoff::default(),
+        || engine.prepare_payload(payload_env.clone()),
+    )?;
     trace!("submitted EL payload job, waiting for completion");
 
     // Wait 2 seconds for the block to be finished.
@@ -351,7 +360,14 @@ fn poll_status_loop<E: ExecEngineCtl>(
 
         // Check the payload for the result.
         trace!(%job, "polling engine for completed payload");
-        let payload = engine.get_payload_status(job)?;
+
+        let payload = retry_with_backoff(
+            "engine_get_payload_status",
+            DEFAULT_ENGINE_CALL_MAX_RETRIES,
+            &ExponentialBackoff::default(),
+            || engine.get_payload_status(job),
+        )?;
+
         if let PayloadStatus::Ready(pl, gas_used) = payload {
             return Ok(Some((pl, gas_used)));
         }

--- a/crates/sequencer/src/block_template/block_assembly.rs
+++ b/crates/sequencer/src/block_template/block_assembly.rs
@@ -311,6 +311,8 @@ fn prepare_exec_data<E: ExecEngineCtl>(
         remaining_gas_limit,
     );
 
+    // TODO: should we use retry with backoff in here too?
+    // IMO yes, but we don't need graceful shutdown for it
     let key = engine.prepare_payload(payload_env)?;
     trace!("submitted EL payload job, waiting for completion");
 

--- a/functional-tests/factory/factory.py
+++ b/functional-tests/factory/factory.py
@@ -265,7 +265,7 @@ class RethFactory(flexitest.Factory):
         custom_chain: str = "dev",
         name_suffix: str = "",
     ) -> flexitest.Service:
-        name = f"reth.{id}.{name_suffix}"
+        name = f"reth.{id}{'.' + name_suffix if name_suffix else ''}"
         datadir = ctx.make_service_dir(name)
         authrpc_port = self.next_port()
         listener_port = self.next_port()


### PR DESCRIPTION
## Description
Today any *engine* connection failure inside block execution leads to:

1. The block being tagged **Invalid**.
2. The Sync crate advancing past that height (see Issue 1).

A transient network hiccup should trigger **retry with back-off** or, after `N` failures, a *graceful shutdown*, **not** a permanent Invalid flag. 

<!--
Provide a brief summary of the changes and the motivation behind them.
-->

### Type of Change

<!--
Select the type of change your PR introduces (put an `x` in all that apply):
-->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature/Enhancement (non-breaking change which adds functionality or enhances an existing one)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactor
- [ ] New or updated tests
- [ ] Dependency Update

## Notes to Reviewers

**Why is the retry_with_backoff + graceful shutdown strategy sufficient?**
[Notion Link](
https://www.notion.so/Sync-Crate-Analysis-1f6901ba000f80418a35ed25eda463b7?pvs=4#1f9901ba000f8081b7c9fbaeb91f0c8e)

<!--
Anything in particular you want to note that will help reviewers fulfill their role
in reviewing this PR?
-->

## Checklist

<!--
Ensure all the following are checked:
-->

- [x] I have performed a self-review of my code.
- [x] I have commented my code where necessary.
- [ ] I have updated the documentation if needed.
- [ ] My changes do not introduce new warnings.
- [ ] I have added (where necessary) tests that prove my changes are effective or that my feature works.
- [x] New and existing tests pass with my changes.

## Related Issues

STR-1275
<!--
Link any related issues (e.g., `closes #123`, `fixes #456`).
-->
