### PR TITLE
STR-1401 faucet signet leads to 404

### DIFF
--- a/bin/alpen-cli/src/cmd/faucet.rs
+++ b/bin/alpen-cli/src/cmd/faucet.rs
@@ -181,7 +181,7 @@ pub async fn faucet(
     let url = format!(
         "{base}{}/{}/{}",
         claim,
-        encode(&solution.to_be_bytes()),
+        encode(&solution.to_le_bytes()),
         address
     );
     let res = client

--- a/bin/alpen-cli/src/cmd/faucet.rs
+++ b/bin/alpen-cli/src/cmd/faucet.rs
@@ -220,10 +220,8 @@ fn pow_valid(mut hasher: Sha256, difficulty: u8, solution: Solution) -> bool {
 
 /// Ensures that the URL has a trailing slash.
 fn ensure_trailing_slash(mut url: Url) -> Url {
-    if !url.path().ends_with('/') {
-        let new_path = format!("{}/", url.path().trim_end_matches('/'));
-        url.set_path(&new_path);
-    }
+    let new_path = format!("{}/", url.path().trim_end_matches('/'));
+    url.set_path(&new_path);
     url
 }
 
@@ -243,6 +241,13 @@ mod tests {
     #[test]
     fn leaves_trailing_slash_when_present() {
         let url = Url::parse("https://example.com/").unwrap();
+        let fixed = ensure_trailing_slash(url);
+        assert_eq!(fixed.as_str(), "https://example.com/");
+    }
+
+    #[test]
+    fn handles_trailing_slashes_when_present() {
+        let url = Url::parse("https://example.com//").unwrap();
         let fixed = ensure_trailing_slash(url);
         assert_eq!(fixed.as_str(), "https://example.com/");
     }

--- a/bin/alpen-cli/src/cmd/faucet.rs
+++ b/bin/alpen-cli/src/cmd/faucet.rs
@@ -124,7 +124,7 @@ pub async fn faucet(
         network_type
     ))?;
     let endpoint = base
-        .join(&format!("/pow_challenge/{chain}"))
+        .join(&format!("pow_challenge/{chain}"))
         .expect("a valid URL");
 
     let res = client
@@ -179,9 +179,9 @@ pub async fn faucet(
     println!("Claiming to {} address {}", network_type, address);
 
     let url = format!(
-        "{base}/{}/{}/{}",
+        "{base}{}/{}/{}",
         claim,
-        encode(&solution.to_le_bytes()),
+        encode(&solution.to_be_bytes()),
         address
     );
     let res = client

--- a/bin/alpen-cli/src/cmd/faucet.rs
+++ b/bin/alpen-cli/src/cmd/faucet.rs
@@ -218,6 +218,7 @@ fn pow_valid(mut hasher: Sha256, difficulty: u8, solution: Solution) -> bool {
     count_leading_zeros(&hasher.finalize()) >= difficulty
 }
 
+/// Ensures that the URL has a trailing slash.
 fn ensure_trailing_slash(mut url: Url) -> Url {
     if !url.path().ends_with('/') {
         let new_path = format!("{}/", url.path().trim_end_matches('/'));

--- a/bin/alpen-cli/src/cmd/faucet.rs
+++ b/bin/alpen-cli/src/cmd/faucet.rs
@@ -117,13 +117,15 @@ pub async fn faucet(
     println!("Fetching challenge from faucet");
 
     let client = reqwest::Client::new();
-    let base = Url::from_str(&settings.faucet_endpoint)
+    let mut base_url = Url::from_str(&settings.faucet_endpoint)
         .user_error("Invalid faucet endopoint. Check the config file")?;
+    base_url = ensure_trailing_slash(base_url);
+
     let chain = Chain::from_network_type(network_type.clone()).user_error(format!(
         "Unsupported network {}. Must be `signet` or `alpen`",
         network_type
     ))?;
-    let endpoint = base
+    let endpoint = base_url
         .join(&format!("pow_challenge/{chain}"))
         .expect("a valid URL");
 
@@ -179,7 +181,7 @@ pub async fn faucet(
     println!("Claiming to {} address {}", network_type, address);
 
     let url = format!(
-        "{base}{}/{}/{}",
+        "{base_url}{}/{}/{}",
         claim,
         encode(&solution.to_le_bytes()),
         address
@@ -214,4 +216,33 @@ fn count_leading_zeros(data: &[u8]) -> u8 {
 fn pow_valid(mut hasher: Sha256, difficulty: u8, solution: Solution) -> bool {
     hasher.update(solution);
     count_leading_zeros(&hasher.finalize()) >= difficulty
+}
+
+fn ensure_trailing_slash(mut url: Url) -> Url {
+    if !url.path().ends_with('/') {
+        let new_path = format!("{}/", url.path().trim_end_matches('/'));
+        url.set_path(&new_path);
+    }
+    url
+}
+
+#[cfg(test)]
+mod tests {
+    use reqwest::Url;
+
+    use super::*;
+
+    #[test]
+    fn adds_trailing_slash_when_missing() {
+        let url = Url::parse("https://example.com").unwrap();
+        let fixed = ensure_trailing_slash(url);
+        assert_eq!(fixed.as_str(), "https://example.com/");
+    }
+
+    #[test]
+    fn leaves_trailing_slash_when_present() {
+        let url = Url::parse("https://example.com/").unwrap();
+        let fixed = ensure_trailing_slash(url);
+        assert_eq!(fixed.as_str(), "https://example.com/");
+    }
 }


### PR DESCRIPTION
## Description

In the case of signet, extra / between base url and `claim_l1` was causing the 404 error.
Claim to signet address was failing because of "strata" to "alpen" renaming in alpen CLI. The fix is part of [this PR](https://github.com/alpenlabs/faucet-api/pull/69)

### Type of Change

<!--
Select the type of change your PR introduces (put an `x` in all that apply):
-->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature/Enhancement (non-breaking change which adds functionality or enhances an existing one)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactor
- [ ] New or updated tests
- [ ] Dependency Update

## Notes to Reviewers

<!--
Anything in particular you want to note that will help reviewers fulfill their role
in reviewing this PR?
-->

## Checklist

<!--
Ensure all the following are checked:
-->

- [x] I have performed a self-review of my code.
- [x] I have commented my code where necessary.
- [ ] I have updated the documentation if needed.
- [ ] My changes do not introduce new warnings.
- [ ] I have added (where necessary) tests that prove my changes are effective or that my feature works.
- [ ] New and existing tests pass with my changes.

## Related Issues

<!--
Link any related issues (e.g., `closes #123`, `fixes #456`).
-->
